### PR TITLE
Transcription corrections: cod-ve07v1_kzz7yh-a02943.xml (5 changes)

### DIFF
--- a/kzz7yh-a02943/cod-ve07v1_kzz7yh-a02943.xml
+++ b/kzz7yh-a02943/cod-ve07v1_kzz7yh-a02943.xml
@@ -61,10 +61,10 @@
           <cb ed="#P" n="b"/>
           <lb ed="#V" n="64"/>nuria ac tenuitatem nostra penuria dicit defectum 
           <lb ed="#V" n="65"/>substantie exterioris: tenuitas vero defectum 
-          sub<lb ed="#V" n="66" break="no"/>stantie interioris. et ideo hec cpenuria) 
+          sub<lb ed="#V" n="66" break="no"/>stantie interioris. et ideo hec (penuria) 
           transmitti<lb ed="#V" n="67" break="no"/>tur ad significandum defectum scientie acquisite. 
           <lb ed="#V" n="68"/>(Tenuitas) autem ad significandum defectum 
-          na<lb ed="#V" n="69" break="no"/>turalis intelligentie. (Gamophylatium.) Locus est 
+          na<lb ed="#V" n="69" break="no"/>turalis intelligentie. (Gazophylatium.) Locus est 
           <lb ed="#V" n="70"/>in quo ponitur pecunia. et dicitur a gaza quod est 
           pecu<lb ed="#V" n="71" break="no"/>nia: et phylaxe quod est seruare. Dicitur autem a 
           qui<lb ed="#V" n="72" break="no"/>busdam quod corbona erat locus in quo 
@@ -95,7 +95,7 @@
           manife<lb ed="#V" n="94" break="no"/>stare. Quia verum valens ad expositionem sacre 
           scri<lb ed="#V" n="95" break="no"/>pture. In ipsa implicite et virtualiter continetur. 
           <lb ed="#V" n="96"/>(Professus est. idest promisit. Selo domus dei.) 
-          <lb ed="#V" n="97"/>non secundum quod excludit confortium bonum: sed 
+          <lb ed="#V" n="97"/>non secundum quod excludit consortium bonum: sed 
           ma<lb ed="#V" n="98" break="no"/>lum. (Carnalium.) qui carnaliter de deo sentiunt. 
           <lb ed="#V" n="99"/>scilicet quod habeat membra carnea. (Atque animalium. 
           <lb ed="#V" n="100"/>qui de deo sentiunt ad modum anime: scilicet quod 
@@ -118,7 +118,7 @@
           Ca<lb ed="#V" n="115" break="no"/>lumnie.) Calumniator est falsi criminis accusator. 
           <lb ed="#V" n="116"/>(Obnoxium.) idest debitum vel subiectum. (
           Dis<lb ed="#V" n="117" break="no"/>sentiens quoque sit animorum consensus.) quia 
-          vo<lb ed="#V" n="118" break="no"/>luntas multum trahit iudicium. (eritati autem 
+          vo<lb ed="#V" n="118" break="no"/>luntas multum trahit iudicium. (Veritati autem 
           <lb ed="#V" n="119"/>non intellecte.) sicut tripliciter impeditur visus ne 
           <lb ed="#V" n="120"/>videat: aut si propter impedimentum in organo: aut 
           <lb ed="#V" n="121"/>propter auersionem ab obiecto: aut propter defectum 
@@ -161,7 +161,7 @@
           hypo<lb ed="#V" n="22" break="no"/>crisis mendax.) quia aliud pretendit et aliud 
           inten<lb ed="#V" n="23" break="no"/>dit. (Omnium verborum mendacio.) vel a 
           falsita<lb ed="#V" n="24" break="no"/>te signi: vel a falsitate intentionis. (Pruriginem.) 
-          <lb ed="#V" n="25"/>idest seruorem ad audiendum. (Opilare.) idest 
+          <lb ed="#V" n="25"/>idest feruorem ad audiendum. (Opilare.) idest 
           obtu<lb ed="#V" n="26" break="no"/>rare: vel claudere. (viperee doctrine.) idest 
           heretice<lb ed="#V" n="27" break="no"/>(Liberum correctorem.) qui scilicet solo amore corrigendi 
           <lb ed="#V" n="28"/>non inuidia reprehendat. Unde dicit quidam. 

--- a/kzz7yh-a02943/cod-ve07v1_kzz7yh-a02943.xml
+++ b/kzz7yh-a02943/cod-ve07v1_kzz7yh-a02943.xml
@@ -94,7 +94,7 @@
           <lb ed="#V" n="93"/>esset apponere: sed implicitum explicare et 
           manife<lb ed="#V" n="94" break="no"/>stare. Quia verum valens ad expositionem sacre 
           scri<lb ed="#V" n="95" break="no"/>pture. In ipsa implicite et virtualiter continetur. 
-          <lb ed="#V" n="96"/>(Professus est. idest promisit. Selo domus dei.) 
+          <lb ed="#V" n="96"/>(Professus est. idest promisit. (Zelo domus dei.) 
           <lb ed="#V" n="97"/>non secundum quod excludit consortium bonum: sed 
           ma<lb ed="#V" n="98" break="no"/>lum. (Carnalium.) qui carnaliter de deo sentiunt. 
           <lb ed="#V" n="99"/>scilicet quod habeat membra carnea. (Atque animalium. 


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve07v1_kzz7yh-a02943.xml`.

## Applied changes

- p. 5r l. 66: cpenuria) → (penuria): c misread as (
- p. 5r l. 69: Gamophylatium → Gazophylatium: m/z misread
- p. 5r l. 97: confortium → consortium: f/s misread
- p. 5r l. 118: eritati → Veritati: missing initial V (ornamental capital)
- p. 5v l. 25: seruorem → feruorem: s/f misread

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_