### PR TITLE
Transcription corrections: cod-ve07v1_kzz7yh-a03899.xml (25 changes)

### DIFF
--- a/kzz7yh-a03899/cod-ve07v1_kzz7yh-a03899.xml
+++ b/kzz7yh-a03899/cod-ve07v1_kzz7yh-a03899.xml
@@ -148,7 +148,7 @@
             <lb ed="#V" n="17"/>rei ad finem. quia secundum quod dicit philosophus 2o phisi. na intendit finem: 
             <lb ed="#V" n="18"/>tamen quia illum finem cognoscendo natura non praestituit: et quia talis 
             appe<lb ed="#V" n="19" break="no"/>titus in re naturali non est ab ea sed ab instituente naturam est in ea. 
-            <lb ed="#V" n="20"/>ideo sic appetem realem applicationem rei ad finem debitum non 
+            <lb ed="#V" n="20"/>ideo sic appetere realem applicationem rei ad finem debitum non 
             <lb ed="#V" n="21"/>est vti illa re. Unde appetitus grauis existentis super trabem non 
             <lb ed="#V" n="22"/>potest dici vti ipso graui: quamuis appetat ipsum graue esse de 
             <lb ed="#V" n="23"/>orsum propter grauis naturam. similiter quamuis appetitus sensitiuus 
@@ -159,7 +159,7 @@
             <lb ed="#V" n="28"/>rationem debiti et ratione ordis rei ad finem: sed dirigitur quodam 
             <lb ed="#V" n="29"/>naturali instinctu nec ille appetitus libere mouetur: sed quadam naturali
             <lb ed="#V" n="30"/>necessitate agitur: dicente Dam. libro 7. c. 2r. quod bruta aguntur 
-            <lb ed="#V" n="31"/>a naturali appetitu: ideo brutum appetendo setu suum deduci ad 
+            <lb ed="#V" n="31"/>a naturali appetitu: ideo brutum appetendo fetum suum deduci ad 
             <lb ed="#V" n="32"/>perfectionem: non dicitur vti suo fetum: voluntas autem appetendo 
             <lb ed="#V" n="33"/>creaturam realiter applicari ad finem suum: quia ad hoc appetendo 
             <lb ed="#V" n="34"/>mouet se: dicitur vti illa re quia sic applicat rem ad finem suum in 
@@ -187,7 +187,7 @@
             ¶ Ad 2m cum dicis quod ratio vtitur omnibus iudicando etc. 
             <lb ed="#V" n="52"/>Dico quod ibi accipitur vti non proprie sed pro actu primo ad actum 
             <lb ed="#V" n="53"/>vtendi proprie dictu: vel accipitur ibi vti secundum quod dicit 
-            execu<lb ed="#V" n="54" break="no"/>tionem realis applicationis postrad actum suum.
+            execu<lb ed="#V" n="54" break="no"/>tionem realis applicationis potentiae actum suum.
           </p>
           <p xml:id="kzz7yh-a03899-d1e357">
             ¶ Ad 3m 
@@ -272,7 +272,7 @@
             <lb ed="#V" n="103"/>est de mercede increata que deus est qui est summa merces 
             di<lb ed="#V" n="104" break="no"/>ligentium se. Unde dixit ad Abraham <ref xml:id="kzz7yh-a03899-Rd1e508">Gen. 15</ref> <quote xml:id="kzz7yh-a03899-Qd1e511" source="http://scta.info/resource/gen15_1@13-24">Noli timere 
             <lb ed="#V" n="105"/>Abraham ego protector tuus sum et merces tua magna 
-            ni<lb ed="#V" n="106" break="no"/>mis</quote>: et hoc patet si legitur littera glo. primallegate que talis est: Qui 
+            ni<lb ed="#V" n="106" break="no"/>mis</quote>: et hoc patet si legitur littera glo. primo allegatae que talis est: Qui 
             <lb ed="#V" n="107"/>futurae mercedis intuitu digna operari satagunt quotidianis 
             <lb ed="#V" n="108"/>superne gratiae reficiuntur alimentis.
           </p>
@@ -296,7 +296,7 @@
             <lb ed="#V" n="121"/>intelligentia. plus enim diligitur quam intelligatur et appropinquant 
             <lb ed="#V" n="122"/>dilectio et intrat vbi intellectus foris est. sed quia per gratiam 
             communem<lb ed="#V" n="123" break="no"/>potest intellectus noster magis assentire primo veritati quam veritati 
-            crea<lb ed="#V" n="124" break="no"/>te: non est licitum nobis magis assentiter alicui veritati 
+            crea<lb ed="#V" n="124" break="no"/>te: non est licitum nobis magis assentire alicui veritati 
             crea<lb ed="#V" n="125" break="no"/>te quam increate.
           </p>
           <p xml:id="kzz7yh-a03899-d1e552">
@@ -308,7 +308,7 @@
             regula<lb ed="#V" n="130" break="no"/>mur et sic vtimur habitu virtutis non vitii: et sic intelligitur 
             <lb ed="#V" n="131"/>verbum Magistri libro 2. dis. 17. et accipitur ab Augo 2o de libero ar. 
             <lb ed="#V" n="132"/>versus finem cum dicit quod nullus male vtitur virtute: aut sicut 
-            <lb ed="#V" n="133"/>actu quodo mouemur et sic non omni actu contingit bene vti: sic illo 
+            <lb ed="#V" n="133"/>actu quo mouemur et sic non omni actu contingit bene vti: sic illo 
             <lb ed="#V" n="134"/>qu mox nominatus coniunctus est malo vt mentiri et sic de consimilibus. 
             <!--00026.xml-->
             <pb ed="#V" n="6-v"/>
@@ -365,7 +365,7 @@
             vo<lb ed="#V" n="34" break="no"/>luntatem vtitur excepta creatura damnata que voluntate sua 
             <lb ed="#V" n="35"/>non vtitur sed abutitur illud quod refert non in finem debitum sed in 
             <lb ed="#V" n="36"/>debitum referendo. sed ipsa creatura que vtitur re: qua vtitur 
-            <lb ed="#V" n="37"/>refert in finem debitum qui est aliuda referente. deus aut refert 
+            <lb ed="#V" n="37"/>refert in finem debitum qui est aliud referente. deus aut refert 
             <lb ed="#V" n="38"/>ea quibus vtitur ad finem debitum qui est ipsemet. Quod autem deus vtatur 
             <lb ed="#V" n="39"/>creatura testatur Augustinus primo de doc. christi. inter medium et finem: 
             <lb ed="#V" n="40"/>dicens sic de deo. Non fruitur nobis sed vtitur. natura si neque fruitur 
@@ -389,7 +389,7 @@
             ¶ Ad tertium 
             <lb ed="#V" n="51"/>cum dicis quod motus cessat cum peruenitur ad terminum etc. Dico 
             <lb ed="#V" n="52"/>quod verum est de illo motu qui est propter distantiam a termino: sed non 
-            <lb ed="#V" n="53"/>est verum de motu qui causatur ex coniunctione cum termino sius 
+            <lb ed="#V" n="53"/>est verum de motu qui causatur ex coniunctione cum termino siue 
             <lb ed="#V" n="54"/>cum fine perfectus autem vsus causatur ex coniunctione voluntatis cum 
             <lb ed="#V" n="55"/>ipso fine. Unde beati propter hoc quod sunt coniuncti cum fine perfectius 
             <lb ed="#V" n="56"/>diligendo referunt creaturas quas diligunt in finem quam cum 

--- a/kzz7yh-a03899/cod-ve07v1_kzz7yh-a03899.xml
+++ b/kzz7yh-a03899/cod-ve07v1_kzz7yh-a03899.xml
@@ -118,9 +118,9 @@
             <lb ed="#V" n="119"/>abusio nominanda est: et posui ibi semel accipiendo vti 
             in<lb ed="#V" n="120" break="no"/>quantum diuiditur contra ociositatem. posui est ibi frequenter 
             acci<lb ed="#V" n="121" break="no"/>piendo vti secundum quod diuiditur contra dissuetudinem. rem autem referre 
-            <lb ed="#V" n="122"/>ad finem debitum potest aliquis dupliter scilicet aut realem 
+            <lb ed="#V" n="122"/>ad finem debitum potest aliquis dupliciter scilicet aut realem 
             applicatio<lb ed="#V" n="123" break="no"/>nem alicuius rei ad finem debitum exequendo: aut intendendo: 
-            <lb ed="#V" n="124"/>ita tamen quod intendens se moueat aute determinet ad illam 
+            <lb ed="#V" n="124"/>ita tamen quod intendens se moueat autem determinet ad illam 
             in<lb ed="#V" n="125" break="no"/>tentionem. aliter enim intendens finem non refert proprie 
             <lb ed="#V" n="126"/>loquendo aliquid ad finem intentionaliter: sed ille ipse qui ipsum 
             <!--00025.xml-->
@@ -155,7 +155,7 @@
             appe<lb ed="#V" n="24" break="no"/>tat realem applicationem alicuius rei ad finem debitum: sicut 
             <lb ed="#V" n="25"/>cum brutum appetit aliquam perfectionem sui setus vtpote 
             appe<lb ed="#V" n="26" break="no"/>tit quod hebeat plumas ad volandum: quia tamen ille appetitus non 
-            di<lb ed="#V" n="27" break="no"/>rigitur libera conitione considerante in ipso fine rationem finis et 
+            di<lb ed="#V" n="27" break="no"/>rigitur libera cognitione considerante in ipso fine rationem finis et 
             <lb ed="#V" n="28"/>rationem debiti et ratione ordis rei ad finem: sed dirigitur quodam 
             <lb ed="#V" n="29"/>naturali instinctu nec ille appetitus libere mouetur: sed quadam naturali
             <lb ed="#V" n="30"/>necessitate agitur: dicente Dam. libro 7. c. 2r. quod bruta aguntur 
@@ -166,10 +166,10 @@
             <lb ed="#V" n="35"/>intentione. Unde voluntas dicitur vti creatura quam diligit propter 
             <lb ed="#V" n="36"/>deum: sic ergo patet ex his omnibus quod vti proprie et principaliter non est 
             <lb ed="#V" n="37"/>alicutus postnisi ipsius appetitus rationalis qui est voluntas: quia 
-            vo<lb ed="#V" n="38" break="no"/>luntas est principaliter mouens et fuiipsius et omnium que sunt in 
+            vo<lb ed="#V" n="38" break="no"/>luntas est principaliter mouens et sui ipsius et omnium que sunt in 
             <lb ed="#V" n="39"/>regno anime. Unde Anselmus in libro de concordia praescientie et liberi arbicri inter 
-            <lb ed="#V" n="40"/>medium et finem. voluntas mouet omnia alia insttera quibus sponte 
-            <lb ed="#V" n="41"/>vtimur et que sunt in nobis vt manus: ligua: visus: et quae 
+            <lb ed="#V" n="40"/>medium et finem. voluntas mouet omnia alia instrumenta quibus sponte 
+            <lb ed="#V" n="41"/>vtimur et que sunt in nobis vt manus: lingua: visus: et quae 
             <lb ed="#V" n="42"/>sunt extra nos: vt stilus et securis: et facit omnes voluntarios 
             <lb ed="#V" n="43"/>motus: ipsa vero se suis affectionibus mouet: actiones autem non 
             <lb ed="#V" n="44"/>attribuuntur proprie loquendo istis sed principali agenti.
@@ -231,17 +231,17 @@
           </p>
           <p xml:id="kzz7yh-a03899-d1e424">
             ¶ Item 
-            li<lb ed="#V" n="77" break="no"/>citum est aliquid magis cognoscem quam summam veritatem. ergo similiter 
-            lici<lb ed="#V" n="78" break="no"/>tum est aliquid magis diligem quam summam bonitatem. sed quod licitum 
-            <lb ed="#V" n="79"/>est minus diligem licitum est referre in intentione ad magis 
+            li<lb ed="#V" n="77" break="no"/>citum est aliquid magis cognoscere quam summam veritatem. ergo similiter 
+            lici<lb ed="#V" n="78" break="no"/>tum est aliquid magis diligere quam summam bonitatem. sed quod licitum 
+            <lb ed="#V" n="79"/>est minus diligere licitum est referre in intentione ad magis 
             <lb ed="#V" n="80"/>dilectum. hoc aut est vti. ergo vtendum est summa bonitate multo 
             <lb ed="#V" n="81"/>fortius ergo quacumque re alia est vtendum.
           </p>
           <p xml:id="kzz7yh-a03899-d1e437">
             ¶ Item Augustinus. x. de 
-            <lb ed="#V" n="82"/>tri. c. xi. vti est aliquid assumen in facultatem voluntatis. sed 
+            <lb ed="#V" n="82"/>tri. c. xi. vti est aliquid assumere in facultatem voluntatis. sed 
             <lb ed="#V" n="83"/>peccata possunt assumi in facultatem voluntatis: ergo peccatis est 
-            vten<lb ed="#V" n="84" break="no"/>dum multofortius ergo quacumque realia: cum peccata formaliter 
+            vten<lb ed="#V" n="84" break="no"/>dum multo fortius ergo quacumque realia: cum peccata formaliter 
             lo<lb ed="#V" n="85" break="no"/>quendo non debent dici res sed voluntarii defectus rerum. 
           </p>
           <p xml:id="kzz7yh-a03899-d1e449">
@@ -273,26 +273,26 @@
             di<lb ed="#V" n="104" break="no"/>ligentium se. Unde dixit ad Abraham <ref xml:id="kzz7yh-a03899-Rd1e508">Gen. 15</ref> <quote xml:id="kzz7yh-a03899-Qd1e511" source="http://scta.info/resource/gen15_1@13-24">Noli timere 
             <lb ed="#V" n="105"/>Abraham ego protector tuus sum et merces tua magna 
             ni<lb ed="#V" n="106" break="no"/>mis</quote>: et hoc patet si legitur littera glo. primallegate que talis est: Qui 
-            <lb ed="#V" n="107"/>futur mercedis intuitu digna operari satagunt quotidianis 
+            <lb ed="#V" n="107"/>futurae mercedis intuitu digna operari satagunt quotidianis 
             <lb ed="#V" n="108"/>superne gratiae reficiuntur alimentis.
           </p>
           <p xml:id="kzz7yh-a03899-d1e509">
             ¶ Ad 2m cum dicis quod omnis 
             <lb ed="#V" n="109"/>qui fruitur vtitur etc. dico quod sumitur ibi: vti nimis improprie 
             <lb ed="#V" n="110"/>et nimis large. extendit enim vti ad omnem actum volendi: quod 
-            <lb ed="#V" n="111"/>patet: quia postquam dixit Aug. omnis qui fruitur vtitur: statim subiciugit: 
-            <lb ed="#V" n="112"/>assumit enim aliquid in facultatem voluntatiss
+            <lb ed="#V" n="111"/>patet: quia postquam dixit Aug. omnis qui fruitur vtitur: statim subiungit: 
+            <lb ed="#V" n="112"/>assumit enim aliquid in facultatem voluntatis
           </p>
           <p xml:id="kzz7yh-a03899-d1e520">
             ¶ Ad 3m cum 
-            <lb ed="#V" n="113"/>dicis quod licitum est magis aliquid cognoscem quam summam 
-            verita<lb ed="#V" n="114" break="no"/>tem etc. dico quod si ita faciliter possemus magis cognoscem per gratiam 
+            <lb ed="#V" n="113"/>dicis quod licitum est magis aliquid cognoscere quam summam 
+            verita<lb ed="#V" n="114" break="no"/>tem etc. dico quod si ita faciliter possemus magis cognoscere per gratiam 
             <lb ed="#V" n="115"/>communem veritatem increatam quam creatam. Sicut possumus magis 
-            <lb ed="#V" n="116"/>diligem bonitatem increatam quam creatam: non esset nobis licitum 
-            <lb ed="#V" n="117"/>magis cognoscem veritatem creatam quam increatam: nunc autem ita non 
+            <lb ed="#V" n="116"/>diligere bonitatem increatam quam creatam: non esset nobis licitum 
+            <lb ed="#V" n="117"/>magis cognoscere veritatem creatam quam increatam: nunc autem ita non 
             <lb ed="#V" n="118"/>est quia nostra dilectio plus ascendit quam nostra cognitio. vnde super 
-            <lb ed="#V" n="119"/>illudverbum ange. hierar. 7. c. calidum acntum et superferuidum. 
-            <lb ed="#V" n="120"/>Habetur in commento. dilectio supeminet scientie et maior est 
+            <lb ed="#V" n="119"/>illud verbum ange. hierar. 7. c. calidum acutum et superferuidum. 
+            <lb ed="#V" n="120"/>Habetur in commento. dilectio supereminet scientie et maior est 
             <lb ed="#V" n="121"/>intelligentia. plus enim diligitur quam intelligatur et appropinquant 
             <lb ed="#V" n="122"/>dilectio et intrat vbi intellectus foris est. sed quia per gratiam 
             communem<lb ed="#V" n="123" break="no"/>potest intellectus noster magis assentire primo veritati quam veritati 
@@ -304,8 +304,8 @@
             <lb ed="#V" n="126"/>assumi in facultatem voluntatis. dico quod vti aliquo ad 
             prae<lb ed="#V" n="127" break="no"/>sens potest accipi quaedrupliciter: aut sicut instro quo operamur: 
             si<lb ed="#V" n="128" break="no"/>cut carpentarius vtitur securi et sic sola voluntate vtimur 
-            ac<lb ed="#V" n="129" break="no"/>cipiendo vti proprie et principaliter: autem sicut hitu quo 
-            regula<lb ed="#V" n="130" break="no"/>mur et sic vtimur hitu virtutis non vitii: et sic intelligitur 
+            ac<lb ed="#V" n="129" break="no"/>cipiendo vti proprie et principaliter: autem sicut habitu quo 
+            regula<lb ed="#V" n="130" break="no"/>mur et sic vtimur habitu virtutis non vitii: et sic intelligitur 
             <lb ed="#V" n="131"/>verbum Magistri libro 2. dis. 17. et accipitur ab Augo 2o de libero ar. 
             <lb ed="#V" n="132"/>versus finem cum dicit quod nullus male vtitur virtute: aut sicut 
             <lb ed="#V" n="133"/>actu quodo mouemur et sic non omni actu contingit bene vti: sic illo 
@@ -333,7 +333,7 @@
             <lb ed="#V" n="11"/>Tertio queritur vtrum quelibet res habens 
             volu<lb ed="#V" n="12" break="no"/>tatem vtatur. Et videtur quod non. Augustinus primo de 
             <lb ed="#V" n="13"/>doc. christi. inter medium et finem. Res quibus vtimur ad 
-            <lb ed="#V" n="14"/>idreferimus vt bonitate dei perfruamur. sed ipse non 
+            <lb ed="#V" n="14"/>id referimus vt bonitate dei perfruamur. sed ipse non 
             <lb ed="#V" n="15"/>refert aliquam rem ad se: vt per hoc ipse fruatur bonitate 
             <lb ed="#V" n="16"/>sua. ergo deus nulla re vtitur.
           </p>
@@ -359,7 +359,7 @@
           </p>
           <p xml:id="kzz7yh-a03899-d1e660">
             <lb ed="#V" n="30"/>¶ Respondeo. Uti re aliqua est ipsum referre in debitum 
-            fi<lb ed="#V" n="31" break="no"/>nem. sed omnis res habens volutatem potest aliquam 
+            fi<lb ed="#V" n="31" break="no"/>nem. sed omnis res habens voluntatem potest aliquam 
             <lb ed="#V" n="32"/>creaturam referre in debitum finem siue sit creator nue 
             cre<lb ed="#V" n="33" break="no"/>tura beatam: siue creatura viatrix: ergo quelibet res habens 
             vo<lb ed="#V" n="34" break="no"/>luntatem vtitur excepta creatura damnata que voluntate sua 
@@ -382,7 +382,7 @@
           <p xml:id="kzz7yh-a03899-d1e704">
             ¶ Ad secundum cum 
             di<lb ed="#V" n="48" break="no"/>cis quod qui aliqua re vtitur indiget ea. Dico quod non est verum quando 
-            il<lb ed="#V" n="49" break="no"/>le qui vtitur rem quam vtitur non refert in seipsm vt in finem propter 
+            il<lb ed="#V" n="49" break="no"/>le qui vtitur rem quam vtitur non refert in seipsum vt in finem propter 
             sui<lb ed="#V" n="50" break="no"/>ipsius vtilitatem: sed bonitatem sic est vtitur deus.
           </p>
           <p xml:id="kzz7yh-a03899-d1e713">


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve07v1_kzz7yh-a03899.xml`.

## Applied changes

- p. 5B-v l. 122: dupliter → dupliciter: missing ci
- p. 5B-v l. 124: aute → autem: missing m (high conf was wrong: aure)
- p. 6r l. 27: conitione → cognitione: missing g
- p. 6r l. 38: fuiipsius → sui ipsius: f/s misread + missing space
- p. 6r l. 40: insttera → instrumenta: garbled
- p. 6r l. 41: ligua → lingua: missing n
- p. 6r l. 77: cognoscem → cognoscere: misread ending
- p. 6r l. 78: diligem → diligere: misread ending
- p. 6r l. 79: diligem → diligere: misread ending
- p. 6r l. 82: assumen → assumere: misread ending
- p. 6r l. 84: multofortius → multo fortius: missing space
- p. 6r l. 107: futur → futurae: missing ae
- p. 6r l. 111: subiciugit → subiungit: OCR misread
- p. 6r l. 112: voluntatiss → voluntatis: doubled s
- p. 6r l. 113: cognoscem → cognoscere: misread ending
- p. 6r l. 114: cognoscem → cognoscere: misread ending
- p. 6r l. 116: diligem → diligere: misread ending
- p. 6r l. 117: cognoscem → cognoscere: misread ending
- p. 6r l. 119: illudverbum → illud verbum (space); acntum → acutum (transposition)
- p. 6r l. 120: supeminet → supereminet: missing r
- p. 6r l. 129: hitu → habitu: missing ab (l129)
- p. 6r l. 130: hitu → habitu: missing ab (l130)
- p. 6v l. 14: idreferimus → id referimus: missing space
- p. 6v l. 31: volutatem → voluntatem: missing n
- p. 6v l. 49: seipsm → seipsum: missing u

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_