### PR TITLE
Transcription corrections: cod-ve07v1_kzz7yh-a04629.xml (23 changes)

### DIFF
--- a/kzz7yh-a04629/cod-ve07v1_kzz7yh-a04629.xml
+++ b/kzz7yh-a04629/cod-ve07v1_kzz7yh-a04629.xml
@@ -142,7 +142,7 @@
             obie<lb ed="#V" n="4" break="no"/>cto per actum ordinatum ad actum vlteriorem: quia in tali actu 
             <lb ed="#V" n="5"/>magis est tendentia quam quies: actum est cognitiue non 
             concomi<lb ed="#V" n="6" break="no"/>tatur delectatio nisi mediante actu appetitiue potentie. non 
-            <lb ed="#V" n="7"/>enim delectamur in cogniti nisi quia ipsum dil gimus: nec 
+            <lb ed="#V" n="7"/>enim delectamur in cognitis nisi quia ipsum diligimus: nec 
             de<lb ed="#V" n="8" break="no"/>lectamur in cognitione nisi inquantum diligimus cognitionem. 
             <lb ed="#V" n="9"/>Sequitur ergo quod frui non est actus cognitiue potentie: nisi 
             <lb ed="#V" n="10"/>dispositiue: et quod est solius posteur appetitiue elicite. cognto enim 
@@ -168,7 +168,7 @@
             <lb ed="#V" n="25"/>contemplatiua quae comprehendit cognitionem et dilectionem: 
             ali<lb ed="#V" n="26" break="no"/>quando tamen magis denominatur a cognitione quam a dilectione: non quia 
             <lb ed="#V" n="27"/>principalius sit in cognitione quam in dilectione finis rationalis 
-            <lb ed="#V" n="28"/>creature: immo econclusio: vt in 4o ostendetur. sed quia visio euidentius 
+            <lb ed="#V" n="28"/>creature: immo e conclusione: vt in 4o ostendetur. sed quia visio euidentius 
             <lb ed="#V" n="29"/>distinguit statum patrie a statu vie quam dilectio eo quod deus non 
             <lb ed="#V" n="30"/>videtur immediate in via de communi lege. Deus autem immediate 
             di<lb ed="#V" n="31" break="no"/>ligitur et in via et in patria: quamuis in via imperfecte et in patria 
@@ -177,7 +177,7 @@
           <p xml:id="kzz7yh-a04629-d1e319">
             ¶ Ad 3m cum dicis quod quilibet potentia delectatur in 
             <lb ed="#V" n="33"/>sua perfectione: dico quod hoc intelligendum est appetitiua post 
-            <lb ed="#V" n="34"/>mediate. Ad perfectionem autem postur apprehensiue apprehendens 
+            <lb ed="#V" n="34"/>mediate. Ad perfectionem autem potentiae apprehensiue apprehendens 
             <lb ed="#V" n="35"/>delectatur per pos um appetitiuam.
           </p>
           <p xml:id="kzz7yh-a04629-d1e329">
@@ -185,7 +185,7 @@
             <lb ed="#V" n="36"/>dilectio huic intelligentie quae cogitatione formatur etc. non est 
             <lb ed="#V" n="37"/>intelligendum quod per intellectum diligamus: cum ante in eodem lio 
             di<lb ed="#V" n="38" break="no"/>cat Augustinus quod non amamus nisi per voluntatem. sed intelligendum est 
-            <lb ed="#V" n="39"/>quod hebet per posm concomitantem: cuius est actus amandi per quem 
+            <lb ed="#V" n="39"/>quod hebet per potentiam concomitantem: cuius est actus amandi per quem 
             ap<lb ed="#V" n="40" break="no"/>plicatur ipsa intelligentia ad hoc vt actus intelligendi 
             for<lb ed="#V" n="41" break="no"/>metur.
           </p>
@@ -206,7 +206,7 @@
           </p>
           <p xml:id="kzz7yh-a04629-d1e370">
             <lb ed="#V" n="50"/>¶ Item sancti in patria nulla re indigent: quia secundum beato Aug. 
-            <lb ed="#V" n="51"/>13. de tri. ca. 5. Ptus non est nisi qui hebet omnia quae vuult et 
+            <lb ed="#V" n="51"/>13. de tri. ca. 5. Beatus non est nisi qui hebet omnia quae <sic>vuult</sic> et 
             ni<lb ed="#V" n="52" break="no"/>hil mali vult. Sed vt iam dictum est qui fruitur re aliqua indiget 
             <lb ed="#V" n="53"/>ea: ergo sancti in patria non fruuntur.
           </p>
@@ -234,7 +234,7 @@
             <lb ed="#V" n="67"/>¶ Contra frui aliqua re sicut obiecto est in ea quiescens cum 
             <!--00027.xml-->
             <cb ed="#P" n="b"/>
-            <lb ed="#V" n="68"/>delectatione: sed hoc potest competem cuilibet rei habenti potentiam 
+            <lb ed="#V" n="68"/>delectatione: sed hoc potest competere cuilibet rei habenti potentiam 
             <lb ed="#V" n="69"/>cognitiuam et appetitiua. ergo omnis talis res potest frui. 
           </p>
           <p xml:id="kzz7yh-a04629-d1e428">
@@ -248,7 +248,7 @@
             <lb ed="#V" n="77"/>corporali voluptate non absurde estimantur bestie: secundum autem 
             <lb ed="#V" n="78"/>voluntatem recta ratione regulatam contingit frui tripliciter: secundum quod 
             <lb ed="#V" n="79"/>triplex potest esse quies per voluntatem in summo bono. Uno modo per 
-            <lb ed="#V" n="80"/>omnimodam vdemptitatem realem: et sic fruitur deus seipso. Alio modo per 
+            <lb ed="#V" n="80"/>omnimodam ydentitatem realem: et sic fruitur deus seipso. Alio modo per 
             <lb ed="#V" n="81"/>gloriam et sic fruuntur beati deo. Alio modo per gratiam vie et sic 
             sancti<lb ed="#V" n="82" break="no"/>homines viatores fruuntur deo.
           </p>
@@ -287,7 +287,7 @@
           </p>
           <p xml:id="kzz7yh-a04629-d1e511">
             ¶ Ad 4m 
-            <lb ed="#V" n="99"/>dico quod verbum Anselmnum debet intelligi de angelis malis pro statu 
+            <lb ed="#V" n="99"/>dico quod verbum Anselmi debet intelligi de angelis malis pro statu 
             <lb ed="#V" n="100"/>quam habebunt post iudicium: quia tamen dilectio eorum qua de 
             ma<lb ed="#V" n="101" break="no"/>lis gaudent est tanta amaritudine respersa: ideo non debet concedi quod 
             <lb ed="#V" n="102"/>fruantur nisi secundum quid et determinando qualiter fruuntur et qualiter no. 
@@ -295,9 +295,9 @@
           <p xml:id="kzz7yh-a04629-d1e522">
             <lb ed="#V" n="103"/>¶ Ad 5m dicis quod inter creaturas nos et angeli scienti sumus 
             <lb ed="#V" n="104"/>qui fruuntur etc. hoc non est intelligendum cum praecisione. Unde non 
-            po<lb ed="#V" n="105" break="no"/>nitur ibi tantum: nominat tamen magis homines et angelos sanctios quam 
+            po<lb ed="#V" n="105" break="no"/>nitur ibi tantum: nominat tamen magis homines et angelos sanctos quam 
             <lb ed="#V" n="106"/>bruta propter hoc quod rationali nature quae est homo et angelis sanctis conuenit 
-            <lb ed="#V" n="107"/>fruitio secundum rationem perfectam: brum is autem secundum rationem imperfectam: quia 
+            <lb ed="#V" n="107"/>fruitio secundum rationem perfectam: beatum is autem secundum rationem imperfectam: quia 
             <lb ed="#V" n="108"/>brutum et si cognoscat bonum in quo appetitus eius quiescit 
             <lb ed="#V" n="109"/>secundum id quod est: non tamen cognoscit in eo rationem boni: et quamuis etiam 
             <lb ed="#V" n="110"/>appetat ipsum secundum id quod non est: tamen appetit in ipso rationem 
@@ -327,7 +327,7 @@
             ali<lb ed="#V" n="124" break="no"/>quod bonum finitum potest esse fruitionis nostre debitum obiectum. 
           </p>
           <p xml:id="kzz7yh-a04629-d1e582">
-            <lb ed="#V" n="125"/>¶ Item apostoite ad phi. Ita fter ego te fruar in domino: sed in hoc apituole 
+            <lb ed="#V" n="125"/>¶ Item apostolus ad phi. Ita frater ego te fruar in domino: sed in hoc apostolus 
             <lb ed="#V" n="126"/>non reprehenditur: ergo creatura potest esse debitum fruitionis obiectum. 
           </p>
           <p xml:id="kzz7yh-a04629-d1e589">
@@ -345,7 +345,7 @@
             <pb ed="#V" n="7-v"/>
             <cb ed="#P" n="a"/>
             <lb ed="#V" n="1"/>voluntatem. et hoc ostendo per auctoritates et rationes. per auctoritates sic. 
-            <lb ed="#V" n="2"/>Dicit enim beatus Augustinus primo de docu christius parum post principium 
+            <lb ed="#V" n="2"/>Dicit enim beatus Augustinus primo de doctrina christiana parum post principium 
             <lb ed="#V" n="3"/>vtendum est hoc mundo non fruendum. et paru post dicit. res 
             <lb ed="#V" n="4"/>quibus fruendum est sunt pater et filius et spiritus sanctus. Item infra in 
             eo<lb ed="#V" n="5" break="no"/>dem lius cum adest quod diligitur etiam dilectionem secum necesse 
@@ -365,7 +365,7 @@
             <lb ed="#V" n="17"/>imaginatio dei quo eius capax et particeps esse potest: quod a 
             simili<lb ed="#V" n="18" break="no"/>potest dici de angelo. ergo nulli voluntati licitum est statuere 
             vl<lb ed="#V" n="19" break="no"/>timam quietem nisi in deo. sed frui re aliqua est in ea vltimo 
-            <lb ed="#V" n="20"/>quiescem: vt heberi potest ex supraedictis dicente Augo primo de doc 
+            <lb ed="#V" n="20"/>quiescere: vt heberi potest ex supradictis dicente Augustino primo de doctrina 
             <lb ed="#V" n="21"/>christiana quod frui est amore inhaerere alicui rei propter seipsum. ergo 
             <lb ed="#V" n="22"/>non est licitum frui nisi deo.
           </p>
@@ -395,10 +395,10 @@
             <!--TODO: add para break -->
             <lb ed="#V" n="44"/>Ad primum in oppositum cum dicis quod scientia et virtus propter se expetenda
             <lb ed="#V" n="45"/>sunt etc. dico quod ibi ponitur praepositio pro praepositione ly propter
-            <lb ed="#V" n="46"/>pro per. Unde vult dicere quod per se expetenda sunt. quia sic bona hoe 
+            <lb ed="#V" n="46"/>pro per. Unde vult dicere quod per se expetenda sunt. quia sic bona hone 
             <lb ed="#V" n="47"/>sta et per se ordinantia hominem in vltimum finem: non tamen propter hoc 
             <lb ed="#V" n="48"/>sequitur quod expetenda sunt propter se sicut propter finem vltimum. vnde 
-            <lb ed="#V" n="49"/>lpter per se excludit per accidens.
+            <lb ed="#V" n="49"/>ly per se excludit per accidens.
           </p>
           <p xml:id="kzz7yh-a04629-d1e730">
             ¶ Ad 2m cum dicis quod 

--- a/kzz7yh-a04629/cod-ve07v1_kzz7yh-a04629.xml
+++ b/kzz7yh-a04629/cod-ve07v1_kzz7yh-a04629.xml
@@ -396,7 +396,7 @@
             <lb ed="#V" n="44"/>Ad primum in oppositum cum dicis quod scientia et virtus propter se expetenda
             <lb ed="#V" n="45"/>sunt etc. dico quod ibi ponitur praepositio pro praepositione ly propter
             <lb ed="#V" n="46"/>pro per. Unde vult dicere quod per se expetenda sunt. quia sic bona hone 
-            <lb ed="#V" n="47"/>sta et per se ordinantia hominem in vltimum finem: non tamen propter hoc 
+            hone<lb ed="#V" n="47" break="no"/>sta et per se ordinantia hominem in vltimum finem: non tamen propter hoc 
             <lb ed="#V" n="48"/>sequitur quod expetenda sunt propter se sicut propter finem vltimum. vnde 
             <lb ed="#V" n="49"/>ly per se excludit per accidens.
           </p>

--- a/kzz7yh-a04629/cod-ve07v1_kzz7yh-a04629.xml
+++ b/kzz7yh-a04629/cod-ve07v1_kzz7yh-a04629.xml
@@ -107,7 +107,7 @@
           <p xml:id="kzz7yh-a04629-d1e184">
             ¶ Item Augustinus 15 de triat. 
             <lb ed="#V" n="115"/>c. 21. Inest memoria: mest dilectio huic intelligentie quae 
-            co<lb ed="#V" n="116" break="no"/>gnitione formatur potentia. ergo intellectiua potest diligem: sed frui 
+            co<lb ed="#V" n="116" break="no"/>gnitione formatur potentia. ergo intellectiua potest diligere: sed frui 
             <lb ed="#V" n="117"/>est actus cuiusset potentie: qui cognoscendo potest diligem: quia talis 
             <lb ed="#V" n="118"/>potest in obiecto delectabiliter quiescem: ergo frui est actus postmur intelliue. 
           </p>
@@ -159,7 +159,7 @@
             nobilis<lb ed="#V" n="19" break="no"/>sima potentia etc. dico quod voluntas 
             nobi<lb ed="#V" n="20" break="no"/>lior est potentia quam intellectus vt ostendetur libro 2. vnde ad hoc vt verbum philosophi
             <lb ed="#V" n="21"/>allegatum verum sit: debet accipi intellectus prout nominat totam partem 
-            <lb ed="#V" n="22"/>intellectiuam comprehendentem rationem et voluntatem quae distiguitur 
+            <lb ed="#V" n="22"/>intellectiuam comprehendentem rationem et voluntatem quae distinguitur 
             <lb ed="#V" n="23"/>contra vegetatiuam et sensitiuam.
           </p>
           <p xml:id="kzz7yh-a04629-d1e297">
@@ -169,7 +169,7 @@
             ali<lb ed="#V" n="26" break="no"/>quando tamen magis denominatur a cognitione quam a dilectione: non quia 
             <lb ed="#V" n="27"/>principalius sit in cognitione quam in dilectione finis rationalis 
             <lb ed="#V" n="28"/>creature: immo econclusio: vt in 4o ostendetur. sed quia visio euidentius 
-            <lb ed="#V" n="29"/>distiguit statum patrie a statu vie quam dilectio eo quod deus non 
+            <lb ed="#V" n="29"/>distinguit statum patrie a statu vie quam dilectio eo quod deus non 
             <lb ed="#V" n="30"/>videtur immediate in via de communi lege. Deus autem immediate 
             di<lb ed="#V" n="31" break="no"/>ligitur et in via et in patria: quamuis in via imperfecte et in patria 
             per<lb ed="#V" n="32" break="no"/>fecte
@@ -205,7 +205,7 @@
             <lb ed="#V" n="49"/>deo summe exclusa est: ergo deus non fruitur nec se nec alio. 
           </p>
           <p xml:id="kzz7yh-a04629-d1e370">
-            <lb ed="#V" n="50"/>¶ Item sancti in patria nulla re indigent: quia secundum b.o Aug. 
+            <lb ed="#V" n="50"/>¶ Item sancti in patria nulla re indigent: quia secundum beato Aug. 
             <lb ed="#V" n="51"/>13. de tri. ca. 5. Ptus non est nisi qui hebet omnia quae vuult et 
             ni<lb ed="#V" n="52" break="no"/>hil mali vult. Sed vt iam dictum est qui fruitur re aliqua indiget 
             <lb ed="#V" n="53"/>ea: ergo sancti in patria non fruuntur.
@@ -215,7 +215,7 @@
             <lb ed="#V" n="54"/>x. Fruimur cognitis in quibus voluntas propter seipsa 
             delecta<lb ed="#V" n="55" break="no"/>ta conquiescit. sed sancti in via non quiescunt: quia deo perfecte 
             coniun<lb ed="#V" n="56" break="no"/>cti non sunt. Unde dicit beatus Augustinus primo confes. loquens ad deum 
-            <lb ed="#V" n="57"/>Fecisti nos domine ad te et inquetum est cor nosterm donec 
+            <lb ed="#V" n="57"/>Fecisti nos domine ad te et inquietum est cor nostrum donec 
             requie<lb ed="#V" n="58" break="no"/>scat in te. ergo sancti in via non fruuntur.
           </p>
           <p xml:id="kzz7yh-a04629-d1e394">
@@ -242,14 +242,14 @@
             <lb ed="#V" n="71"/>re aliqua tamquam in obiecto quam actum delectatio 
             <lb ed="#V" n="72"/>concomitatur immediate. Hec aut quietatio potest esse vel secundum 
             appe<lb ed="#V" n="73" break="no"/>titum regulatum ratione tantum: et sic fruuntur boni summo bono: 
-            <lb ed="#V" n="74"/>viel secundum appetitum libidinosum liberum tamen: et sic fruuntur 
+            <lb ed="#V" n="74"/>vel secundum appetitum libidinosum liberum tamen: et sic fruuntur 
             mali<lb ed="#V" n="75" break="no"/>bono creato. vel secundum appetitum sensualitatis tantum: et sic 
             bru<lb ed="#V" n="76" break="no"/>ta fruuntur cibo. Unde Augustinus lio 83. q. q. 30. frui cibo et qualibet 
             <lb ed="#V" n="77"/>corporali voluptate non absurde estimantur bestie: secundum autem 
-            <lb ed="#V" n="78"/>volutatem recta ratione regulatam contingit frui tripliciter: secundum quod 
-            <lb ed="#V" n="79"/>triplex potest esse quies per voluntatem in summo bono. Unomodo per 
+            <lb ed="#V" n="78"/>voluntatem recta ratione regulatam contingit frui tripliciter: secundum quod 
+            <lb ed="#V" n="79"/>triplex potest esse quies per voluntatem in summo bono. Uno modo per 
             <lb ed="#V" n="80"/>omnimodam vdemptitatem realem: et sic fruitur deus seipso. Alio modo per 
-            <lb ed="#V" n="81"/>gluiam et sic fruuntur beati deo. Alio modo per gratiam vie et sic 
+            <lb ed="#V" n="81"/>gloriam et sic fruuntur beati deo. Alio modo per gratiam vie et sic 
             sancti<lb ed="#V" n="82" break="no"/>homines viatores fruuntur deo.
           </p>
           <p xml:id="kzz7yh-a04629-d1e459">
@@ -272,8 +272,8 @@
           </p>
           <p xml:id="kzz7yh-a04629-d1e486">
             ¶ Patet etiam 
-            <lb ed="#V" n="90"/>ad 2m quia indigentia necessitatis quae est de bono hieito non est 
-            <lb ed="#V" n="91"/>contra rationem beatitudis nec repugnat huic quod dictum est quod 
+            <lb ed="#V" n="90"/>ad 2m quia indigentia necessitatis quae est de bono habito non est 
+            <lb ed="#V" n="91"/>contra rationem beatitudinis nec repugnat huic quod dictum est quod 
             bea<lb ed="#V" n="92" break="no"/>ti habent quicquid volunt
           </p>
           <p xml:id="kzz7yh-a04629-d1e495">
@@ -313,7 +313,7 @@
             <lb ed="#V" n="113"/>Tertio queritur vtrum solus deus sit debitum 
             obie<lb ed="#V" n="114" break="no"/>ctum fruitionis. Et videtur quod non: dicit enim 
             <lb ed="#V" n="115"/>Tullius in rethorica: quod expetendorum tria sunt genera. 
-            <lb ed="#V" n="116"/>Unum quod propter se expetendum estscilictictentia et virtus. Aliud 
+            <lb ed="#V" n="116"/>Unum quod propter se expetendum est scilicet scientia et virtus. Aliud 
             <lb ed="#V" n="117"/>quod propter alterum tantum vt pecuia. Alterum quod propter vtrumque 
             <lb ed="#V" n="118"/>vt amicicia: sed illud quod propter se est expetendum potest esse 
             debi<lb ed="#V" n="119" break="no"/>tum obiectum fruitionis: ergo scientia et virtus possunt esse fruitionis 
@@ -333,7 +333,7 @@
           <p xml:id="kzz7yh-a04629-d1e589">
             <lb ed="#V" n="127"/>Contra Augustinum primo de doctrina christiana parum post principium. Frui est 
             <lb ed="#V" n="128"/>amore inherere alicui rei per seipsam. sed soli deo 
-            <lb ed="#V" n="129"/>propter seipsum est amore imherendum: ergo solo deo est fruendum. 
+            <lb ed="#V" n="129"/>propter seipsum est amore inhaerendum: ergo solo deo est fruendum. 
           </p>
           <p xml:id="kzz7yh-a04629-d1e599">
             <lb ed="#V" n="130"/>Respondeo quod solus deus est debitum obiectum fruitionis 
@@ -347,13 +347,13 @@
             <lb ed="#V" n="1"/>voluntatem. et hoc ostendo per auctoritates et rationes. per auctoritates sic. 
             <lb ed="#V" n="2"/>Dicit enim beatus Augustinus primo de docu christius parum post principium 
             <lb ed="#V" n="3"/>vtendum est hoc mundo non fruendum. et paru post dicit. res 
-            <lb ed="#V" n="4"/>quibus fruendum est sunt pater et filius et spiritus sanctus. Item infra in eo 
-            <lb ed="#V" n="5"/>dem lius cum adest quod diligitur etiam dilectionem secum necesse 
+            <lb ed="#V" n="4"/>quibus fruendum est sunt pater et filius et spiritus sanctus. Item infra in 
+            eo<lb ed="#V" n="5" break="no"/>dem lius cum adest quod diligitur etiam dilectionem secum necesse 
             <lb ed="#V" n="6"/>est gerat: per quam si transieris eamque ad illud vbi per amandum 
             <lb ed="#V" n="7"/>est rettuleris: vteris ea et abusiue non proprie diceris frui. 
             <lb ed="#V" n="8"/>Si vero inheseris atque permanseris finem in ea ponens letitie 
             <lb ed="#V" n="9"/>tue: tunc vere et proprie frui dicendum es: quod non est faciendum 
-            <lb ed="#V" n="10"/>nisi in illa trinitate id est summo et incommunicabilt bono. 
+            <lb ed="#V" n="10"/>nisi in illa trinitate id est summo et incommunicabili bono. 
           </p>
           <p xml:id="kzz7yh-a04629-d1e640">
             <lb ed="#V" n="11"/>¶ Hoc idem ostenditur duabus rationibus: primo sic non est licitum 
@@ -363,10 +363,10 @@
             <lb ed="#V" n="15"/>finem pro vltimo fine. sed deus est res nobilissima et per 
             vo<lb ed="#V" n="16" break="no"/>luntatem attingi potest quia de anima dicitur. 14. de trinitate. c. 8. quod eo est 
             <lb ed="#V" n="17"/>imaginatio dei quo eius capax et particeps esse potest: quod a 
-            simili<lb ed="#V" n="18" break="no"/>potest dici de angelo. ergo nulli voluntati licitum est statuem 
+            simili<lb ed="#V" n="18" break="no"/>potest dici de angelo. ergo nulli voluntati licitum est statuere 
             vl<lb ed="#V" n="19" break="no"/>timam quietem nisi in deo. sed frui re aliqua est in ea vltimo 
             <lb ed="#V" n="20"/>quiescem: vt heberi potest ex supraedictis dicente Augo primo de doc 
-            <lb ed="#V" n="21"/>christiana quod frui est amore imherere alicui rei propter seipsum. ergo 
+            <lb ed="#V" n="21"/>christiana quod frui est amore inhaerere alicui rei propter seipsum. ergo 
             <lb ed="#V" n="22"/>non est licitum frui nisi deo.
           </p>
           <p xml:id="kzz7yh-a04629-d1e669">
@@ -378,8 +378,8 @@
             <lb ed="#V" n="27"/>quietem: quia vt supraedictum est: frui est vltimus actus 
             appeti<lb ed="#V" n="28" break="no"/>tiue potentie quo delectabiliter quiescitur in obiecto. ergo non est 
             <lb ed="#V" n="29"/>licitum frui aliqua re tanquam obiecto nisi deo. Minor patet 
-            per<lb ed="#V" n="30" break="no"/>Augumentum dicentem pramo confess. prope principium ad deum sic. fecisti nos 
-            <lb ed="#V" n="31"/>domine ad te et inquetum est cor nosterm donec requiescat in te. et per 
+            per<lb ed="#V" n="30" break="no"/>Augumentum dicentem primo confess. prope principium ad deum sic. fecisti nos 
+            <lb ed="#V" n="31"/>domine ad te et inquietum est cor nostrum donec requiescat in te. et per 
             <lb ed="#V" n="32"/>auctorem de spiritum et anima ante medium dicentem quod tante 
             dignita<lb ed="#V" n="33" break="no"/>tis est humana conditio vt nullum bonum ei possit 
             sufficen<lb ed="#V" n="34" break="no"/>praeter summum quod etiam persuadet experientia: quia homo experitur in 
@@ -396,7 +396,7 @@
             <lb ed="#V" n="44"/>Ad primum in oppositum cum dicis quod scientia et virtus propter se expetenda
             <lb ed="#V" n="45"/>sunt etc. dico quod ibi ponitur praepositio pro praepositione ly propter
             <lb ed="#V" n="46"/>pro per. Unde vult dicere quod per se expetenda sunt. quia sic bona hoe 
-            <lb ed="#V" n="47"/>sta et per se ordinantia hominem in vltium finem: non tamen propter hoc 
+            <lb ed="#V" n="47"/>sta et per se ordinantia hominem in vltimum finem: non tamen propter hoc 
             <lb ed="#V" n="48"/>sequitur quod expetenda sunt propter se sicut propter finem vltimum. vnde 
             <lb ed="#V" n="49"/>lpter per se excludit per accidens.
           </p>
@@ -406,10 +406,10 @@
             <lb ed="#V" n="51"/>voluntas nostra capax est sicut rei intrinsece et inherentis 
             <lb ed="#V" n="52"/>finitum est: tamen boni infiniti tamque obiecti ipsa capax est: quia 
             <lb ed="#V" n="53"/>ipsum apprehendit non tamen comprehendit: quamuis actu finito et 
-            im<lb ed="#V" n="54" break="no"/>tensiue. et ideo in bono finito nullatenus perfecte quiescem potest 
+            im<lb ed="#V" n="54" break="no"/>tensiue. et ideo in bono finito nullatenus perfecte quiescere potest 
           </p>
           <p xml:id="kzz7yh-a04629-d1e743">
-            <lb ed="#V" n="55"/>¶ Ad 3m cum arguis per apistolindum ad Phil. dico quod sensus 
+            <lb ed="#V" n="55"/>¶ Ad 3m cum arguis per apostolum ad Phil. dico quod sensus 
             <lb ed="#V" n="56"/>est secundum glo. Ego te fruar in domino id est gaudebo de te in 
             re<lb ed="#V" n="57" break="no"/>gno dei si feceris quod rogo: hoc est dictu: gaudebo de 
             fru<lb ed="#V" n="58" break="no"/>ctu tuo. simile dicitur ad Ro. 15 vbi apostolus si vobis primum ex 
@@ -439,7 +439,7 @@
             <!--missing paragaph break for the Contra-->
             <lb ed="#V" n="70"/>Contra. relativa sunt simul natura et intellectum secundum philosophum in 
             praedica<lb ed="#V" n="71" break="no"/>menta. sed tres persone non distinguuntur nisi relationibus secundum 
-            <lb ed="#V" n="72"/>Boeentum primolius de trinitate. c. vltimo: dicentem quod substantia continet 
+            <lb ed="#V" n="72"/>Boethium primo libro de trinitate. c. vltimo: dicentem quod substantia continet 
             vni<lb ed="#V" n="73" break="no"/>tatem: relatio multiplicat trinitatem. ergo tres persone vnica 
             co<lb ed="#V" n="74" break="no"/>gnitione cognoscuntur: ergo et beati illa vnica fruitione fruuntu.
           </p>


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve07v1_kzz7yh-a04629.xml`.

## Applied changes

- p. 6v l. 116: diligem → diligere: misread ending
- p. 7r l. 22: distiguitur → distinguitur: missing n
- p. 7r l. 29: distiguit → distinguit: missing n
- p. 7r l. 50: b.o → beato: abbreviated
- p. 7r l. 57: inquetum → inquietum; nosterm → nostrum
- p. 7r l. 74: viel → vel: OCR confusion
- p. 7r l. 78: volutatem → voluntatem: missing n
- p. 7r l. 79: Unomodo → Uno modo: missing space
- p. 7r l. 81: gluiam → gloriam: OCR misread
- p. 7r l. 90: hieito → habito: OCR misread
- p. 7r l. 91: beatitudis → beatitudinis: missing in
- p. 7r l. 116: estscilictictentia → est scilicet scientia: garbled merge
- p. 7r l. 129: imherendum → inhaerendum: m/n + spelling
- p. 7v l. 5: 'eo' + 'dem' split across line break without break="no" on lb n=5
- p. 7v l. 10: incommunicabilt → incommunicabili: missing final i
- p. 7v l. 18: statuem → statuere: misread ending
- p. 7v l. 21: imherere → inhaerere: m/n + spelling
- p. 7v l. 30: pramo → primo; Augumentum → Argumentum
- p. 7v l. 31: inquetum → inquietum; nosterm → nostrum
- p. 7v l. 47: vltium → vltimum: missing m
- p. 7v l. 54: quiescem → quiescere: misread ending
- p. 7v l. 55: apistolindum → apostolum: garbled
- p. 7v l. 72: Boeentum → Boethium; primolius → primo libro

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_