### PR TITLE
Transcription corrections: cod-ve07v1_kzz7yh-a06241.xml (16 changes)

### DIFF
--- a/kzz7yh-a06241/cod-ve07v1_kzz7yh-a06241.xml
+++ b/kzz7yh-a06241/cod-ve07v1_kzz7yh-a06241.xml
@@ -84,7 +84,7 @@
             ¶ Questio I. 
             <lb ed="#V" n="117"/>PRimo ergo queritur vtrum vna sit diuina
             <lb ed="#V" n="118"/>essentia tantum vel plures. Et videtur 
-            <lb ed="#V" n="119"/>quod plures. Anselis monolis 15 c. Omne quod melius 
+            <lb ed="#V" n="119"/>quod plures. Anselmus Monologion 15 c. Omne quod melius 
             <lb ed="#V" n="120"/>est ipsum quam non ipsum in deo ponendum est: sed 
             me<lb ed="#V" n="121" break="no"/>lius est plures diuinas essentias esse quam non esse. Cum 
             <lb ed="#V" n="122"/>secundum philosophum 3o thopicorum plura bona paucioribus magis 
@@ -542,7 +542,7 @@
             <lb ed="#V" n="62"/>quam facio de potentia et sic de aliis: quamuis ab eterno 
             <lb ed="#V" n="63"/>non essent: tamen ab eterno fuerunt intellecte a deo: sicut 
             <lb ed="#V" n="64"/>etiam et omues creature fuerunt a deo intellecte ab eter 
-            <lb ed="#V" n="65"/>no: quamuis ab eterno non habuerint esse: vnde vdee 
+            <lb ed="#V" n="65"/>no: quamuis ab eterno non habuerint esse: vnde ydee 
             ea<lb ed="#V" n="66" break="no"/>rum aliter fuerunt in deo ab eterno: aliter creature: quia 
             <lb ed="#V" n="67"/>idee fuerunt in deo per modum rei intrinsece: et ita re¬ 
             <!--00034.xml-->
@@ -601,7 +601,7 @@
             attribu<lb ed="#V" n="105" break="no"/>ta diuine essentie sit aliquis 
             <lb ed="#V" n="106"/>ordo rationum. Et videtur quod non. Augustinus 19 
             <lb ed="#V" n="107"/>de ciuitate capitulo 13. Ordo est parium dispariumque 
-            <lb ed="#V" n="108"/>Arerum sua cuique loca tribuens dispositio: sed 
+            <lb ed="#V" n="108"/>rerum sua cuique loca tribuens dispositio: sed 
             <lb ed="#V" n="109"/>inter diuina attributa nullo modo est disparitas secundum 
             <lb ed="#V" n="110"/>rationem. omnes enim rationes eorum equalis sunt 
             no<lb ed="#V" n="111" break="no"/>bilitatis cum vnum sint in deo: ergo inter illa non est 

--- a/kzz7yh-a06241/cod-ve07v1_kzz7yh-a06241.xml
+++ b/kzz7yh-a06241/cod-ve07v1_kzz7yh-a06241.xml
@@ -86,7 +86,7 @@
             <lb ed="#V" n="118"/>essentia tantum vel plures. Et videtur 
             <lb ed="#V" n="119"/>quod plures. Anselis monolis 15 c. Omne quod melius 
             <lb ed="#V" n="120"/>est ipsum quam non ipsum in deo ponendum est: sed 
-            me<lb ed="#V" n="121" break="no"/>lius est prures diuinas essentias esse quam non esse. Cum 
+            me<lb ed="#V" n="121" break="no"/>lius est plures diuinas essentias esse quam non esse. Cum 
             <lb ed="#V" n="122"/>secundum philosophum 3o thopicorum plura bona paucioribus magis 
             <lb ed="#V" n="123"/>sunt eligenda. ergo videtur quod sint plures diuine 
             es<lb ed="#V" n="124" break="no"/>sentie.
@@ -167,10 +167,10 @@
             <lb ed="#V" n="42"/>Anselmi monolis 4. ca.
           </p>
           <p xml:id="kzz7yh-a06241-d1e287">
-            ¶ Tertia talis. Omnes creatu 
-            <lb ed="#V" n="43"/>re aliquam habent connexionem: quia partes sunt 
+            ¶ Tertia talis. Omnes 
+            creatu<lb ed="#V" n="43" break="no"/>re aliquam habent connexionem: quia partes sunt 
             vni<lb ed="#V" n="44" break="no"/>us mundi. connexionem autem diuersorum oportet 
-            redu<lb ed="#V" n="45" break="no"/>cere ad aliquid vnum. oportet ergo conmnexionis creatu 
+            redu<lb ed="#V" n="45" break="no"/>cere ad aliquid vnum. oportet ergo connexionis creatu 
             <lb ed="#V" n="46"/>rarum esse vnum primum principium tantum. Et hec ratio 
             <lb ed="#V" n="47"/>trahi potest ex verbis philosophi. xii. metaphy. circa finem: vbi 
             <lb ed="#V" n="48"/>loquens contra illos qui ponebant plura principia non 
@@ -180,13 +180,13 @@
             <lb ed="#V" n="52"/>est.
           </p>
           <p xml:id="kzz7yh-a06241-d1e311">
-            ¶ Quarta talis. Omne imperfectum oportet trahe 
-            <lb ed="#V" n="53"/>re originem ab aliquo simpliciter perfecto. perfectum 
+            ¶ Quarta talis. Omne imperfectum oportet 
+            trahe<lb ed="#V" n="53" break="no"/>re originem ab aliquo simpliciter perfecto. perfectum 
             <lb ed="#V" n="54"/>autem simpliciter non potest esse nisi vnum: quia si essent 
             plu<lb ed="#V" n="55" break="no"/>res essentie perfecte: aliqua perfectio esset in vna que 
             <lb ed="#V" n="56"/>non esset secundum illum modum: nec altiori in alia: et sic 
             neu<lb ed="#V" n="57" break="no"/>tra simpliciter esset perfecta. Quia secundum quod potest trahi ex 
-            <lb ed="#V" n="58"/>verbis philosophi. 5. metaphy. c. de perfecto. Illud autem simpliter 
+            <lb ed="#V" n="58"/>verbis philosophi. 5. metaphy. c. de perfecto. Illud autem simpliciter 
             <lb ed="#V" n="59"/>perfectum in quo reperiuntur omnes nobilitates cuius 
             <lb ed="#V" n="60"/>libet entis per modum tamen altiorem. Illud est 
             simpli<lb ed="#V" n="61" break="no"/>citer perfectum deus est. Unde etiam Commentator ibi 
@@ -262,7 +262,7 @@
             <lb ed="#V" n="106"/>Secundo queritur vtrum quodlibet  
             attri<lb ed="#V" n="107" break="no"/>butum divine essentie sit 
             ip<lb ed="#V" n="108" break="no"/>sa diuina essentia tantum. Et videtur quod non. quia ipsa 
-            <lb ed="#V" n="109"/>dinina essentia non est attributum sed fundamen 
+            <lb ed="#V" n="109"/>diuina essentia non est attributum sed fundamen 
             <lb ed="#V" n="110"/>tum attributorum suorum. sed si quodlibet attributum 
             <lb ed="#V" n="111"/>esset ipsa tantum: ipsa esset attributum: ergo nullum attributum 
             <lb ed="#V" n="112"/>diuine essentie est ipsa diuina essentia tantum.
@@ -333,7 +333,7 @@
           </p>
           <p xml:id="kzz7yh-a06241-d1e602">
             <lb ed="#V" n="31"/>Ad primum dicendum quod eadem res sub vna ratione 
-            <lb ed="#V" n="32"/>bene est in seipsa cosiderata sub 
+            <lb ed="#V" n="32"/>bene est in seipsa considerata sub 
             ratio<lb ed="#V" n="33" break="no"/>ne alia. Bene enim dicitur quod diuinitas est in deo.
           </p>
           <p xml:id="kzz7yh-a06241-d1e611">
@@ -462,7 +462,7 @@
             haben<lb ed="#V" n="122" break="no"/>do formam auri vel atgenti per modum rei intrinsece quam non 
             <lb ed="#V" n="123"/>habendo et sic de multis aliis: quapropter quamuis in deo sint 
             <lb ed="#V" n="124"/>superexcellentie perfectionum repertaru in generibus entium: non tamen 
-            <lb ed="#V" n="125"/>omnia nomina signntia istas perfectiones de deo praedicamus: 
+            <lb ed="#V" n="125"/>omnia nomina significantia istas perfectiones de deo praedicamus: 
             prae<lb ed="#V" n="126" break="no"/>dicatione enim propria non diceremus deum esse 
             au<lb ed="#V" n="127" break="no"/>rum: nec deum esse asinum: nec deum esse lapidem: nisi per 
             mo<lb ed="#V" n="128" break="no"/>dum translationis. secundum quod dicit apostolus id est ad Corum. x. petra 
@@ -477,8 +477,8 @@
             <cb ed="#P" n="a"/>
             <lb ed="#V" n="1"/>diuina essentia est potens: sapiens iusta et sic de aliis. 
             <lb ed="#V" n="2"/>Unde est in communi vsu loquendi: si aliquis predicat 
-            sa<lb ed="#V" n="3" break="no"/>pientiam de aliquo. dicendo petrus est sapiens: nos dici 
-            <lb ed="#V" n="4"/>mus quod talis attribuit petro sapientiam. hoc de prim artius. 
+            sa<lb ed="#V" n="3" break="no"/>pientiam de aliquo. dicendo petrus est sapiens: nos 
+            dici<lb ed="#V" n="4" break="no"/>mus quod talis attribuit petro sapientiam. hoc de prim artius. 
             <!--TODO: insert para break-->
             <lb ed="#V" n="5"/>Quartum ad 2m sciendum quod relationes secundum rem 
             dicun<lb ed="#V" n="6" break="no"/>tur que consequuntur res secundum esse suum 
@@ -506,7 +506,7 @@
             <lb ed="#V" n="27"/>Quantum ad 3m articulum notandum est quod ista 
             plu<lb ed="#V" n="28" break="no"/>ralitas rationum conuenit ex hoc quod 
             <lb ed="#V" n="29"/>res que deus est superat intellectum nostrum: ita quod vna 
-            <lb ed="#V" n="30"/>conceptione non potest apprehendere omnesmodos 
+            <lb ed="#V" n="30"/>conceptione non potest apprehendere omnes modos 
             per<lb ed="#V" n="31" break="no"/>fectionum que sunt in deo: et ideo aliam conceptionem 
             <lb ed="#V" n="32"/>format de diuina sapientia: aliam de potentia et sic de 
             <lb ed="#V" n="33"/>aliis: maxime quia ad cognoscendum ista in deo ascendit 
@@ -515,7 +515,7 @@
             comprehen<lb ed="#V" n="36" break="no"/>dendo semetipsum intelligit vno conceptu: totam suam 
             <lb ed="#V" n="37"/>perfectionem plenissime dicit: beati tamen quia deum 
             imme<lb ed="#V" n="38" break="no"/>diate vident: sibi possent vnum nomen imponere quod 
-            <lb ed="#V" n="39"/>nec signaret sapientiam tantum: nec potentiam tantum: sed omenes 
+            <lb ed="#V" n="39"/>nec signaret sapientiam tantum: nec potentiam tantum: sed omnes 
             <lb ed="#V" n="40"/>perfectiones dei quas in deo apprehendunt. Unde 
             pro<lb ed="#V" n="41" break="no"/>statu patrie dicitur de nobis Sach. vltimo. quod in illa die 
             <lb ed="#V" n="42"/>erit dominus vnus et nomen eius vnum. non tamen possent 
@@ -582,7 +582,7 @@
             <lb ed="#V" n="95"/>vna.
           </p>
           <p xml:id="kzz7yh-a06241-d1e1090">
-            ¶ Ad 3m cum dicis quod ratio quam signt nomen est 
+            ¶ Ad 3m cum dicis quod ratio quam signat nomen est 
             <lb ed="#V" n="96"/>diffinitio etc. Dico quod intelligendum est in habentibus 
             <lb ed="#V" n="97"/>diffinitionem. In his autem que non habent 
             diffinitio<lb ed="#V" n="98" break="no"/>nem ratio est illud quod primo concipimus per nomen 
@@ -605,11 +605,11 @@
             <lb ed="#V" n="109"/>inter diuina attributa nullo modo est disparitas secundum 
             <lb ed="#V" n="110"/>rationem. omnes enim rationes eorum equalis sunt 
             no<lb ed="#V" n="111" break="no"/>bilitatis cum vnum sint in deo: ergo inter illa non est 
-            <lb ed="#V" n="112"/>ordo secundum rationem.
+            <lb ed="#V" n="112"/>ordo secundum nem.
           </p>
           <p xml:id="kzz7yh-a06241-d1e1137">
             ¶ Item non est ibi ordo secundum ratio 
-            <lb ed="#V" n="113"/>nem ex parte diuine essentie: nec ex parte intellectum: 
+            ratio<lb ed="#V" n="113" break="no"/>nem ex parte diuine essentie: nec ex parte intellectum: 
             <lb ed="#V" n="114"/>quia illud attributum quod vna vice intelligit primo: 
             <lb ed="#V" n="115"/>alia vice potest intelligere secundo. ergo nullo modo 
             <lb ed="#V" n="116"/>lectus cassa est et vana cui nihil respondet in re. sed 
@@ -630,12 +630,12 @@
             ¶ Item 
             <lb ed="#V" n="127"/>prius est in deo secundum rationem intelligendi intelligere 
             <lb ed="#V" n="128"/>quam velle: ergo in ipso priora sunt secundum rationem intelligendi 
-            <lb ed="#V" n="129"/>attributa respicientia intellectum quam respicientia volutatem.
+            <lb ed="#V" n="129"/>attributa respicientia intellectum quam respicientia voluntatem.
           </p>
           <p xml:id="kzz7yh-a06241-d1e1182">
             <lb ed="#V" n="130"/>Respondeo Cum impossibile sit esse ordinem sine aliqua 
             <lb ed="#V" n="131"/>pluralitate et inter diuina attributa non sit 
-            <lb ed="#V" n="132"/>aliqua realis pluralitas secundum rem absolutam nec secundum rem raliuam 
+            <lb ed="#V" n="132"/>aliqua realis pluralitas secundum rem absolutam nec secundum rem relativam 
             <lb ed="#V" n="133"/>vt patet ex quaestione precedenti: impossibile est quod inter diui¬ 
             <!--00035.xml-->
             <pb ed="#V" n="11-r"/>
@@ -691,7 +691,7 @@
             perfectio<lb ed="#V" n="49" break="no"/>nes reducit ad eternitatem: sapientiam: beatitudinem. Ex 
             <lb ed="#V" n="50"/>dictis potest concludi quod istarum trium perfectionum: vnitas: 
             <lb ed="#V" n="51"/>veritas: bonitas. primo secundum rationem intelligendi est vnitas. 2t 
-            <lb ed="#V" n="52"/>veritas 3o bonitas. et ideo de hoc non opetet facere quaestionem. 
+            <lb ed="#V" n="52"/>veritas 3o bonitas. et ideo de hoc non oportet facere quaestionem. 
             <!--TODO: insert para break-->
             <lb ed="#V" n="53"/>Ad primum in oppositum dicendum quod illud verbum Augustini
             <lb ed="#V" n="54"/>intelligitur de ordine qui est inter res 


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve07v1_kzz7yh-a06241.xml`.

## Applied changes

- p. 9r l. 121: prures → plures: r/l misread
- p. 9v l. 43: 'creatu' + 're' split across line break without break="no" on lb n=43
- p. 9v l. 45: conmnexionis → connexionis: spurious m
- p. 9v l. 53: 'trahe' + 're' split across line break without break="no" on lb n=53
- p. 9v l. 58: simpliter → simpliciter: missing ci
- p. 9v l. 109: dinina → diuina: n/u misread
- p. 10r l. 32: cosiderata → considerata: missing n
- p. 10r l. 125: signntia → significantia: garbled
- p. 10v l. 4: 'dici' + 'mus' split across line break without break="no" on lb n=4
- p. 10v l. 30: omnesmodos → omnes modos: missing space
- p. 10v l. 39: omenes → omnes: spurious e
- p. 10v l. 95: signt → signat: missing a
- p. 10v l. 113: 'ratio' + 'nem' split across line break without break="no" on lb n=113
- p. 10v l. 129: volutatem → voluntatem: missing n
- p. 10v l. 132: raliuam → relativam: OCR scramble
- p. 11r l. 52: opetet → oportet: missing or

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_