### PR TITLE
Transcription corrections: cod-ve07v1_kzz7yh-a07504.xml (15 changes)

### DIFF
--- a/kzz7yh-a07504/cod-ve07v1_kzz7yh-a07504.xml
+++ b/kzz7yh-a07504/cod-ve07v1_kzz7yh-a07504.xml
@@ -194,14 +194,14 @@
           </p>
           <p xml:id="kzz7yh-a07504-d1e360">
             <lb ed="#V" n="34"/>Ad primum in oppositum cum dicis quod eque nobilis est 
-            <lb ed="#V" n="35"/>persona sicut esentiam etc. Dico quod verum 
+            <lb ed="#V" n="35"/>persona sicut essentia etc. Dico quod verum 
             <lb ed="#V" n="36"/>est: tamen non posse diuinam essentiam multiplicari 
             spe<lb ed="#V" n="37" break="no"/>ctat ad eius nobilitatem: quia talis plurificatio non 
             pos<lb ed="#V" n="38" break="no"/>set fieri nisi per proprietates absolutas et realiter 
             distin<lb ed="#V" n="39" break="no"/>ctas: et ita plus esset de bonitate in pluribus quam in vna: 
             <lb ed="#V" n="40"/>et sequeretur quamlibet illarum esse limitatam: quod esset 
             con<lb ed="#V" n="41" break="no"/>tra diuine essentie nobilitatem. Distinctio autem 
-            persona<lb ed="#V" n="42" break="no"/>rum est per proprietates relatiuas: dicente Boeus in libro de 
+            persona<lb ed="#V" n="42" break="no"/>rum est per proprietates relatiuas: dicente Boethio in libro de 
             <lb ed="#V" n="43"/>trinitate. c. x. quod relatio multiplicat trinitatem: ad talem autem 
             <lb ed="#V" n="44"/>distinctionem non sequitur in diuina essentia: nec 
             argu<lb ed="#V" n="45" break="no"/>mentum: nec multiplicatio bonitatis.
@@ -346,7 +346,7 @@
             <lb ed="#V" n="8"/>persona procedens per modum 
             po<lb ed="#V" n="9" break="no"/>tentie etc. dico quod non oportet: quia quia cum productio persone 
             <lb ed="#V" n="10"/>sit actio manens intra: non accipitur secundum principium 
-            agen<lb ed="#V" n="11" break="no"/>di in aliud extra. potentia autem in diuinis est habmi 
+            agen<lb ed="#V" n="11" break="no"/>di in aliud extra. potentia autem in diuinis est huius 
             princi<lb ed="#V" n="12" break="no"/>pium: bene secundum ipsam consideratur actio ad extra: et ita secundum 
             <lb ed="#V" n="13"/>ipsam non est aliqua emanatio nisi extrinseca que est 
             <lb ed="#V" n="14"/>emanatio creaturarum.
@@ -389,7 +389,7 @@
             <lb ed="#V" n="45"/>eodem actu quo genitus est non generaret nisi seipsum: quod 
             <lb ed="#V" n="46"/>ergo spiritus sanctus non potest generare nec spirare: non est 
             <lb ed="#V" n="47"/>propter hoc quod sit minus nobilis quam pater vel filius: quia 
-            <lb ed="#V" n="48"/>ex eadem nobilitate diuine essentie est quod pater generatet spirat: et 
+            <lb ed="#V" n="48"/>ex eadem nobilitate diuine essentie est quod pater generaret spirat: et 
             <lb ed="#V" n="49"/>et filius spirat et non generat et spiritus sanctus: non quod generat neque 
             <lb ed="#V" n="50"/>spirat.
           </p>
@@ -558,7 +558,7 @@
             <lb ed="#V" n="28"/>sanctus etc.
           </p>
           <p xml:id="kzz7yh-a07504-d1e1046">
-            ¶ 7o per operum appropriationem. Genem primo 
+            ¶ 7o per operum appropriationem. Genesim primo 
             <lb ed="#V" n="29"/>In principio creauit deus etc.
           </p>
           <p xml:id="kzz7yh-a07504-d1e1051">

--- a/kzz7yh-a07504/cod-ve07v1_kzz7yh-a07504.xml
+++ b/kzz7yh-a07504/cod-ve07v1_kzz7yh-a07504.xml
@@ -116,7 +116,7 @@
             rela<lb ed="#V" n="100" break="no"/>tiua. sicut videmus quod de ratione sortis est homo cum 
             ra<lb ed="#V" n="101" break="no"/>tione distinctiua quecumque sit illa: cum ergo essentia 
             in<lb ed="#V" n="102" break="no"/>diuinis non plurificetur: non plurificatur quicquid est de 
-            <lb ed="#V" n="103"/>ratione diuine persone. sed non possunt dici simpliciter plurles 
+            <lb ed="#V" n="103"/>ratione diuine persone. sed non possunt dici simpliciter plures 
             <lb ed="#V" n="104"/>persone: quando non plurificatur quicquid est de earum ratione. ergo 
             <lb ed="#V" n="105"/>in deo non sunt simpliciter plures persone. 
           </p>
@@ -154,7 +154,7 @@
             diui<lb ed="#V" n="131" break="no"/>nis oportet esse personam increatam cui summe 
             com<lb ed="#V" n="132" break="no"/>municetur: sed nullus potest eam summe communicare 
             ni<lb ed="#V" n="133" break="no"/>si persona increata: ergo oportet esse in diuinis personam 
-            sum<lb ed="#V" n="134" break="no"/>me comunicantem diuinam bonitatem et aliam cui summe colotur. 
+            sum<lb ed="#V" n="134" break="no"/>me communicantem diuinam bonitatem et aliam cui summe colotur. 
             <!--00036.xml-->
             <pb ed="#V" n="11-v"/>
             <cb ed="#P" n="a"/>
@@ -172,7 +172,7 @@
             in<lb ed="#V" n="12" break="no"/>pluribus suppositis inuenitur: vt patet in vniuersali: quod 
             <lb ed="#V" n="13"/>simplicius est singulari. Ex defectu autem simplicitatis 
             <lb ed="#V" n="14"/>est quod numeretur in pluribus suppositis: ergo cum in 
-            di<lb ed="#V" n="15" break="no"/>uina essentia sit simplicitas in nullo deficiens: opoertet quod 
+            di<lb ed="#V" n="15" break="no"/>uina essentia sit simplicitas in nullo deficiens: oportet quod 
             <lb ed="#V" n="16"/>sit in pluribus suppositis non plurificata. Ex quarta 
             <lb ed="#V" n="17"/>suppositione arguo sic: In deo est summa primitas: et 
             quam<lb ed="#V" n="18" break="no"/>to aliquid prius tanto fecundius: ergo sicut essentia 
@@ -183,7 +183,7 @@
             <lb ed="#V" n="23"/>Omnes emanationes necesse est reduci in vnam primam: 
             <lb ed="#V" n="24"/>sicut omnes vnitates in vnam primam vnitatem. Non 
             <lb ed="#V" n="25"/>possunt autem omnes reduci in vnam emanationem 
-            alicu<lb ed="#V" n="26" break="no"/>ius creature: quia mualte creature a deo immediate tantum 
+            alicu<lb ed="#V" n="26" break="no"/>ius creature: quia multae creature a deo immediate tantum 
             ema<lb ed="#V" n="27" break="no"/>nauerunt: ergo oportet omnes emanationes reduci ad 
             ema<lb ed="#V" n="28" break="no"/>nationem alicuius increate persone: sed eadem persona 
             <lb ed="#V" n="29"/>non potest emanare a semetipsa. Unde Augustinus primo de trini. 
@@ -211,8 +211,8 @@
             di<lb ed="#V" n="46" break="no"/>cis quod que sunt omnino idem re: plurificato vno 
             plu<lb ed="#V" n="47" break="no"/>rificatur aliud etc. Dico quod verum est si est idemptitas secundum 
             <lb ed="#V" n="48"/>rem et secundum modum se habendi: quamuis autem essentia et persona 
-            <lb ed="#V" n="49"/>sint idem re: tamen essentia habet modum essendi absolu 
-            <lb ed="#V" n="50"/>tum: persona vero habet modum se habendi in relatione ad 
+            <lb ed="#V" n="49"/>sint idem re: tamen essentia habet modum essendi 
+            absolu<lb ed="#V" n="50" break="no"/>tum: persona vero habet modum se habendi in relatione ad 
             <lb ed="#V" n="51"/>aliam.
           </p>
           <p xml:id="kzz7yh-a07504-d1e406">
@@ -286,7 +286,7 @@
           <p xml:id="kzz7yh-a07504-d1e528">
             ¶ Item 
             <lb ed="#V" n="93"/>quia filius non accepit voluntatem per spirationem: ideo 
-            <lb ed="#V" n="94"/>potest spirare. ergo a simili cum spritus sanctus non habeat 
+            <lb ed="#V" n="94"/>potest spirare. ergo a simili cum spiritus sanctus non habeat 
             <lb ed="#V" n="95"/>naturam per generationem videtur quod potest generare: et ex consequenti quod generat. 
             <!--TODO: insert para break and a line; the text is corrupted here-->
             <!-- missing line break --> Contra primo Cano. Io. capitulo vltimo. Tres sunt qui
@@ -303,10 +303,10 @@
             perso<lb ed="#V" n="104" break="no"/>nalis sit actio ad aliquam intra: oportet quod radicetur in 
             actu<lb ed="#V" n="105" break="no"/>essentiali non tendente ad extra sed intra manente. 
             In<lb ed="#V" n="106" break="no"/>deo autem cum sit natura pure intellectualis: non sunt 
-            ni<lb ed="#V" n="107" break="no"/>si duo tales actus: secuet intelligere et velle. ergo in 
+            ni<lb ed="#V" n="107" break="no"/>si duo tales actus: scilicet intelligere et velle. ergo in 
             diui<lb ed="#V" n="108" break="no"/>nis persona non producit personam nisi per modum 
             intelligen<lb ed="#V" n="109" break="no"/>di scilicet de deo. et sic producit verbum: et per modum volendi: 
-            <lb ed="#V" n="110"/>secuet spirando: et sic producunt pater et filius spiritum sanctum. 
+            <lb ed="#V" n="110"/>scilicet spirando: et sic producunt pater et filius spiritum sanctum. 
             <lb ed="#V" n="111"/>Unus autem actus essentialis non potest esse ratio nisi vni 
             <lb ed="#V" n="112"/>us actus personalis in diuinis: quia vnus actus 
             essentia<lb ed="#V" n="113" break="no"/>lis non potest esse ratio duorum actuum personalium simul 
@@ -329,7 +329,7 @@
             trian<lb ed="#V" n="130" break="no"/>gulo: quamuis in infinitum sit magis dissimile quam simile. 
             In<lb ed="#V" n="131" break="no"/>triangulo tres sunt anguli et vnus non est alius: et tamen qui 
             <lb ed="#V" n="132"/>libet totam superficiem trianguli comprehendit: ita quod illi tres 
-            <lb ed="#V" n="133"/>anguli in essentia superficiei non distinguuntur: secunum per 
+            <lb ed="#V" n="133"/>anguli in essentia superficiei non distinguuntur: secundum per 
             re<lb ed="#V" n="134" break="no"/>lationes distinctas: cum quilibet angulus totam superficiem¬ 
             <!--00037.xml-->
             <pb ed="#V" n="12-r"/>
@@ -364,7 +364,7 @@
             natu<lb ed="#V" n="23" break="no"/>re: verbum autem per modum nature que est intellectus 
             seu<lb ed="#V" n="24" break="no"/>ratione modi procedendi procedit per modum 
             similitudi<lb ed="#V" n="25" break="no"/>natura intellectualis: et non est distinctio in diuinis 
-            <lb ed="#V" n="26"/>nisi secundum oppositas relationes vel saltim disperatas: alia 
+            <lb ed="#V" n="26"/>nisi secundum oppositas relationes vel saltim disparatas: alia 
             <lb ed="#V" n="27"/>quia id quod procedit per modum intellectus: vt verbum ex 
             <lb ed="#V" n="28"/>nis: sicut et filius qui procedit per modum nature. 
             pro<lb ed="#V" n="29" break="no"/>ductio autem per modum artis reducitur ad productionem. 
@@ -372,9 +372,9 @@
             <lb ed="#V" n="31"/>voluntatis.
           </p>
           <p xml:id="kzz7yh-a07504-d1e700">
-            ¶ Ad 3m cum dicis quod cum spitus sanctus sit 
+            ¶ Ad 3m cum dicis quod cum spiritus sanctus sit 
             <lb ed="#V" n="32"/>eque nobilis sicut alie persone producit personam etc. 
-            di<lb ed="#V" n="33" break="no"/>co quod non opetet: immo ex hoc quod est equalis nobilitas: sicut 
+            di<lb ed="#V" n="33" break="no"/>co quod non oportet: immo ex hoc quod est equalis nobilitas: sicut 
             <lb ed="#V" n="34"/>alie persone non producit aliquam personam: quia cum 
             proba<lb ed="#V" n="35" break="no"/>tum sit in corpore quaestionis quod in diuinis non potest esse 
             ni<lb ed="#V" n="36" break="no"/>si vnus actus spirandi nec nisi vnus actus generandi: 
@@ -445,7 +445,7 @@
           </p>
           <p xml:id="kzz7yh-a07504-d1e839">
             ¶ Item dicere presupponit hypostasim 
-            pa<lb ed="#V" n="87" break="no"/>tris perfecte sapientem: secundum Augutentum 7o de trinit. cap. primo 
+            pa<lb ed="#V" n="87" break="no"/>tris perfecte sapientem: secundum Augustinum 7o de trinit. cap. primo 
             <lb ed="#V" n="88"/>In deo hoc est esse quod sapere: ergo dicere presupponit 
             <lb ed="#V" n="89"/>hypostasim patris perfecte existentem. sed de ratione 
             <lb ed="#V" n="90"/>perfecte existentie persone est perfecta existentia 
@@ -550,7 +550,7 @@
           </p>
           <p xml:id="kzz7yh-a07504-d1e1034">
             ¶ 5per verborum 
-            ordinen<lb ed="#V" n="26" break="no"/>in psalmum. Bstendicat nos deus deus noster: bedicat nos 
+            ordinen<lb ed="#V" n="26" break="no"/>in psalmum. Benedicat nos deus deus noster: benedicat nos 
             de<lb ed="#V" n="27" break="no"/>us.
           </p>
           <p xml:id="kzz7yh-a07504-d1e1041">
@@ -563,7 +563,7 @@
           </p>
           <p xml:id="kzz7yh-a07504-d1e1051">
             ¶ 8o per constitutionis 
-            ha<lb ed="#V" n="30" break="no"/>bitudininem differentem Ro. xi. Ex ipo et per ipsum et in ipso etc.
+            ha<lb ed="#V" n="30" break="no"/>bitudininem differentem Ro. xi. Ex ipso et per ipsum et in ipso etc.
           </p>
         </div>
       </div>


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve07v1_kzz7yh-a07504.xml`.

## Applied changes

- p. 11r l. 103: plurles → plures: doubled l
- p. 11r l. 134: comunicantem → communicantem: missing m
- p. 11v l. 15: opoertet → oportet: doubled o
- p. 11v l. 26: mualte → multae: transposed u/l
- p. 11v l. 50: 'absolu' + 'tum' split across line break without break="no" on lb n=50
- p. 11v l. 94: spritus → spiritus: missing i
- p. 11v l. 107: secuet → scilicet: garbled
- p. 11v l. 110: secuet → scilicet: garbled
- p. 11v l. 133: secunum → secundum: missing d
- p. 12r l. 26: disperatas → disparatas: OCR misread
- p. 12r l. 31: spitus → spiritus: missing iri
- p. 12r l. 33: opetet → oportet: missing or
- p. 12r l. 87: Augutentum → Augustinum: garbled
- p. 12v l. 26: Bstendicat → Benedicat; bedicat → benedicat (Psalm 67)
- p. 12v l. 30: ipo → ipso: missing s

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_