### PR TITLE
Transcription corrections: cod-ve07v1_kzz7yh-a100079.xml (33 changes)

### DIFF
--- a/kzz7yh-a100079/cod-ve07v1_kzz7yh-a100079.xml
+++ b/kzz7yh-a100079/cod-ve07v1_kzz7yh-a100079.xml
@@ -97,7 +97,7 @@
             me<lb ed="#V" n="29" break="no"/>diantibus causais secundis impedibilibus: ergo contra beneplacitum illius potest aliquid 
           </p>
           <p xml:id="kzz7yh-a100079-d1e169">
-            <lb ed="#V" n="30"/>Contra. Augu. 2. de ciui. dei. ca. 2. 2millam 
+            <lb ed="#V" n="30"/>Contra. Augu. 2. de ciui. dei. ca. 2. 2m illam 
             vo<lb ed="#V" n="31" break="no"/>luntatem suam que cum eius prescientia 
             sempi<lb ed="#V" n="32" break="no"/>terna est: profecto in celo et in terra omina quecunque voluit 
             <lb ed="#V" n="33"/>non solum preterita vel praesentia: sed etiam futura iam fecit 

--- a/kzz7yh-a100079/cod-ve07v1_kzz7yh-a100079.xml
+++ b/kzz7yh-a100079/cod-ve07v1_kzz7yh-a100079.xml
@@ -80,20 +80,20 @@
             <lb ed="#V" n="18"/>¶ Questio I. 
             <lb ed="#V" n="19"/>PRimo ostendo quod aliquid potest feri contra 
             vo<lb ed="#V" n="20" break="no"/>luntatem diuini beneplaciti. Augu. 
-            <lb ed="#V" n="21"/>xii. de ciui. dei. c. 3. Natura non est conria deo: sed 
+            <lb ed="#V" n="21"/>xii. de ciui. dei. c. 3. Natura non est contraria deo: sed 
             vi<lb ed="#V" n="22" break="no"/>tium. Sed nihil est contrarium deo nisi quod est 
-            contra<lb ed="#V" n="23" break="no"/>beneplacitum voluntatis sue: ergo vitiafiunt cona voluntatem 
+            contra<lb ed="#V" n="23" break="no"/>beneplacitum voluntatis sue: ergo vitia fiunt contra voluntatem 
             di<lb ed="#V" n="24" break="no"/>ni beneplaciti.
           </p>
           <p xml:id="kzz7yh-a100079-d1e153">
-            ¶ Item omnis causa cuius effectus contingentereue 
+            ¶ Item omnis causa cuius effectus contingenter eue 
             <lb ed="#V" n="25"/>nit: potest in suo effectu impediri: sed beneplacitum dei est causa 
             mul<lb ed="#V" n="26" break="no"/>torum quae contigenter eueniunt. ergo potest in suo effctum impediri.
           </p>
           <p xml:id="kzz7yh-a100079-d1e160">
             ¶ Item 
-            ali<lb ed="#V" n="27" break="no"/>quid potest fieri contra beneplacitum illius voluntatis quae effctum producit 
-            me<lb ed="#V" n="28" break="no"/>diante impedibituri causa: sed dia voluntas multos effecuns producit 
+            ali<lb ed="#V" n="27" break="no"/>quid potest fieri contra beneplacitum illius voluntatis quae effectum producit 
+            me<lb ed="#V" n="28" break="no"/>diante impedibili causa: sed diuina voluntas multos effectus producit 
             me<lb ed="#V" n="29" break="no"/>diantibus causais secundis impedibilibus: ergo contra beneplacitum illius potest aliquid 
           </p>
           <p xml:id="kzz7yh-a100079-d1e169">
@@ -103,7 +103,7 @@
             <lb ed="#V" n="33"/>non solum preterita vel praesentia: sed etiam futura iam fecit 
           </p>
           <p xml:id="kzz7yh-a100079-d1e181">
-            <lb ed="#V" n="34"/>¶ Item secundum sententiam phlosophi 8. physi. Omnes corporales motus 
+            <lb ed="#V" n="34"/>¶ Item secundum sententiam philosophi 8. physi. Omnes corporales motus 
             <lb ed="#V" n="35"/>reguntur per motum et influentiam corporis primi nisi aliter 
             ordine<lb ed="#V" n="36" break="no"/>tur per liberum arbitrium humanum vel angelicum: vel divinum: ergo 
             mul<lb ed="#V" n="37" break="no"/>tofortius omnes voluntates includantur secundum beneplacitum 
@@ -112,14 +112,14 @@
           </p>
           <p xml:id="kzz7yh-a100079-d1e197">
             <lb ed="#V" n="40"/>Respondeo quod nihil potest fieri contra 
-            volun<lb ed="#V" n="41" break="no"/>tatem dini beneplaciti. Non enim 
+            volun<lb ed="#V" n="41" break="no"/>tatem divini beneplaciti. Non enim 
             <lb ed="#V" n="42"/>fieri potest vt deus voluntate beneplaciti aliquid velit: et non 
             <lb ed="#V" n="43"/>eueniat quia sua voluntas omnipotens est. Unde Aug. in libro ench. 
             <lb ed="#V" n="44"/>59. c. loquens de reprobis dicit. Quantum ad ipsos attinet 
-            <lb ed="#V" n="45"/>quod deus nluit fecerunt. quantum vero ad omnipotentiam dei 
-            <lb ed="#V" n="46"/>nullo modo id efficem valuerut. De hac est volutate dicitur in libro 
+            <lb ed="#V" n="45"/>quod deus noluit fecerunt. quantum vero ad omnipotentiam dei 
+            <lb ed="#V" n="46"/>nullo modo id efficere valuerut. De hac est volutate dicitur in libro 
             <lb ed="#V" n="47"/>ench. 61. c. Quod omnipotentis voluntas semper est inuicta. 
-            <lb ed="#V" n="48"/>Ad pimnitum in oppositum cum dicitur quod vicium est contrum deo etc. dico 
+            <lb ed="#V" n="48"/>Ad primum in oppositum cum dicitur quod vicium est contrarium deo etc. dico 
             <lb ed="#V" n="49"/>quod hoc intelligendum est non quia sit contrarium voluntati 
             benepla<lb ed="#V" n="50" break="no"/>citi: quae simpliciter et absolute omnibus compensatis vult aliquid fieri vel 
             <lb ed="#V" n="51"/>non fieri: sed quia est contrarium voluntati: hoc est imperio dei: vnde in printia illius 
@@ -128,11 +128,11 @@
           </p>
           <p xml:id="kzz7yh-a100079-d1e230">
             ¶ Ad 2m 
-            <lb ed="#V" n="54"/>cum dicitur quod omnis causa cuius effectus contigenter euenit potest in 
+            <lb ed="#V" n="54"/>cum dicitur quod omnis causa cuius effectus contingenter euenit potest in 
             <lb ed="#V" n="55"/>suo effectu impediri etc. dicunt aliqui quod verum est si 
             contin<lb ed="#V" n="56" break="no"/>genter eueniat per comparationem ad illam cam. sed omnes effectus 
             <lb ed="#V" n="57"/>a deo voliti de necessitate eueniunt per comparationem ad 
-            volun<lb ed="#V" n="58" break="no"/>tatem dini beneplaciti: quamuis aliqui illorum contingenter eueniant 
+            volun<lb ed="#V" n="58" break="no"/>tatem divini beneplaciti: quamuis aliqui illorum contingenter eueniant 
             <lb ed="#V" n="59"/>propter comparationem ad causas secundas. Sed hoc superius improbatum est 
             <lb ed="#V" n="60"/>45. Dii in illa quaestione vtrum voluntas dei sit bonorum creatorum causa 
             <lb ed="#V" n="61"/>necessaria nisi illud intelligatur de necessitate consene.
@@ -145,7 +145,7 @@
             <lb ed="#V" n="65"/>compensatis vult fieri eueniat: et quod vult non fieri non 
             eue<lb ed="#V" n="66" break="no"/>niat: et quod eueniat vel non eueniat eo modo quo vult illud 
             <lb ed="#V" n="67"/>esse venturum: vel non venturum. Et ita ea que vult 
-            contingen<lb ed="#V" n="68" break="no"/>ter euentre de necessitate sequitur quod eueniant et quod contingen¬ 
+            contingen<lb ed="#V" n="68" break="no"/>ter euenire de necessitate sequitur quod eueniant et quod contingen¬ 
             <!--00306.xml-->
             <cb ed="#P" n="b"/>
             <lb ed="#V" n="69"/>ter eueniant.
@@ -154,7 +154,7 @@
             ¶ Ad 3m cum quod aliquid potest fieri contra 
             bene<lb ed="#V" n="70" break="no"/>placitum illius voluntatis quae effectu producit mediante 
             im<lb ed="#V" n="71" break="no"/>pedibili causa etc. dico quod non est verum de illa voluntate 
-            cu<lb ed="#V" n="72" break="no"/>ius potestati plenarie subitentiacet totus ordo causarum creatarum: et 
+            cu<lb ed="#V" n="72" break="no"/>ius potestati plenarie subiacet totus ordo causarum creatarum: et 
             <lb ed="#V" n="73"/>hec est divina voluntas: quia sicut illi effectus causarum secundarium 
             <lb ed="#V" n="74"/>non possunt impediri contra beneplacitum illius voluntatis: ita nec 
             <lb ed="#V" n="75"/>ille secunde causae que quantum est ex parte sua impedibiles sunt. 
@@ -169,7 +169,7 @@
             feri<lb ed="#V" n="79" break="no"/>contra voluntatem signi: et videtur quod 
             <lb ed="#V" n="80"/>non quia signum debet conformari signato: ergo si aliquid 
             <lb ed="#V" n="81"/>posset fieri contra voluntatem signi aliquid posset fieri 
-            con<lb ed="#V" n="82" break="no"/>tra volutatem beneplaciti: quod falsum est.
+            con<lb ed="#V" n="82" break="no"/>tra voluntatem beneplaciti: quod falsum est.
           </p>
           <p xml:id="kzz7yh-a100079-d1e313">
             ¶ Item inter 
@@ -184,7 +184,7 @@
             vo<lb ed="#V" n="89" break="no"/>luntatem beneplaciti: nec contra voluntatem signi. 
           </p>
           <p xml:id="kzz7yh-a100079-d1e333">
-            <lb ed="#V" n="90"/>Contra. Num x. Cur inquit transgredimi verbum dicunt 
+            <lb ed="#V" n="90"/>Contra. Num x. Cur inquit transgrediamini verbum dicunt 
             <lb ed="#V" n="91"/>quod vobis non cedet in prosperum: sed verbum ibi 
             <lb ed="#V" n="92"/>accipitur pro precepto: ergo potest fieri contra signum: quod est praeceptum. 
           </p>
@@ -193,8 +193,8 @@
             <lb ed="#V" n="94"/>scientes contra preceptum fecerant. 
           </p>
           <p xml:id="kzz7yh-a100079-d1e350">
-            <lb ed="#V" n="95"/>Respondeo quod contr signa que sunt respectu suturi 
-            <lb ed="#V" n="96"/>que sunt praeceptio: prohibitio: confilium 
+            <lb ed="#V" n="95"/>Respondeo quod contra signa que sunt respectu suturi 
+            <lb ed="#V" n="96"/>que sunt praeceptio: prohibitio: consilium 
             <lb ed="#V" n="97"/>potest aliquod fieri.
           </p>
           <p xml:id="kzz7yh-a100079-d1e359">
@@ -205,7 +205,7 @@
           <p xml:id="kzz7yh-a100079-d1e366">
             <lb ed="#V" n="100"/>Ad primum in oppositum cum dicitur quod signum debet conforari (cesse est. 
             <lb ed="#V" n="101"/>signato dico quod voluntati signi: quo ad illud quod 
-            <lb ed="#V" n="102"/>signt de voluntate beneplaciti nihil potest contrariari non propter ipsum 
+            <lb ed="#V" n="102"/>signat de voluntate beneplaciti nihil potest contrariari non propter ipsum 
             si<lb ed="#V" n="103" break="no"/>gnum: sed propter ipsum beneplacitum: tamen bene fit aliquid contra voluntatem 
             <lb ed="#V" n="104"/>signi: quo ad illud quod signare videtur secundum estimationem illius cui 
             si<lb ed="#V" n="105" break="no"/>gnum proponitur.
@@ -215,12 +215,12 @@
             <lb ed="#V" n="106"/>aliquid non est signum secundum intellectum dei praecipientis: quia deus 
             <lb ed="#V" n="107"/>velit illud ab omnibus impleri loquendo de voluntate 
             benepla<lb ed="#V" n="108" break="no"/>citi qua deus vult simpliciter et absolute quod aliquid fiat omnibus 
-            pen<lb ed="#V" n="109" break="no"/>satis: que dicitur voluntas conseqens: sed signum est quod deus velit 
+            pen<lb ed="#V" n="109" break="no"/>satis: que dicitur voluntas consequens: sed signum est quod deus velit 
             ransgres<lb ed="#V" n="110" break="no"/>sores illius praecepti puniri: ita patet quod faciendo contra praeceptu non 
-            <lb ed="#V" n="111"/>facit homo contra illud quod sigmbatur per peceptum: quia sic faciens 
+            <lb ed="#V" n="111"/>facit homo contra illud quod signabatur per praeceptum: quia sic faciens 
             puni<lb ed="#V" n="112" break="no"/>tionem non euadit: quia secundum Ansel. i. lib. cur. deus homo. c. 12. Deum 
             <lb ed="#V" n="113"/>non decet aliquid inordinatum in suo regno dimittere: et postea 
-            <lb ed="#V" n="114"/>concludit. Non ergo decet deum pecccatum impunitum dimittem.
+            <lb ed="#V" n="114"/>concludit. Non ergo decet deum peccatum impunitum dimittem.
           </p>
           <p xml:id="kzz7yh-a100079-d1e404">
             ¶ Ad 
@@ -256,18 +256,18 @@
             vo<lb ed="#V" n="130" break="no"/>luntatem signi cum hoc facensit malum: non obsequitur voluntati benepla¬ 
           </p>
           <p xml:id="kzz7yh-a100079-d1e457">
-            <lb ed="#V" n="131"/>Contra. Aug. in libro de praedestinatione sconrum inter me 
-            cciti<lb ed="#V" n="132" break="no"/>dium et finem: est in malorumpotetate peccare: vt autem 
+            <lb ed="#V" n="131"/>Contra. Aug. in libro de praedestinatione sanctorum inter me 
+            cciti<lb ed="#V" n="132" break="no"/>dium et finem: est in malorum potestate peccare: vt autem 
             <lb ed="#V" n="133"/>peccado hoc vel hoc illa malitia faciat non est in eorum potestate 
             <lb ed="#V" n="134"/>sed dei didentis tenebras et ordinantis eas: vt hinc est quod 
             <lb ed="#V" n="135"/>faciunt contra voluntatem dei non impleatur nisi voluntas dei: et ita illud quod 
-            <lb ed="#V" n="136"/>peconres faciunt contra voluntatem signi obsequitur voluntati beneplaciti.
+            <lb ed="#V" n="136"/>peccatores faciunt contra voluntatem signi obsequitur voluntati beneplaciti.
           </p>
           <p xml:id="kzz7yh-a100079-d1e474">
             <!--00307.xml-->
             <pb ed="#V" n="146-r"/>
             <cb ed="#P" n="a"/>
-            <lb ed="#V" n="1"/>¶ Item Grego. sexto liber.o moralis longe ante medium sut 
+            <lb ed="#V" n="1"/>¶ Item Grego. sexto libro moralis longe ante medium sut 
             <lb ed="#V" n="2"/>illud Iob. 5. Comprehendit sapientes in astutia eorum sic 
             di<lb ed="#V" n="3" break="no"/>cit omnipotentis dei consilio: dum resistere nituntur: 
             obsequun<lb ed="#V" n="4" break="no"/>tur: quia sepe: et hoc eius dispositioni apte militat quod deo per 
@@ -288,7 +288,7 @@
             homo<lb ed="#V" n="17" break="no"/>vel malus angelus divinae voluntati et ordinationi 
             subiacer<lb ed="#V" n="18" break="no"/>nolit: non tamen eum fugere valet: quia si vult fugere de sub 
             vo<lb ed="#V" n="19" break="no"/>luntate iubente currit sub voluntatem punientem: et si 
-            que<lb ed="#V" n="20" break="no"/>ris qua transit non nisi sub voluntate permittente: et hoec ipsum quod 
+            que<lb ed="#V" n="20" break="no"/>ris qua transit non nisi sub voluntate permittente: et hoc ipsum quod 
             <lb ed="#V" n="21"/>peruerse vult autem agit in vniuersitatis prefate ordinem et 
             pul<lb ed="#V" n="22" break="no"/>chritudinem summa sapientia conuertit. Per hoc patere potest 
             <lb ed="#V" n="23"/>responsio ad argumenta ad vtranque partem.
@@ -350,8 +350,8 @@
             <lb ed="#V" n="54"/>non potest malum precipi. 
           </p>
           <p xml:id="kzz7yh-a100079-d1e628">
-            <lb ed="#V" n="55"/>Respondeo quod deum posse pecipere malum 
-            du<lb ed="#V" n="56" break="no"/>pliciter potest intelligi. vnomodo 
+            <lb ed="#V" n="55"/>Respondeo quod deum posse praecipere malum 
+            du<lb ed="#V" n="56" break="no"/>pliciter potest intelligi. vno modo 
             <lb ed="#V" n="57"/>ita quod possit praecipere malum non obstante praecepto manens 
             <lb ed="#V" n="58"/>malum: et hoc simpliciter est impossibile: quia tunc idem posset 
             praecipe<lb ed="#V" n="59" break="no"/>re: et prohibere simul: et ita posset contingere quod homo aliquid 
@@ -375,7 +375,7 @@
             pos<lb ed="#V" n="72" break="no"/>set coaptando ad praecepta decalogi in speciali non oportet 
             <lb ed="#V" n="73"/>quia magis habet locum in tertio vbi queretur deo dante 
             <lb ed="#V" n="74"/>si in preceptis decalogi potest aliquis dispensari. 
-            <lb ed="#V" n="75"/>Ad princitm in oppositum dicendum quod praecipere innocente interfici: non est 
+            <lb ed="#V" n="75"/>Ad primum in oppositum dicendum quod praecipere innocente interfici: non est 
             <lb ed="#V" n="76"/>precipere malum: quod per preceptum non posset 
             fie<lb ed="#V" n="77" break="no"/>ri bonum: sicut enim deus posset iuste flagellare innocentem 
             <lb ed="#V" n="78"/>vt per illam flagellationem augeretur praemium innocentis 
@@ -394,7 +394,7 @@
           </p>
           <p xml:id="kzz7yh-a100079-d1e712">
             ¶ Ad 
-            <lb ed="#V" n="88"/>secundum dicendum quod non fuit intentio domini quod POsee 
+            <lb ed="#V" n="88"/>secundum dicendum quod non fuit intentio domini quod Osee 
             <lb ed="#V" n="89"/>fornicaretur: sed quod acciperet in vxorem mulierem prius 
             for<lb ed="#V" n="90" break="no"/>nicariam: ita quod filii ex ea nati dicerentur filii fornicationum non 
             <lb ed="#V" n="91"/>quia nati ex fornicatione: sed quia nati de fornicaria. 
@@ -408,13 +408,13 @@
             alie<lb ed="#V" n="97" break="no"/>nam. Si autem aliqui de filiis Israel in petendo illa vasa 
             <lb ed="#V" n="98"/>et illas vestes habuerunt fraudulentam intentionem: et 
             ma<lb ed="#V" n="99" break="no"/>lignam: hoc non precepit eis dominus: et forte ratio 
-            congrui<lb ed="#V" n="100" break="no"/>tatis quater deus illas diuitias ab egyptiis voluit transfer 
-            <lb ed="#V" n="101"/>re in filios Israel: fuit quia filii Israel pluribus annis 
+            congrui<lb ed="#V" n="100" break="no"/>tatis quater deus illas diuitias ab egyptiis voluit 
+            transfer<lb ed="#V" n="101" break="no"/>re in filios Israel: fuit quia filii Israel pluribus annis 
             gra<lb ed="#V" n="102" break="no"/>ui seruitute seruierant egyptiis: nec ab eis debitam receperant 
             <lb ed="#V" n="103"/>mercedem.
           </p>
           <p xml:id="kzz7yh-a100079-d1e753">
-            ¶ Ad 4m dicendum quod illud verbum imparatiui modi quod 
+            ¶ Ad 4m dicendum quod illud verbum imperativi modi quod 
             <lb ed="#V" n="104"/>refert Micheas deum dixisse spiritui mendaci intelligi debet 
             per<lb ed="#V" n="105" break="no"/>missiue non imparatiue: vel potest dici quod sicut in scriptura verbum 
             indi<lb ed="#V" n="106" break="no"/>catiui modi aliquando accipitur imperatiue: vt exodi. 20. 

--- a/kzz7yh-a100079/cod-ve07v1_kzz7yh-a100079.xml
+++ b/kzz7yh-a100079/cod-ve07v1_kzz7yh-a100079.xml
@@ -98,7 +98,7 @@
           </p>
           <p xml:id="kzz7yh-a100079-d1e169">
             <lb ed="#V" n="30"/>Contra. Augu. 2. de ciui. dei. ca. 2. 2millam vo¬ cfieri. 
-            <lb ed="#V" n="31"/>vluntatem suam que cum eius prescientia 
+            <lb ed="#V" n="31"/>luntatem suam que cum eius prescientia 
             sempi<lb ed="#V" n="32" break="no"/>terna est: profecto in celo et in terra omina quecunque voluit 
             <lb ed="#V" n="33"/>non solum preterita vel praesentia: sed etiam futura iam fecit 
           </p>
@@ -122,7 +122,7 @@
             <lb ed="#V" n="48"/>Ad primum in oppositum cum dicitur quod vicium est contrarium deo etc. dico 
             <lb ed="#V" n="49"/>quod hoc intelligendum est non quia sit contrarium voluntati 
             benepla<lb ed="#V" n="50" break="no"/>citi: quae simpliciter et absolute omnibus compensatis vult aliquid fieri vel 
-            <lb ed="#V" n="51"/>non fieri: sed quia est contrarium voluntati: hoc est imperio dei: vnde in printia illius 
+            <lb ed="#V" n="51"/>non fieri: sed quia est contrarium voluntati: hoc est imperio dei: vnde in principio illius 
             <lb ed="#V" n="52"/>capituli dicit Aug. dicunt vt in scripturis inimici dei: qui non 
             <lb ed="#V" n="53"/>natura: sed vitiis aduersantur eius imperio.
           </p>
@@ -140,7 +140,7 @@
           <p xml:id="kzz7yh-a100079-d1e250">
             ¶ Potest 
             <lb ed="#V" n="62"/>ergo dici quod maior argumenti non habet veritatem de causa 
-            <lb ed="#V" n="63"/>que est voluntas divini beneplaciti: quia enim voluntas illa opstus est 
+            <lb ed="#V" n="63"/>que est voluntas divini beneplaciti: quia enim voluntas illa opus est 
             <lb ed="#V" n="64"/>de necessitate sequitur quod illud quod simpliciter et absolute omnibus 
             <lb ed="#V" n="65"/>compensatis vult fieri eueniat: et quod vult non fieri non 
             eue<lb ed="#V" n="66" break="no"/>niat: et quod eueniat vel non eueniat eo modo quo vult illud 
@@ -180,7 +180,7 @@
           <p xml:id="kzz7yh-a100079-d1e322">
             <lb ed="#V" n="86"/>¶ Item <ref xml:id="kzz7yh-a100079-Rd1e329">Augu. in. 2. Gen.contra manicheos in fine</ref>. Dei 
             vo<lb ed="#V" n="87" break="no"/>luntas superat omnia: nulla ex parte quicquam sentit inuitus: ergo cum ibi 
-            <lb ed="#V" n="88"/>non videatur de voluntate distinguem: videtur quod nihil fiat nec contra 
+            <lb ed="#V" n="88"/>non videatur de voluntate distinguere: videtur quod nihil fiat nec contra 
             vo<lb ed="#V" n="89" break="no"/>luntatem beneplaciti: nec contra voluntatem signi. 
           </p>
           <p xml:id="kzz7yh-a100079-d1e333">
@@ -203,7 +203,7 @@
             <lb ed="#V" n="99"/>libro periher. Esse quod est quando est: et non esse quod non est: quando non est ne¬ 
           </p>
           <p xml:id="kzz7yh-a100079-d1e366">
-            <lb ed="#V" n="100"/>Ad primum in oppositum cum dicitur quod signum debet conforari (cesse est. 
+            <lb ed="#V" n="100"/>Ad primum in oppositum cum dicitur quod signum debet conformari (cesse est. 
             <lb ed="#V" n="101"/>signato dico quod voluntati signi: quo ad illud quod 
             <lb ed="#V" n="102"/>signat de voluntate beneplaciti nihil potest contrariari non propter ipsum 
             si<lb ed="#V" n="103" break="no"/>gnum: sed propter ipsum beneplacitum: tamen bene fit aliquid contra voluntatem 
@@ -225,7 +225,7 @@
           <p xml:id="kzz7yh-a100079-d1e404">
             ¶ Ad 
             <lb ed="#V" n="115"/>2 ostensum est in corpore quaestionis. Quod enim nihil potest fieri contra 
-            permissi<lb ed="#V" n="116" break="no"/>onem est propter hoc quod permissio est tlm praesentis.
+            permissi<lb ed="#V" n="116" break="no"/>onem est propter hoc quod permissio est respectu praesentis.
           </p>
           <p xml:id="kzz7yh-a100079-d1e412">
             ¶ Ad 4m quod 
@@ -242,7 +242,7 @@
             <lb ed="#V" n="122"/>non obsequitur alii: sed magis repugnat.
           </p>
           <p xml:id="kzz7yh-a100079-d1e435">
-            ¶ Item quai facit contra 
+            ¶ Item qui facit contra 
             praecer<lb ed="#V" n="123" break="no"/>ptum alicuius iusti principis non obsequitur voluntati illius. 
             Rer<lb ed="#V" n="124" break="no"/>enim terrenus si iustus est facientem contra praeceptum suum non reputat 
             ob<lb ed="#V" n="125" break="no"/>sequi sue voluntati: sed deus est princeps iustissimus: ergo qui facit 
@@ -250,15 +250,15 @@
           </p>
           <p xml:id="kzz7yh-a100079-d1e446">
             ¶ Item Diony. x. c. 
-            <lb ed="#V" n="127"/>de di. no. Neque enim quicquam mali naturam aspiciens ea facitlqua facit. 
+            <lb ed="#V" n="127"/>de di. no. Neque enim quicquae mali naturam aspiciens ea facit quam facit. 
             <lb ed="#V" n="128"/>ergo malum est praeter intentionem voluntatis: sed quod est praeter 
             intentio<lb ed="#V" n="129" break="no"/>nem voluntatis non obsequitur voluntati: ergo illud quod fit contra 
-            vo<lb ed="#V" n="130" break="no"/>luntatem signi cum hoc facensit malum: non obsequitur voluntati benepla¬ 
+            vo<lb ed="#V" n="130" break="no"/>luntatem signi cum hoc faciens malum: non obsequitur voluntati benepla¬ 
           </p>
           <p xml:id="kzz7yh-a100079-d1e457">
             <lb ed="#V" n="131"/>Contra. Aug. in libro de praedestinatione sanctorum inter me 
             cciti<lb ed="#V" n="132" break="no"/>dium et finem: est in malorum potestate peccare: vt autem 
-            <lb ed="#V" n="133"/>peccado hoc vel hoc illa malitia faciat non est in eorum potestate 
+            <lb ed="#V" n="133"/>peccando hoc vel hoc illa malitia faciat non est in eorum potestate 
             <lb ed="#V" n="134"/>sed dei didentis tenebras et ordinantis eas: vt hinc est quod 
             <lb ed="#V" n="135"/>faciunt contra voluntatem dei non impleatur nisi voluntas dei: et ita illud quod 
             <lb ed="#V" n="136"/>peccatores faciunt contra voluntatem signi obsequitur voluntati beneplaciti.

--- a/kzz7yh-a100079/cod-ve07v1_kzz7yh-a100079.xml
+++ b/kzz7yh-a100079/cod-ve07v1_kzz7yh-a100079.xml
@@ -97,7 +97,7 @@
             me<lb ed="#V" n="29" break="no"/>diantibus causais secundis impedibilibus: ergo contra beneplacitum illius potest aliquid 
           </p>
           <p xml:id="kzz7yh-a100079-d1e169">
-            <lb ed="#V" n="30"/>Contra. Augu. 2. de ciui. dei. ca. 2. 2millam vo 
+            <lb ed="#V" n="30"/>Contra. Augu. 2. de ciui. dei. ca. 2. 2millam 
             vo<lb ed="#V" n="31" break="no"/>luntatem suam que cum eius prescientia 
             sempi<lb ed="#V" n="32" break="no"/>terna est: profecto in celo et in terra omina quecunque voluit 
             <lb ed="#V" n="33"/>non solum preterita vel praesentia: sed etiam futura iam fecit 

--- a/kzz7yh-a100079/cod-ve07v1_kzz7yh-a100079.xml
+++ b/kzz7yh-a100079/cod-ve07v1_kzz7yh-a100079.xml
@@ -97,8 +97,8 @@
             me<lb ed="#V" n="29" break="no"/>diantibus causais secundis impedibilibus: ergo contra beneplacitum illius potest aliquid 
           </p>
           <p xml:id="kzz7yh-a100079-d1e169">
-            <lb ed="#V" n="30"/>Contra. Augu. 2. de ciui. dei. ca. 2. 2millam vo¬ cfieri. 
-            <lb ed="#V" n="31"/>luntatem suam que cum eius prescientia 
+            <lb ed="#V" n="30"/>Contra. Augu. 2. de ciui. dei. ca. 2. 2millam vo 
+            vo<lb ed="#V" n="31" break="no"/>luntatem suam que cum eius prescientia 
             sempi<lb ed="#V" n="32" break="no"/>terna est: profecto in celo et in terra omina quecunque voluit 
             <lb ed="#V" n="33"/>non solum preterita vel praesentia: sed etiam futura iam fecit 
           </p>


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve07v1_kzz7yh-a100079.xml`.

## Applied changes

- p. 145v l. 21: conria → contraria: garbled
- p. 145v l. 23: vitiafiunt cona → vitia fiunt contra: merged words + missing tr
- p. 145v l. 24: contingentereue → contingenter eue|nit: break=no split
- p. 145v l. 27: effctum → effectum: missing e
- p. 145v l. 28: impedibituri → impedibili; effecuns → effectus; dia → diuina
- p. 145v l. 34: phlosophi → philosophi: missing o
- p. 145v l. 41: dini → divini: abbreviated
- p. 145v l. 45: nluit → noluit: missing o
- p. 145v l. 46: efficem → efficere: garbled; volutate → voluntate: missing n
- p. 145v l. 48: pimnitum → primum: garbled; contrum → contrarium: garbled
- p. 145v l. 54: contigenter → contingenter: missing n
- p. 145v l. 58: dini → divini: abbreviated
- p. 145v l. 68: euentre → euenire: r/i misread
- p. 145v l. 72: subitentiacet → subiacet: garbled
- p. 145v l. 82: volutatem → voluntatem: missing n
- p. 145v l. 90: transgredimi → transgrediamini: missing ani
- p. 145v l. 95: contr → contra: abbreviated
- p. 145v l. 96: confilium → consilium: f/s misread
- p. 145v l. 102: signt → signat: missing a
- p. 145v l. 109: conseqens → consequens: missing u
- p. 145v l. 111: sigmbatur → signabatur: garbled; peceptum → praeceptum: missing rae
- p. 145v l. 114: pecccatum → peccatum: tripled c
- p. 145v l. 131: sconrum → sanctorum: garbled (De praedestinatione sanctorum)
- p. 145v l. 132: malorumpotetate → malorum potestate: merged + missing s
- p. 145v l. 136: peconres → peccatores: garbled
- p. 146r l. 1: liber.o → libro: garbled punctuation
- p. 146r l. 20: hoec → hoc: spurious e
- p. 146r l. 55: pecipere → praecipere: missing rae
- p. 146r l. 56: vnomodo → vno modo: missing space
- p. 146r l. 75: princitm → primum: garbled
- p. 146r l. 88: POsee → Osee: spurious P (ornamental capital)
- p. 146r l. 101: 'transfer' + 're' split across line break without break="no" on lb n=101
- p. 146r l. 103: imparatiui → imperativi: garbled

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_