### PR TITLE
Transcription corrections: cod-ve07v1_kzz7yh-a100758.xml (1 change)

### DIFF
--- a/kzz7yh-a100758/cod-ve07v1_kzz7yh-a100758.xml
+++ b/kzz7yh-a100758/cod-ve07v1_kzz7yh-a100758.xml
@@ -63,7 +63,7 @@
           Res<lb ed="#V" n="115" break="no"/>pondeo non accipitur hic praedestinatio proprie: sed 
           pro<lb ed="#V" n="116" break="no"/>preperatione cuiuslibet premii siue boni: siue mali. (
           Ope<lb ed="#V" n="117" break="no"/>ra hominum dicit ea que mala sunt que preter 
-          volunta<lb ed="#V" n="118" break="no"/>tem dei siunt: que ipse est: sed non preter eius permissionem 
+          volunta<lb ed="#V" n="118" break="no"/>tem dei fiunt: que ipse est: sed non preter eius permissionem 
           <lb ed="#V" n="119"/>que ipse non est. Contra. actio dei deus est. 
           Respon<lb ed="#V" n="120" break="no"/>deo permissio non dicit actionem per modum positionis 
           <lb ed="#V" n="121"/>se habentem: sed per modum negationis. Permittere enim 

--- a/kzz7yh-a100758/cod-ve07v1_kzz7yh-a100758.xml
+++ b/kzz7yh-a100758/cod-ve07v1_kzz7yh-a100758.xml
@@ -77,8 +77,8 @@
           <lb ed="#V" n="129"/>quod preceptum est signum quod deus vult penam illius qui 
           trans<lb ed="#V" n="130" break="no"/>greditur preceptum. (Quedam personaliter precepit et in 
           ve<lb ed="#V" n="131" break="no"/>teri et in noua lege: que ab eis quibus precepit noluit fieri: 
-          <lb ed="#V" n="132"/>vt Abrahe de immolatione filii. Et in Cuang. quibusdam cura 
-          <lb ed="#V" n="133"/>tis: quibus precepit ne cui dicerent.) Contra Abraham 
+          <lb ed="#V" n="132"/>vt Abrahe de immolatione filii. Et in Cuang. quibusdam 
+          cura<lb ed="#V" n="133" break="no"/>tis: quibus precepit ne cui dicerent.) Contra Abraham 
           vo<lb ed="#V" n="134" break="no"/>lendo filium occidere conformauit voluntatem sum 
           volun<lb ed="#V" n="135" break="no"/>tati diuine. Respondeo. deus noluit quod puer Isaac 
           occi<lb ed="#V" n="136" break="no"/>deretur: sed voluit quod Abraham hoc vellet.


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve07v1_kzz7yh-a100758.xml`.

## Applied changes

- p. 146r l. 133: 'cura' + 'tis' split across line break without break="no" on lb n=133

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_