### PR TITLE
Transcription corrections: cod-ve07v1_kzz7yh-a101750.xml (14 changes)

### DIFF
--- a/kzz7yh-a101750/cod-ve07v1_kzz7yh-a101750.xml
+++ b/kzz7yh-a101750/cod-ve07v1_kzz7yh-a101750.xml
@@ -79,7 +79,7 @@
             vo<lb ed="#V" n="121" break="no"/>lito.
           </p>
           <p xml:id="kzz7yh-a101750-d1e144">
-            ¶ Item deus in transgredientibus sua prccepta non 
+            ¶ Item deus in transgredientibus sua praecepta non 
             <lb ed="#V" n="122"/>vult gratiam suam conseruari: sed nullus tenetur gratiam 
             <lb ed="#V" n="123"/>suam velle non conseruari in seipso: ergo non tenetur quilibet se 
             <lb ed="#V" n="124"/>conformare deo in volito.
@@ -125,12 +125,12 @@
           <p xml:id="kzz7yh-a101750-d1e219">
             ¶ Item Matth. 12 qui non est mecum contra me est 
             <lb ed="#V" n="9"/>ergo qui non conformat se deo in volito est contra deum: sed 
-            quili<lb ed="#V" n="10" break="no"/>bet tenetur non esse contra deum: ergo quilibet tenetur se conforma 
-            <lb ed="#V" n="11"/>re deo in volito. 
+            quili<lb ed="#V" n="10" break="no"/>bet tenetur non esse contra deum: ergo quilibet tenetur se 
+            conforma<lb ed="#V" n="11" break="no"/>re deo in volito. 
           </p>
           <p xml:id="kzz7yh-a101750-d1e228">
             <lb ed="#V" n="12"/>Respondeo quod non tenentur homo velle nisi quod 
-            pre<lb ed="#V" n="13" break="no"/>cepit ipsum deus velle implictte: vel 
+            pre<lb ed="#V" n="13" break="no"/>cepit ipsum deus velle implicite: vel 
             <lb ed="#V" n="14"/>explicite: nec tenetur non velle nisi quod deus prohibet ipsum 
             <lb ed="#V" n="15"/>velle implicite vel explicite. Nec enim sufficiunt ad salutem 
             <lb ed="#V" n="16"/>cum dominus dicat Matth. 19. Si vis ad vitam ingredi 
@@ -190,7 +190,7 @@
           <p xml:id="kzz7yh-a101750-d1e335">
             <lb ed="#V" n="51"/>Ad primum cum dicitur quod nullus tenetur velle 
             dam<lb ed="#V" n="52" break="no"/>nari etc. dico quod verum est: quia non 
-            con<lb ed="#V" n="53" break="no"/>gruit homni hoc velle. Alii tamen dicunt quod quamuis nullus 
+            con<lb ed="#V" n="53" break="no"/>gruit homini hoc velle. Alii tamen dicunt quod quamuis nullus 
             tene<lb ed="#V" n="54" break="no"/>atur velle damnari habendo aspectum ad naturam suam et absolute: 
             <lb ed="#V" n="55"/>tamen aliquis tenetur velle damnari sub hac conditione si decedit 
             <lb ed="#V" n="56"/>in peccato mortali.
@@ -208,7 +208,7 @@
           </p>
           <p xml:id="kzz7yh-a101750-d1e367">
             ¶ Ad 4m cum dicitur quod non teneor velle quod vult 
-            pre<lb ed="#V" n="62" break="no"/>latus meus etc. Dicunt aliqui quod si scirem quod pramelatus meus vel 
+            pre<lb ed="#V" n="62" break="no"/>latus meus etc. Dicunt aliqui quod si scirem quod praelatus meus vel 
             <lb ed="#V" n="63"/>let quod ego aliquid facerem quod teneret intentione necessitatis 
             il<lb ed="#V" n="64" break="no"/>lud facere quod durum videtur: nisi scirem quod in voluntate sua 
             <lb ed="#V" n="65"/>intenderet hoc mihi precipe per obedientiam mentaliter: et quod 
@@ -238,7 +238,7 @@
             <lb ed="#V" n="79"/>in forma volendi: et videtur quod non: quia quicquid deus vult 
             <lb ed="#V" n="80"/>ex charitate vult. Sed si homo in articulo 
             neces<lb ed="#V" n="81" break="no"/>sitatis vult honorare parentes non tamen ex charitate: sed ex 
-            <lb ed="#V" n="82"/>naturali pietate non peccat: ergo non tenetur ad conforrmitatem in 
+            <lb ed="#V" n="82"/>naturali pietate non peccat: ergo non tenetur ad conformitatem in 
             <lb ed="#V" n="83"/>forma volendi.
           </p>
           <p xml:id="kzz7yh-a101750-d1e433">
@@ -253,7 +253,7 @@
             <lb ed="#V" n="88"/>in potestate nostra. 
           </p>
           <p xml:id="kzz7yh-a101750-d1e449">
-            <lb ed="#V" n="89"/>Contra. Deuter. 19. Iuste quod iustum est prosequaeris: 
+            <lb ed="#V" n="89"/>Contra. Deuter. 19. Iuste quod iustum est prosequaris: 
             er<lb ed="#V" n="90" break="no"/>go non sufficit nobis velle quod iustum est: nisi 
             <lb ed="#V" n="91"/>velimus illud iuste: non sufficit ergo nos deo conformare 
             in<lb ed="#V" n="92" break="no"/>volito nisi conformemus nos sibi etiam in forma volendi. 
@@ -266,13 +266,13 @@
             <lb ed="#V" n="97"/>quod preceptum est. 
           </p>
           <p xml:id="kzz7yh-a101750-d1e474">
-            <lb ed="#V" n="98"/>Respondeo cum: vt superius hitum est: teneamur 
+            <lb ed="#V" n="98"/>Respondeo cum: vt superius habitum est: teneamur 
             <lb ed="#V" n="99"/>conformare voluntatem nostram 
             volun<lb ed="#V" n="100" break="no"/>tati divinae in rectitudine: et voluntas nostra non sit recta nisi 
             <lb ed="#V" n="101"/>deo sit conformis in forma volendi concedendum est quod 
             tenea<lb ed="#V" n="102" break="no"/>mur conformare voluntatem nostram voluntati divinae non tantum 
             <lb ed="#V" n="103"/>modo in volito: sed illud in forma volendi. tenemur enim 
-            <lb ed="#V" n="104"/>ad habendum hieitum illius forme ad hoc quod sumus digni vt 
+            <lb ed="#V" n="104"/>ad habendum habitum illius forme ad hoc quod sumus digni vt 
             <lb ed="#V" n="105"/>ta eterna: quia illa forma charitas est: sine qua nullus est 
             di<lb ed="#V" n="106" break="no"/>gnus vita eterna. Unde apostolus primo ad Corinth. 13 
             Se<lb ed="#V" n="107" break="no"/>habuero omnem fidem: ita vt montes transferam: charitati 
@@ -284,7 +284,7 @@
             <lb ed="#V" n="113"/>tenemur habere charitatem semper et ad semper: quamuis semt 
             <lb ed="#V" n="114"/>teneamur nos praeparare pro loco et tempore quantum in nobis est: ad 
             <lb ed="#V" n="115"/>hoc vt deus nobis eam infundat. Ad habendum etiam actum istius fore 
-            <lb ed="#V" n="116"/>quamuis smper teneamur: non tamen tenemur ad sper. Exire autem in actu 
+            <lb ed="#V" n="116"/>quamuis semper teneamur: non tamen tenemur ad sper. Exire autem in actu 
             <lb ed="#V" n="117"/>charitatis praeceptum affirmatiuum est. Quando autem est alia 
             op<lb ed="#V" n="118" break="no"/>portunitas exeundi in actum illum ita quod nihil tume homo eliciat 
             <lb ed="#V" n="119"/>actum ex charitate incurrit peccatum magis debet 
@@ -293,8 +293,8 @@
           <p xml:id="kzz7yh-a101750-d1e526">
             <lb ed="#V" n="121"/>Ad primum in oppositum dicendum quod non plus concludit nisi quod 
             <lb ed="#V" n="122"/>non tenemur ad conforrmitatem in forma 
-            <lb ed="#V" n="123"/>volendi seper ad semper loquendo de tali tentione quam non implendo nouum 
-            <lb ed="#V" n="124"/>pecccaum incurritur.
+            <lb ed="#V" n="123"/>volendi semper ad semper loquendo de tali tentione quam non implendo nouum 
+            <lb ed="#V" n="124"/>peccatum incurritur.
           </p>
           <p xml:id="kzz7yh-a101750-d1e537">
             ¶ Ad 2m sitis est soluendum.
@@ -304,14 +304,14 @@
             <lb ed="#V" n="125"/>dicitur quod hebere charitatem non est in nostra potestate etc. dico quod quamuis 
             <lb ed="#V" n="126"/>non sit in nostra potestate causare charitatem in nobis: tamen in nostra 
             po<lb ed="#V" n="127" break="no"/>testate principaliter mota a divina virtute: quae sper parata est nos iuuater 
-            <lb ed="#V" n="128"/>est pramperare nos ad recipiendum charitatem: qua prampaeratione 
+            <lb ed="#V" n="128"/>est praeparare nos ad recipiendum charitatem: qua praeparatione 
             ha<lb ed="#V" n="129" break="no"/>bita deus liberaliter in anima nostra charitatem infundit.
           </p>
           <p xml:id="kzz7yh-a101750-d1e552">
             ¶ Argumentum ad 
             <lb ed="#V" n="130"/>partem aliam non concludunt quod ad illam conformitatem 
             tenea<lb ed="#V" n="131" break="no"/>mur semper et ad semper tentione absoluta: sed quod ad illam 
-            tene<lb ed="#V" n="132" break="no"/>mur occurente tali opportunitate quod si tunc non 
+            tene<lb ed="#V" n="132" break="no"/>mur occurrente tali opportunitate quod si tunc non 
             conformare<lb ed="#V" n="133" break="no"/>mur deo voluntatem nostram in forma volendi divinam 
             bo<lb ed="#V" n="134" break="no"/>nitatem contineremus. 
           </p>

--- a/kzz7yh-a101750/cod-ve07v1_kzz7yh-a101750.xml
+++ b/kzz7yh-a101750/cod-ve07v1_kzz7yh-a101750.xml
@@ -109,7 +109,7 @@
             <!--00311.xml-->
             <pb ed="#V" n="148-r"/>
             <cb ed="#P" n="a"/>
-            <lb ed="#V" n="1"/>ergo qualet voluntas tenetur conformare voluntati divine in volito. 
+            <lb ed="#V" n="1"/>ergo quaelibet voluntas tenetur conformare voluntati divine in volito. 
           </p>
           <p xml:id="kzz7yh-a101750-d1e199">
             <lb ed="#V" n="2"/>¶ Item Glo. super illud psal. Non adhesit mihi cor prauum id est 
@@ -176,7 +176,7 @@
           </p>
           <p xml:id="kzz7yh-a101750-d1e313">
             ¶ Ad 4m cum dicitur quod qui non est mecum contra 
-            me<lb ed="#V" n="44" break="no"/>est etc. dico quod sic exponendum est super Glo. i. qui dissimilialin eis 
+            me<lb ed="#V" n="44" break="no"/>est etc. dico quod sic exponendum est super Glo. i. qui dissimilia eis 
             <lb ed="#V" n="45"/>opera facit mihi contrarius est. Et accipitur ibi dissimilitudo 
             pro<lb ed="#V" n="46" break="no"/>contraritate. Qui autem conformat voluntatem suam dei praecepto 
             quam<lb ed="#V" n="47" break="no"/>uis non velit facere illud quod deus consulit non facit opera 
@@ -211,7 +211,7 @@
             pre<lb ed="#V" n="62" break="no"/>latus meus etc. Dicunt aliqui quod si scirem quod praelatus meus vel 
             <lb ed="#V" n="63"/>let quod ego aliquid facerem quod teneret intentione necessitatis 
             il<lb ed="#V" n="64" break="no"/>lud facere quod durum videtur: nisi scirem quod in voluntate sua 
-            <lb ed="#V" n="65"/>intenderet hoc mihi precipe per obedientiam mentaliter: et quod 
+            <lb ed="#V" n="65"/>intenderet hoc mihi praecipere per obedientiam mentaliter: et quod 
             <lb ed="#V" n="66"/>praeceptum verbotenus aliqua de causa explicare non 
             aude<lb ed="#V" n="67" break="no"/>ret potest ergo dici quod non est idem dicere quod si praelatus meus 
             vul<lb ed="#V" n="68" break="no"/>aliquid fieri: quod ego velim illud fieri: et si vult quod ego faciam 
@@ -219,7 +219,7 @@
             <!--00311.xml-->
             <cb ed="#P" n="b"/>
             <lb ed="#V" n="70"/>meus aliquid fieri per vnum hominem qui non est in obedientia 
-            <lb ed="#V" n="71"/>sua: et tamen posse velle hoc non fieri sine pecato mortali: ita 
+            <lb ed="#V" n="71"/>sua: et tamen posse velle hoc non fieri sine <sic>pecato</sic> mortali: ita 
             <lb ed="#V" n="72"/>potest dici quod quamuis teneor velle facere illud quod scio deum vel 
             <lb ed="#V" n="73"/>le me facere: non tamen teneor omne illud velle fieri: quod scio 
             <lb ed="#V" n="74"/>deum velle fieri: quia forte hoc velle mihi non congruit.
@@ -281,7 +281,7 @@
             <lb ed="#V" n="110"/>ita vt ardeam: charitatem autem non humero nihil mihi prodest. 
             <lb ed="#V" n="111"/>non tamen semper peccamus quamdiu charitatem non hebemus: quia 
             ta<lb ed="#V" n="112" break="no"/>li tentione quam non implendo nouum peccatum incurritur non 
-            <lb ed="#V" n="113"/>tenemur habere charitatem semper et ad semper: quamuis semt 
+            <lb ed="#V" n="113"/>tenemur habere charitatem semper et ad semper: quamuis semper 
             <lb ed="#V" n="114"/>teneamur nos praeparare pro loco et tempore quantum in nobis est: ad 
             <lb ed="#V" n="115"/>hoc vt deus nobis eam infundat. Ad habendum etiam actum istius fore 
             <lb ed="#V" n="116"/>quamuis semper teneamur: non tamen tenemur ad sper. Exire autem in actu 
@@ -292,7 +292,7 @@
           </p>
           <p xml:id="kzz7yh-a101750-d1e526">
             <lb ed="#V" n="121"/>Ad primum in oppositum dicendum quod non plus concludit nisi quod 
-            <lb ed="#V" n="122"/>non tenemur ad conforrmitatem in forma 
+            <lb ed="#V" n="122"/>non tenemur ad <sic>conforrmitatem</sic> in forma 
             <lb ed="#V" n="123"/>volendi semper ad semper loquendo de tali tentione quam non implendo nouum 
             <lb ed="#V" n="124"/>peccatum incurritur.
           </p>
@@ -303,7 +303,7 @@
             ¶ Ad 3m cum 
             <lb ed="#V" n="125"/>dicitur quod hebere charitatem non est in nostra potestate etc. dico quod quamuis 
             <lb ed="#V" n="126"/>non sit in nostra potestate causare charitatem in nobis: tamen in nostra 
-            po<lb ed="#V" n="127" break="no"/>testate principaliter mota a divina virtute: quae sper parata est nos iuuater 
+            po<lb ed="#V" n="127" break="no"/>testate principaliter mota a divina virtute: quae semper parata est nos iuuare 
             <lb ed="#V" n="128"/>est praeparare nos ad recipiendum charitatem: qua praeparatione 
             ha<lb ed="#V" n="129" break="no"/>bita deus liberaliter in anima nostra charitatem infundit.
           </p>


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve07v1_kzz7yh-a101750.xml`.

## Applied changes

- p. 147v l. 121: prccepta: not in Latin word list — review needed
- p. 148r l. 11: 'conforma' + 're' split across line break without break="no" on lb n=11
- p. 148r l. 13: implictte: not in Latin word list — review needed
- p. 148r l. 53: homni: not in Latin word list — review needed
- p. 148r l. 62: pramelatus: not in Latin word list — review needed
- p. 148r l. 82: conforrmitatem: not in Latin word list — review needed
- p. 148r l. 89: prosequaeris: not in Latin word list — review needed
- p. 148r l. 98: hitum: not in Latin word list — review needed
- p. 148r l. 104: hieitum: not in Latin word list — review needed
- p. 148r l. 116: smper: not in Latin word list — review needed
- p. 148r l. 123: volendi: not in Latin word list — review needed; seper: not in Latin word list — review needed
- p. 148r l. 124: pecccaum: not in Latin word list — review needed
- p. 148r l. 128: pramperare: not in Latin word list — review needed; prampaeratione: not in Latin word list — review needed
- p. 148r l. 132: occurente: not in Latin word list — review needed

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_