### PR TITLE
Transcription corrections: cod-ve07v1_kzz7yh-a10381.xml (9 changes)

### DIFF
--- a/kzz7yh-a10381/cod-ve07v1_kzz7yh-a10381.xml
+++ b/kzz7yh-a10381/cod-ve07v1_kzz7yh-a10381.xml
@@ -195,7 +195,7 @@
             <lb ed="#V" n="76"/>ista non addunt rem absolutam super creatam essentiam 
             <lb ed="#V" n="77"/>que ratione istorum vestigium dicitur esse: relatio autem 
             creatu<lb ed="#V" n="78" break="no"/>re ad deum non refertur ad ipsum mediante alia relatione. 
-            <lb ed="#V" n="79"/>et ideo non opetet esse vestigium vestigii sine sine: quamuis in 
+            <lb ed="#V" n="79"/>et ideo non oportet esse vestigium vestigii sine sine: quamuis in 
             <lb ed="#V" n="80"/>omni creatura sit dei vestigium vt dictum est.
           </p>
           <p xml:id="kzz7yh-a10381-d1e365">
@@ -264,7 +264,7 @@
             <lb ed="#V" n="122"/>Respondeo quod quamuis omnis cognitio quam habemus de deo
             <lb ed="#V" n="123"/>per naturam sit valde in generali: tamen vna 
             ma<lb ed="#V" n="124" break="no"/>gis est in generali quam alia. Cum enim intelligimus ens in 
-            <lb ed="#V" n="125"/>communi non descendendo adens creatum vel increatum 
+            <lb ed="#V" n="125"/>communi non descendendo addens creatum vel increatum 
             intel<lb ed="#V" n="126" break="no"/>ligimus deum intellectione generalissima: inquantum 
             intel<lb ed="#V" n="127" break="no"/>ligimus aliquid commune sibi et cuilibet creature non 
             con<lb ed="#V" n="128" break="no"/>munitate vniuoca sed analoga. Et hec naturalis 
@@ -290,7 +290,7 @@
           </p>
           <p xml:id="kzz7yh-a10381-d1e534">
             ¶ Ad 3m dicendum simili modo tamen non omnem 
-            <lb ed="#V" n="9"/>cognitionem per vestigium opetet praecedere appetitum: quamuis 
+            <lb ed="#V" n="9"/>cognitionem per vestigium oportet praecedere appetitum: quamuis 
             <lb ed="#V" n="10"/>oporteat quod precedat ordine nature vel temporis formatam 
             <lb ed="#V" n="11"/>cognitionem que est partus mentis vel non sine partu. 
           </p>

--- a/kzz7yh-a10381/cod-ve07v1_kzz7yh-a10381.xml
+++ b/kzz7yh-a10381/cod-ve07v1_kzz7yh-a10381.xml
@@ -148,11 +148,11 @@
             ac<lb ed="#V" n="39" break="no"/>cipitur pro pulchritudine secundum quod dicitur iste est valde 
             spe<lb ed="#V" n="40" break="no"/>ciosus id est pulcher. Ex hoc autem quod deus est causa 
             creatu<lb ed="#V" n="41" break="no"/>rarum efficiens exemplaris et finalis oportet in 
-            om<lb ed="#V" n="42" break="no"/>ni creatura esse bonitatem eoipso quod effecta est: et 
-            pul<lb ed="#V" n="43" break="no"/>chritudinem eoipso quod ad pulcherrimum exemplar facta est 
-            <lb ed="#V" n="44"/>et ordinem eoipso quod finem habet. In re enim que habet 
-            <lb ed="#V" n="45"/>finem opetet esse ordinem ad finem. Quia ergo modus creatu 
-            <lb ed="#V" n="46"/>re hoc est eius limitatio vel mensura deum representat 
+            om<lb ed="#V" n="42" break="no"/>ni creatura esse bonitatem eo ipso quod effecta est: et 
+            pul<lb ed="#V" n="43" break="no"/>chritudinem eo ipso quod ad pulcherrimum exemplar facta est 
+            <lb ed="#V" n="44"/>et ordinem eo ipso quod finem habet. In re enim que habet 
+            <lb ed="#V" n="45"/>finem opetet esse ordinem ad finem. Quia ergo modus 
+            creatu<lb ed="#V" n="46" break="no"/>re hoc est eius limitatio vel mensura deum representat 
             <lb ed="#V" n="47"/>sub ratione cause efficientis: et pulchritudo eius deum 
             repre<lb ed="#V" n="48" break="no"/>sentat sub ratione cause exemplaris. Et ordo ipsum 
             represen<lb ed="#V" n="49" break="no"/>tat sub ratione cause finalis que est representatio non 
@@ -184,7 +184,7 @@
           <p xml:id="kzz7yh-a10381-d1e333">
             <lb ed="#V" n="69"/>Ad primum in oppositum dico quod quamuis vestigium 
             di<lb ed="#V" n="70" break="no"/>stinguatur contra imagines: tamen simul 
-            pos<lb ed="#V" n="71" break="no"/>sunt esse in eadem creatura sub rone alia ita quodsic 
+            pos<lb ed="#V" n="71" break="no"/>sunt esse in eadem creatura sub ratione alia ita quod sic 
             vesti<lb ed="#V" n="72" break="no"/>gium ratione modi: speciei: et ordinis. imago aut ratione 
             <lb ed="#V" n="73"/>alicuius specialioris distinctionis per quam deum 
             ma<lb ed="#V" n="74" break="no"/>gis distincte representat.
@@ -248,7 +248,7 @@
             <lb ed="#V" n="111"/>Contra Nostra prima nationalis cognitio de deo est per 
             ef<lb ed="#V" n="112" break="no"/>fectus: quia anima non potest acquirere cognitionem 
             <lb ed="#V" n="113"/>de re aliqua nisi per eius effectum vel causam. Deus autem 
-            <lb ed="#V" n="114"/>non habet causam. Sed cognitio dei persuos effectus est 
+            <lb ed="#V" n="114"/>non habet causam. Sed cognitio dei per suos effectus est 
             <lb ed="#V" n="115"/>cognitio eius per vestigium. ergo prima nostra naturalis 
             co<lb ed="#V" n="116" break="no"/>gnitio de deo est per vestigium.
           </p>
@@ -270,7 +270,7 @@
             con<lb ed="#V" n="128" break="no"/>munitate vniuoca sed analoga. Et hec naturalis 
             cognitio<lb ed="#V" n="129" break="no"/>de deo prior est quam dei cognitio per vestigium: quia ista 
             pre<lb ed="#V" n="130" break="no"/>supponit in intellectu alicuius alterius cognitionem. 
-            <lb ed="#V" n="131"/>sed illa non. Unde secundum Auic. libro primio meta. c. 5 ens commune 
+            <lb ed="#V" n="131"/>sed illa non. Unde secundum Auic. libro primo meta. c. 5 ens commune 
             omni<lb ed="#V" n="132" break="no"/>bus rebus nullo modo potest manifestari nobis per aliquid 
             <lb ed="#V" n="133"/>notius illo. Alio modo cognoscitur deus a nobis in 
             genera<lb ed="#V" n="134" break="no"/>li inquantum coguoscimus esse aliquod ens increatum 
@@ -289,9 +289,9 @@
             <lb ed="#V" n="8"/>generalissime dicti.
           </p>
           <p xml:id="kzz7yh-a10381-d1e534">
-            ¶ Ad 3m dicendum simili modo tamei non omnem 
+            ¶ Ad 3m dicendum simili modo tamen non omnem 
             <lb ed="#V" n="9"/>cognitionem per vestigium opetet praecedere appetitum: quamuis 
-            <lb ed="#V" n="10"/>dporteat quod precedat ordine nature vel temporis formatam 
+            <lb ed="#V" n="10"/>oporteat quod precedat ordine nature vel temporis formatam 
             <lb ed="#V" n="11"/>cognitionem que est partus mentis vel non sine partu. 
           </p>
           <p xml:id="kzz7yh-a10381-d1e543">


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve07v1_kzz7yh-a10381.xml`.

## Applied changes

- p. 15v l. 42: eoipso: not in Latin word list — review needed
- p. 15v l. 43: eoipso: not in Latin word list — review needed
- p. 15v l. 44: eoipso: not in Latin word list — review needed
- p. 15v l. 46: 'creatu' + 're' split across line break without break="no" on lb n=46
- p. 15v l. 71: rone: not in Latin word list — review needed; quodsic: not in Latin word list — review needed
- p. 15v l. 114: persuos: not in Latin word list — review needed
- p. 15v l. 131: primio: not in Latin word list — review needed
- p. 16r l. 8: tamei → ramei: t/r transposition
- p. 16r l. 10: dporteat: not in Latin word list — review needed; precedat: not in Latin word list — review needed

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_