### PR TITLE
Transcription corrections: cod-ve07v1_kzz7yh-a14178.xml (9 changes)

### DIFF
--- a/kzz7yh-a14178/cod-ve07v1_kzz7yh-a14178.xml
+++ b/kzz7yh-a14178/cod-ve07v1_kzz7yh-a14178.xml
@@ -138,7 +138,7 @@
             <lb ed="#V" n="80"/>deus non genuit deum etc. Dico quod verum est: quia hoc 
             no<lb ed="#V" n="81" break="no"/>men deus inquantum signat naturam non plurificabilem: nec 
             <lb ed="#V" n="82"/>secundum rem nec secundum apprehensionem: Si tamen vere 
-            apprehen<lb ed="#V" n="83" break="no"/>datur: habet naturam termini singularis cum praeponem vel 
+            apprehen<lb ed="#V" n="83" break="no"/>datur: habet naturam termini singularis cum praeponere vel 
             post<lb ed="#V" n="84" break="no"/>ponere negationem non differt. et ideo dicendo deus non 
             <lb ed="#V" n="85"/>genuit deum: negatur generare non tantummodo de filio: sed de 
             <lb ed="#V" n="86"/>quolibet supposito diuine essentie
@@ -328,7 +328,7 @@
             <lb ed="#V" n="75"/>est iste terminus deus non potest congrue hebere pluralem 
             nu<lb ed="#V" n="76" break="no"/>merum: quamuis possit secundum quandam similitudinem: quia proprie 
             loquen<lb ed="#V" n="77" break="no"/>do nomen est incommunicabile. Unde sapiens Sap. 14 
-            lo<lb ed="#V" n="78" break="no"/>quens de nomine dei: et reprehendens illos qui vdolum 
+            lo<lb ed="#V" n="78" break="no"/>quens de nomine dei: et reprehendens illos qui ydolum 
             ado<lb ed="#V" n="79" break="no"/>rabant pro deo. Dicit incommunicabile nomen lignis et 
             la<lb ed="#V" n="80" break="no"/>pidibus imposuerunt: quia tamen in cognitionem rei quam signat hoc 
             <lb ed="#V" n="81"/>nomen deus ascendimus de lege communi per cognitionem 
@@ -350,7 +350,7 @@
           </p>
           <p xml:id="kzz7yh-a14178-d1e649">
             ¶ Ad 2m dicendum 
-            <lb ed="#V" n="95"/>quod illud verbum pramum accipitur per quandam similitudinem secundum 
+            <lb ed="#V" n="95"/>quod illud verbum <unclear>psalmum</unclear> accipitur per quandam similitudinem secundum 
             quam<lb ed="#V" n="96" break="no"/>viri supra communem legem virtuosi vocantur dii vel diuini. 
           </p>
           <p xml:id="kzz7yh-a14178-d1e657">
@@ -381,7 +381,7 @@
             congrue<lb ed="#V" n="115" break="no"/>dicitur tres persone diuine etc. Dico quod verum est: sed non sequitur 
             <lb ed="#V" n="116"/>quod si denominatiuum congrue habeat pluralem numerum quod ita sit 
             <lb ed="#V" n="117"/>de nomine principali: quia ab vno possunt plura denominari vt ab 
-            <lb ed="#V" n="118"/>isrul omnes israelite. Et hoc de ista quaestione sine praeiudicio dicta sint.
+            <lb ed="#V" n="118"/>israel omnes israelite. Et hoc de ista quaestione sine praeiudicio dicta sint.
           </p>
         </div>
       </div>

--- a/kzz7yh-a14178/cod-ve07v1_kzz7yh-a14178.xml
+++ b/kzz7yh-a14178/cod-ve07v1_kzz7yh-a14178.xml
@@ -157,7 +157,7 @@
           </p>
           <p xml:id="kzz7yh-a14178-d1e289">
             ¶ Ad 4m 
-            <lb ed="#V" n="96"/>co quod terminus signitans naturam modo concreto: non dicitur 
+            <lb ed="#V" n="96"/>co quod terminus significans naturam modo concreto: non dicitur 
             equo<lb ed="#V" n="97" break="no"/>ce de natura in concretione ad supposita: et de supposito 
             <lb ed="#V" n="98"/>nature. Unde iste terminus homo non predicatur 
             equi<lb ed="#V" n="99" break="no"/>uoce de homine et de sorte: immo secundum rationem communem: 
@@ -205,7 +205,7 @@
             genu<lb ed="#V" n="126" break="no"/>it alium deum: quod concedimus propter rationem nunc dictam. 
           </p>
           <p xml:id="kzz7yh-a14178-d1e374">
-            <lb ed="#V" n="127"/>Ad primu in oppositum dico quod deus non genuit 
+            <lb ed="#V" n="127"/>Ad primum in oppositum dico quod deus non genuit 
             <lb ed="#V" n="128"/>alium deum: nec genuit alium non deum: 
             <lb ed="#V" n="129"/>sed dico quod genuit alium in persona: qui est idem deus cum 
             <lb ed="#V" n="130"/>generante. Hee autem due genuit alium deum: genuit alium 
@@ -214,7 +214,7 @@
           </p>
           <p xml:id="kzz7yh-a14178-d1e390">
             ¶ Ad 2m cum dico quod 
-            <lb ed="#V" n="133"/>generatio in diuinis importat distinctionem inisupposito: 
+            <lb ed="#V" n="133"/>generatio in diuinis importat distinctionem in supposito: 
             <lb ed="#V" n="134"/>et vnitatem in natura. alius autem vt dictum est: cum adiun¬ 
             <!--00056.xml-->
             <pb ed="#V" n="21-v"/>
@@ -231,7 +231,7 @@
             <lb ed="#V" n="8"/>secundum exigentiam signationis eius. Deus autem quamuis supponat per 
             <lb ed="#V" n="9"/>sonam: quia potest supponere personam vel essentiam: et pro quo 
             <lb ed="#V" n="10"/>cumque illorum habeat propositio veritatem vera est: tamen significat 
-            <lb ed="#V" n="11"/>subiectum: et ideo cum diitur deus genuit alium deum: notatur 
+            <lb ed="#V" n="11"/>subiectum: et ideo cum dicitur deus genuit alium deum: notatur 
             alie<lb ed="#V" n="12" break="no"/>tas inter generantem et genitum: non tantummodo in 
             supposi<lb ed="#V" n="13" break="no"/>to: sed etiam in sub stantia.
           </p>
@@ -310,12 +310,12 @@
             ple<lb ed="#V" n="44" break="no"/>ne concipientem rem illam sicut est: nisi per quandam 
             similitudi<lb ed="#V" n="45" break="no"/>nem: vnde quia hoc nomen achilles imponitur ad 
             significan<lb ed="#V" n="46" break="no"/>dum rem sub tali modo quod de pleno conceptu illius rei quam 
-            <lb ed="#V" n="47"/>signt est ratio singularitatis sue: ideo hoc nomen achilles non 
+            <lb ed="#V" n="47"/>signat est ratio singularitatis sue: ideo hoc nomen achilles non 
             <lb ed="#V" n="48"/>potest congrue hebere pluralem numerum proprie: sed solum secundum 
             simi<lb ed="#V" n="49" break="no"/>litudinem inquantum multi possunt participare 
             proprieta<lb ed="#V" n="50" break="no"/>tes similes proprietatibus achillis secundum quod dicimus de 
             forti<lb ed="#V" n="51" break="no"/>homine: iste est achilles. hoc autem nomen deus imponitur ad 
-            si<lb ed="#V" n="52" break="no"/>gninncandum rem talem que non est mltiplicabilis realiter:
+            si<lb ed="#V" n="52" break="no"/>gninncandum rem talem que non est multiplicabilis realiter:
             <!--00056.xml-->
             <cb ed="#P" n="b"/>
             <lb ed="#V" n="68"/>et de cuius pleno conceptum est ratio singularitatis sue. 
@@ -330,7 +330,7 @@
             loquen<lb ed="#V" n="77" break="no"/>do nomen est incommunicabile. Unde sapiens Sap. 14 
             lo<lb ed="#V" n="78" break="no"/>quens de nomine dei: et reprehendens illos qui vdolum 
             ado<lb ed="#V" n="79" break="no"/>rabant pro deo. Dicit incommunicabile nomen lignis et 
-            la<lb ed="#V" n="80" break="no"/>pidibus imposuerunt: quia tamen in cognitionem rei quam signt hoc 
+            la<lb ed="#V" n="80" break="no"/>pidibus imposuerunt: quia tamen in cognitionem rei quam signat hoc 
             <lb ed="#V" n="81"/>nomen deus ascendimus de lege communi per cognitionem 
             <lb ed="#V" n="82"/>creaturarum que sunt multiplicabiles in suppositem: et ita non 
             <lb ed="#V" n="83"/>facimus conceptum de ea secundum modum existendi quem hebet. ideo 
@@ -370,9 +370,9 @@
             <lb ed="#V" n="107"/>sue: de pleno enim conceptu principiationis creaturarum non 
             <lb ed="#V" n="108"/>est ratio singularitatis: alii tamen dicunt quod talia nomina principium 
             <lb ed="#V" n="109"/>creator causa prima signant ipsas actiones per modum 
-            concre<lb ed="#V" n="110" break="no"/>tionis ad ipsum a quo sunt: hoc est ad deum: et ideo sigunnt 
+            concre<lb ed="#V" n="110" break="no"/>tionis ad ipsum a quo sunt: hoc est ad deum: et ideo signant 
             ip<lb ed="#V" n="111" break="no"/>sas actiones: et dant intelligere ipsum deum sicut iste terminus 
-            <lb ed="#V" n="112"/>agens primo signt ipsam actionem: et secundario ipsum a quo est 
+            <lb ed="#V" n="112"/>agens primo signat ipsam actionem: et secundario ipsum a quo est 
             <lb ed="#V" n="113"/>actio. Per hoc autem nomen deus intendimus signare directe 
             <lb ed="#V" n="114"/>ipsam diuinam essentiam sicut est.
           </p>


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve07v1_kzz7yh-a14178.xml`.

## Applied changes

- p. 21r l. 96: signitans: not in Latin word list — review needed
- p. 21r l. 127: primu: not in Latin word list — review needed
- p. 21r l. 133: inisupposito: not in Latin word list — review needed
- p. 21v l. 11: diitur: not in Latin word list — review needed
- p. 21v l. 47: signt: not in Latin word list — review needed
- p. 21v l. 52: mltiplicabilis: not in Latin word list — review needed
- p. 21v l. 80: signt: not in Latin word list — review needed
- p. 21v l. 110: sigunnt: not in Latin word list — review needed
- p. 21v l. 112: signt: not in Latin word list — review needed

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_