### PR TITLE
Transcription corrections: cod-ve07v1_kzz7yh-a22327.xml (2 changes)

### DIFF
--- a/kzz7yh-a22327/cod-ve07v1_kzz7yh-a22327.xml
+++ b/kzz7yh-a22327/cod-ve07v1_kzz7yh-a22327.xml
@@ -69,14 +69,14 @@
           <lb ed="#V" n="67"/>preteritum: vel futurum. uon scilicet notitia experientie: quia 
           <!--00079.xml-->
           <cb ed="#P" n="b"/>
-          <lb ed="#V" n="68"/>non variatur tempus: quamuis certissime cognoscat ommia 
+          <lb ed="#V" n="68"/>non variatur tempus: quamuis certissime cognoscat omnia 
           <lb ed="#V" n="69"/>preterita et futura: et possibilia fieri que nunquam erunt. 
           <lb ed="#V" n="70"/>(Solus deus vere est. verum est secundum quod veritas essendi 
           ex<lb ed="#V" n="71" break="no"/>cludit permixtionem cum possibilitate. (Cuius essentie 
           com<lb ed="#V" n="72" break="no"/>paratum nostrum esse non est. hoc verbum debet 
           intel<lb ed="#V" n="73" break="no"/>ligi de operatione secundum determinatam proportionem: quia 
           no<lb ed="#V" n="74" break="no"/>strum esse quantuncumque multiplicetur: nunquam 
-          equipara<lb ed="#V" n="75" break="no"/>tur diuino esse: sicut nec prunctus linee: immo minus: tammen 
+          equipara<lb ed="#V" n="75" break="no"/>tur diuino esse: sicut nec punctus linee: immo minus: tammen 
           <lb ed="#V" n="76"/>nostrum esse aliquam habet habitudinem ad diuinum esse: 
           <lb ed="#V" n="77"/>quia per illam habitudinem sumus. Tantum enim 
           habe<lb ed="#V" n="78" break="no"/>mus de esse: quantum diuinum imitamur. (Esse non est 


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve07v1_kzz7yh-a22327.xml`.

## Applied changes

- p. 33r l. 68: ommia → ammia: o/a misread at word start
- p. 33r l. 75: prunctus: not in Latin word list — review needed; linee: doubled final vowel 'ee' — likely transcription error; tammen: not in Latin word list — review needed

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_