### PR TITLE
Transcription corrections: cod-ve07v1_kzz7yh-a26723.xml (11 changes)

### DIFF
--- a/kzz7yh-a26723/cod-ve07v1_kzz7yh-a26723.xml
+++ b/kzz7yh-a26723/cod-ve07v1_kzz7yh-a26723.xml
@@ -423,7 +423,7 @@
           <p xml:id="kzz7yh-a26723-d1e746">
             <lb ed="#V" n="61"/>Ad primum cum dicitur quod im diuinis est vnitas 
             <lb ed="#V" n="62"/>vbi non obuiat aliqua relationis 
-            op<lb ed="#V" n="63" break="no"/>positio etc. Dico quod verum est: sed non propter est 
+            op<lb ed="#V" n="63" break="no"/>positio etc. Dico quod verum est: sed non propter hoc est 
             intentio<lb ed="#V" n="64" break="no"/>Ansel. quin sufficeret ad distinctionem personalem 
             relatio<lb ed="#V" n="65" break="no"/>num disperatio que esset inter filium et spiritum sanctum: 
             <lb ed="#V" n="66"/>etiam si spiritus sanctus non procederet a filio. Et hoc satis 

--- a/kzz7yh-a26723/cod-ve07v1_kzz7yh-a26723.xml
+++ b/kzz7yh-a26723/cod-ve07v1_kzz7yh-a26723.xml
@@ -186,7 +186,7 @@
             ¶ Preterea 
             <lb ed="#V" n="34"/>illa eadem ratio per quam pater spirat est in filio. Pater 
             <lb ed="#V" n="35"/>enim spirat ratione primitatis ad actum spirandi: que 
-            in<lb ed="#V" n="36" break="no"/>ipso est eoipso quod non spiratur: nec est a spirato. et hoc eadem 
+            in<lb ed="#V" n="36" break="no"/>ipso est eo ipso quod non spiratur: nec est a spirato. et hoc eadem 
             <lb ed="#V" n="37"/>ratio est in filio. filius enim non spiratur nec est a spirato. 
             <lb ed="#V" n="38"/>ergo necessarium est quod spiritus sanctus procedat ab vtroque eorum.
           </p>
@@ -207,7 +207,7 @@
           </p>
           <p xml:id="kzz7yh-a26723-d1e353">
             ¶ Ad illud quod 3o 
-            ar<lb ed="#V" n="49" break="no"/>guebatur per auctoritatem beati Diony. dico quod tlla 
+            ar<lb ed="#V" n="49" break="no"/>guebatur per auctoritatem beati Diony. dico quod illa 
             simili<lb ed="#V" n="50" break="no"/>tudo attenditur quo ad habitudinem horum ad vnum 
             prin<lb ed="#V" n="51" break="no"/>cipium non adinuicem: sicut enim duo flores ab vno 
             prin<lb ed="#V" n="52" break="no"/>cipio. sic filius et spiritus sanctus a patre. Sed in hoc est 
@@ -228,13 +228,13 @@
             ¶ Ad illud quod arguebatur 6o de 
             quat<lb ed="#V" n="60" break="no"/>tuor conciliis. dico quod in eis ita dicitur spiritus sanctus 
             pro<lb ed="#V" n="61" break="no"/>cedere a patre quod non negatur procedere a filio. Et quamuis 
-            <lb ed="#V" n="62"/>non exprimerent ipsum procedere a filio: non propter hioc 
+            <lb ed="#V" n="62"/>non exprimerent ipsum procedere a filio: non propter hoc 
             <lb ed="#V" n="63"/>sequitur quod negarent. Tunc enim forte non erat tanta 
             neces<lb ed="#V" n="64" break="no"/>sitas exprimendi sicut fuit postea.
           </p>
           <p xml:id="kzz7yh-a26723-d1e397">
             ¶ Ad 7m cum dicitur 
-            <lb ed="#V" n="65"/>quod nihil omnino simplex potestesse a duobus etc. Dico quod 
+            <lb ed="#V" n="65"/>quod nihil omnino simplex potest esse a duobus etc. Dico quod 
             <lb ed="#V" n="66"/>verum est a duobus diuersis per essentiam: quarum vna 
             <lb ed="#V" n="67"/>non dependet ab alia: quia que sic differunt per essentiam: 
             <!--00093.xml-->
@@ -297,7 +297,7 @@
             ver<lb ed="#V" n="103" break="no"/>sus principium in diuinis est vnitas vbi non 
             <lb ed="#V" n="104"/>obuiat aliqua relationis oppositio: sed si spiritus sanctus 
             <lb ed="#V" n="105"/>non procederet a filio: relationes eorum non essent 
-            oppo<lb ed="#V" n="106" break="no"/>site. ergo esset realiter vna persona filius et sptritus sanctus. 
+            oppo<lb ed="#V" n="106" break="no"/>site. ergo esset realiter vna persona filius et spiritus sanctus. 
           </p>
           <p xml:id="kzz7yh-a26723-d1e517">
             <lb ed="#V" n="107"/>¶ Item filius et spiritus sanctus non possunt realiter 
@@ -397,7 +397,7 @@
             <lb ed="#V" n="42"/>distinguerentur per distinctionem generationis: et 
             spiratio<lb ed="#V" n="43" break="no"/>nis: cum inter generationem et spirationem non sit realis 
             di<lb ed="#V" n="44" break="no"/>stinctio: nisi per hoc quod spiritus sanctus procedit a genito. 
-            <lb ed="#V" n="45"/>Pocessio ergo spiritus sancti a genito est ratio 
+            <lb ed="#V" n="45"/>Processio ergo spiritus sancti a genito est ratio 
             distinctio<lb ed="#V" n="46" break="no"/>nis realis inter filium et spiritum sanctum: et inter 
             genera<lb ed="#V" n="47" break="no"/>tionem et spirationem.
           </p>
@@ -418,7 +418,7 @@
           </p>
           <p xml:id="kzz7yh-a26723-d1e740">
             ¶ Qui vult sustinere primam 
-            opi<lb ed="#V" n="60" break="no"/>nionem: potest respondere ad argumenta incontrarium per hunc modum.
+            opi<lb ed="#V" n="60" break="no"/>nionem: potest respondere ad argumenta in contrarium per hunc modum.
           </p>
           <p xml:id="kzz7yh-a26723-d1e746">
             <lb ed="#V" n="61"/>Ad primum cum dicitur quod im diuinis est vnitas 
@@ -447,7 +447,7 @@
           </p>
           <p xml:id="kzz7yh-a26723-d1e794">
             ¶ Ad illud quod dicebatur 
-            <lb ed="#V" n="79"/>pro confirmatione alterius opinsonis quod verbum realiter 
+            <lb ed="#V" n="79"/>pro confirmatione alterius opinionis quod verbum realiter 
             <lb ed="#V" n="80"/>non distinguitur a filio etc. Dico quod verum est: tamen 
             for<lb ed="#V" n="81" break="no"/>te ex hoc non sequitur tuum propositum: quia intellectus et 
             <lb ed="#V" n="82"/>natura non possunt creare tantam distinctionem in 
@@ -457,8 +457,8 @@
             <lb ed="#V" n="86"/>sic loquendo intra rationem actionis intellectualis 
             com<lb ed="#V" n="87" break="no"/>prehenditur ratio actionis naturalis: non autem sic de 
             actio<lb ed="#V" n="88" break="no"/>ne que est per modum voluntatis: et de illa que est per 
-            mo<lb ed="#V" n="89" break="no"/>dum intellectus: quamuis vna aliam presupponat secundum ratio 
-            <lb ed="#V" n="90"/>nem intelligendi.
+            mo<lb ed="#V" n="89" break="no"/>dum intellectus: quamuis vna aliam presupponat secundum 
+            ratio<lb ed="#V" n="90" break="no"/>nem intelligendi.
           </p>
         </div>
         <div xml:id="kzz7yh-a26723-Dd1e824">
@@ -645,7 +645,7 @@
             <lb ed="#V" n="70"/>C Qiuenio il 
             <lb ed="#V" n="71"/>QUinto queritur vtrun pater et frius 
             de<lb ed="#V" n="72" break="no"/>niust dctor. Et 
-            vide<lb ed="#V" n="73" break="no"/>tur quod non: quia quicunque spirant sunt spirates: 
+            vide<lb ed="#V" n="73" break="no"/>tur quod non: quia quicunque spirant sunt spirantes: 
             <lb ed="#V" n="74"/>pater et filius spirant: ergo sunt spirantes: ergo 
             <lb ed="#V" n="75"/>a simili sunt spiratores.
           </p>
@@ -653,7 +653,7 @@
             ¶ Item actus quo ad modum 
             si<lb ed="#V" n="76" break="no"/>gnificandi numeratur secundum supposita: sed spirator dicit 
             <lb ed="#V" n="77"/>actum. ergo quo ad modum significandi debet 
-            numera<lb ed="#V" n="78" break="no"/>ri secundum supposita. Cumergo pater et filius sint duo 
+            numera<lb ed="#V" n="78" break="no"/>ri secundum supposita. Cum ergo pater et filius sint duo 
             suppo<lb ed="#V" n="79" break="no"/>sita spirantia: debent dici duo spiratores: non vnus 
             spi<lb ed="#V" n="80" break="no"/>rator.
           </p>

--- a/kzz7yh-a26723/cod-ve07v1_kzz7yh-a26723.xml
+++ b/kzz7yh-a26723/cod-ve07v1_kzz7yh-a26723.xml
@@ -423,7 +423,7 @@
           <p xml:id="kzz7yh-a26723-d1e746">
             <lb ed="#V" n="61"/>Ad primum cum dicitur quod im diuinis est vnitas 
             <lb ed="#V" n="62"/>vbi non obuiat aliqua relationis 
-            op<lb ed="#V" n="63" break="no"/>positio etc. Dico quod verum est: sed non propter hest 
+            op<lb ed="#V" n="63" break="no"/>positio etc. Dico quod verum est: sed non propter est 
             intentio<lb ed="#V" n="64" break="no"/>Ansel. quin sufficeret ad distinctionem personalem 
             relatio<lb ed="#V" n="65" break="no"/>num disperatio que esset inter filium et spiritum sanctum: 
             <lb ed="#V" n="66"/>etiam si spiritus sanctus non procederet a filio. Et hoc satis 
@@ -468,7 +468,7 @@
             ¶ Questio. III. 
             <lb ed="#V" n="91"/>Tertio queritur. Utrum spiritus sanctus 
             pro<lb ed="#V" n="92" break="no"/>cedat a patre et filio inquantum sunt 
-            <lb ed="#V" n="93"/>vnum. Et videtur quod non: quia procedir ab eis: 
+            <lb ed="#V" n="93"/>vnum. Et videtur quod non: quia <sic>procedir</sic> ab eis: 
             <lb ed="#V" n="94"/>vt nexus amborum. nexus autem non est vnus: 
             <lb ed="#V" n="95"/>sed plurium. ergo procedit ab eis: vt sunt plures 
             <lb ed="#V" n="96"/>non vt sunt vnum.


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve07v1_kzz7yh-a26723.xml`.

## Applied changes

- p. 40r l. 36: eoipso: not in Latin word list — review needed
- p. 40r l. 49: tlla: not in Latin word list — review needed
- p. 40r l. 62: hioc: not in Latin word list — review needed
- p. 40r l. 65: potestesse: not in Latin word list — review needed
- p. 40r l. 106: sptritus: not in Latin word list — review needed
- p. 40v l. 45: Pocessio: not in Latin word list — review needed
- p. 40v l. 60: incontrarium: not in Latin word list — review needed
- p. 40v l. 79: opinsonis: not in Latin word list — review needed
- p. 40v l. 90: 'ratio' + 'nem' split across line break without break="no" on lb n=90
- p. 41r l. 73: spirates → spirares: t/r transposition
- p. 41r l. 78: Cumergo: not in Latin word list — review needed

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_