### PR TITLE
Transcription corrections: cod-ve07v1_kzz7yh-a29767.xml (9 changes)

### DIFF
--- a/kzz7yh-a29767/cod-ve07v1_kzz7yh-a29767.xml
+++ b/kzz7yh-a29767/cod-ve07v1_kzz7yh-a29767.xml
@@ -59,7 +59,7 @@
         </p>
         <p xml:id="kzz7yh-a29767-d1e108">
           ¶ 
-          Pri<lb ed="#V" n="78" break="no"/>mo vtrum spirationi spitus sancti vere 
+          Pri<lb ed="#V" n="78" break="no"/>mo vtrum spirationi spiritus sancti vere 
           com<lb ed="#V" n="79" break="no"/>ueniat processionis ratio.
         </p>
         <p xml:id="kzz7yh-a29767-d1e115">
@@ -156,7 +156,7 @@
             ¶ Ad 3m cum dicitur quod 
             spiratio<lb ed="#V" n="8" break="no"/>spiritus sancti non est processio localis nec causalis etc. Dico 
             <lb ed="#V" n="9"/>quod quamuis non sit localis: neque proprie sit a patre et a filio 
-            <lb ed="#V" n="10"/>tanquam a causa: tamen est a patre et a filio tanque a principio. 
+            <lb ed="#V" n="10"/>tanquam a causa: tamen est a patre et a filio tanquam a principio. 
             <lb ed="#V" n="11"/>Unde non valet: non est processio localis neque causalis. 
             <lb ed="#V" n="12"/>ergo non est processio.
           </p>
@@ -165,7 +165,7 @@
             <lb ed="#V" n="13"/>distinguitur a patre et a filio. Dico quod de spiratione actiua 
             <lb ed="#V" n="14"/>verum est: quamuis sit actio patris et filii: sed spiratio 
             passi<lb ed="#V" n="15" break="no"/>ua distinguitur a patre et a filio: nec predicatur de eis: sed 
-            <lb ed="#V" n="16"/>de spiritu sancto. Pocessio autem nominat emanationem 
+            <lb ed="#V" n="16"/>de spiritu sancto. Processio autem nominat emanationem 
             passi<lb ed="#V" n="17" break="no"/>uam. Unde non dicimus quod pater procedat: quamuis ergo 
             <lb ed="#V" n="18"/>spirationi actiue non vere conueniat processionis ratio: 
             <lb ed="#V" n="19"/>vere tamen conuenit spirationi passiue. 
@@ -202,11 +202,11 @@
             san<lb ed="#V" n="37" break="no"/>cto.
           </p>
           <p xml:id="kzz7yh-a29767-d1e355">
-            ¶ Item Richar. 5 libro de trinia. cap. 7. Pocessio 
+            ¶ Item Richar. 5 libro de trinia. cap. 7. Processio 
             im<lb ed="#V" n="38" break="no"/>mediata consistit in personarum dualitate. Mediata vero 
             <lb ed="#V" n="39"/>nunquam sine personarum trinitate. ergo per ipsum habeo quod 
             <lb ed="#V" n="40"/>processio conuenit persone que est a patre immediate tantum. 
-            <lb ed="#V" n="41"/>Pocedere ergo commune est filio et spiritui sancto.
+            <lb ed="#V" n="41"/>Procedere ergo commune est filio et spiritui sancto.
           </p>
           <p xml:id="kzz7yh-a29767-d1e366">
             ¶ Item 
@@ -234,7 +234,7 @@
             gene<lb ed="#V" n="61" break="no"/>rale retinet cum accidens proprium speciali nomine 
             no<lb ed="#V" n="62" break="no"/>minetur scilicet nomine proprii. Sciendum tamen est quod sicut 
             <lb ed="#V" n="63"/>est nomen specialiter significans emanationem filii: quod 
-            <lb ed="#V" n="64"/>nomen est generatio. ita est nomen specialiter significaus 
+            <lb ed="#V" n="64"/>nomen est generatio. ita est nomen specialiter significans 
             <lb ed="#V" n="65"/>emanationem spiritus sancti. et istud nomen est spiratio. 
             <!--TODO: insert para-->
             <lb ed="#V" n="66"/>Per hoc patet quomodo responderi debeat ad  
@@ -340,7 +340,7 @@
             <cb ed="#P" n="a"/>
             <lb ed="#V" n="1"/>signatur earum distinctio per hoc quod spiratio est a filio qui 
             <lb ed="#V" n="2"/>est generatus: et ita spiratio est per generationem 
-            median<lb ed="#V" n="3" break="no"/>te filio. Aliomodo potest intelligi questio: ita vt queratur 
+            median<lb ed="#V" n="3" break="no"/>te filio. Alio modo potest intelligi questio: ita vt queratur 
             <lb ed="#V" n="4"/>vtrum spiratio spiritus sancti habeat in se rationem 
             gene<lb ed="#V" n="5" break="no"/>rationis. et dico quod non. quia generatio est productio similis 
             <lb ed="#V" n="6"/>in natura per modum nature: sed quamuis pater et filius 
@@ -569,7 +569,7 @@
             neces<lb ed="#V" n="22" break="no"/>sitate presupponit generationem 
             fi<lb ed="#V" n="23" break="no"/>lii et spirationem spiritus sancti. Ad cuius intelligentiam 
             scien<lb ed="#V" n="24" break="no"/>dum quod vnam rem de necessitate presupponere aliam 
-            po<lb ed="#V" n="25" break="no"/>test intelligi tripliciter: vnomodo tanquam rem que de 
+            po<lb ed="#V" n="25" break="no"/>test intelligi tripliciter: vno modo tanquam rem que de 
             ne<lb ed="#V" n="26" break="no"/>cessitate simul est cum sua causa: et sic secundum Auic. 6. metap. 
             <lb ed="#V" n="27"/>ca. 5. Incidere de necessitate presupponit fuscitatem in 
             fer<lb ed="#V" n="28" break="no"/>ro. per fuscitatem causa exempli intelligimus colorem 
@@ -657,8 +657,8 @@
             vel<lb ed="#V" n="91" break="no"/>let alia a se non tantum intelligere speculatiuo et velle 
             compla<lb ed="#V" n="92" break="no"/>centie quo sibi complacet in bonis possibilibus fieri: que 
             ta<lb ed="#V" n="93" break="no"/>men nunquam fient. hoc etiam acti intelligendi quo 
-            productio<lb ed="#V" n="94" break="no"/>creature disponitur: et actu volendi quo productio creatu 
-            <lb ed="#V" n="95"/>re: vt ita loquar: affectatur. Sed hoc est impossibile: quia 
+            productio<lb ed="#V" n="94" break="no"/>re disponitur: et actu volendi quo productio creatu 
+            creatu<lb ed="#V" n="95" break="no"/>re: vt ita loquar: affectatur. Sed hoc est impossibile: quia 
             sa<lb ed="#V" n="96" break="no"/>pientia disponens: et amor affectans qui respiciunt actum: 
             <lb ed="#V" n="97"/>sunt sapientia et amor procedens sine quibus intellectus 
             <lb ed="#V" n="98"/>et voluntas non sufficienter disponerentur perisuos actus 

--- a/kzz7yh-a29767/cod-ve07v1_kzz7yh-a29767.xml
+++ b/kzz7yh-a29767/cod-ve07v1_kzz7yh-a29767.xml
@@ -72,7 +72,7 @@
         </p>
         <p xml:id="kzz7yh-a29767-d1e126">
           ¶ Quarto vtrum esse 
-          ingeni<lb ed="#V" n="82" break="no"/>tum posst vere dici de spiritu sancto.
+          ingeni<lb ed="#V" n="82" break="no"/>tum possit vere dici de spiritu sancto.
         </p>
         <p xml:id="kzz7yh-a29767-d1e131">
           ¶ Quinto vtrum de 
@@ -420,7 +420,7 @@
             <lb ed="#V" n="59"/>non est: sed ingenitus atque infectus.
           </p>
           <p xml:id="kzz7yh-a29767-d1e760">
-            ¶ Item aute est non 
+            ¶ Item aut est non 
             <lb ed="#V" n="60"/>genitus: aut non est non genitus: sed non est non genitus 
             <lb ed="#V" n="61"/>quia due negationes equipollent vni affirmationi. ergo 
             <lb ed="#V" n="62"/>est non genitus: sed sequitur est non genitus. ergo ingenitus vt videtur. 


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve07v1_kzz7yh-a29767.xml`.

## Applied changes

- p. 44r l. 78: spitus: not in Latin word list — review needed
- p. 44v l. 10: tanque: not in Latin word list — review needed
- p. 44v l. 16: Pocessio: not in Latin word list — review needed
- p. 44v l. 37: Pocessio: not in Latin word list — review needed
- p. 44v l. 41: Pocedere: not in Latin word list — review needed
- p. 44v l. 64: significaus: not in Latin word list — review needed
- p. 45r l. 3: Aliomodo: not in Latin word list — review needed
- p. 45v l. 25: vnomodo: not in Latin word list — review needed
- p. 45v l. 95: 'creatu' + 're' split across line break without break="no" on lb n=95

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_