### PR TITLE
Transcription corrections: cod-ve07v1_kzz7yh-a31730.xml (5 changes)

### DIFF
--- a/kzz7yh-a31730/cod-ve07v1_kzz7yh-a31730.xml
+++ b/kzz7yh-a31730/cod-ve07v1_kzz7yh-a31730.xml
@@ -101,7 +101,7 @@
           </p>
           <p xml:id="kzz7yh-a31730-d1e176">
             ¶ Item 
-            <lb ed="#V" n="70"/>donum quando datur procedit a dante in recipientem: sed sptussanctus 
+            <lb ed="#V" n="70"/>donum quando datur procedit a dante in recipientem: sed spiritus sanctus 
             <lb ed="#V" n="71"/>datur ex tempore rationali creature. ergo ex tempore procedit in ipsam. 
           </p>
           <p xml:id="kzz7yh-a31730-d1e183">
@@ -148,7 +148,7 @@
             <lb ed="#V" n="107"/>sancti est sua spiratio etc. Dico quod quamuis idem sint re: tamen 
             <lb ed="#V" n="108"/>differunt in modo significandi: quia spiratio non significat 
             <lb ed="#V" n="109"/>nisi habitudinem ad principium a quo et non ad terminum 
-            <lb ed="#V" n="110"/>ad quem. Pocessio vero significat habitudinem vtramque. Et quia 
+            <lb ed="#V" n="110"/>ad quem. Processio vero significat habitudinem vtramque. Et quia 
             <lb ed="#V" n="111"/>processio spiritus sancti non potest esse temporalis nisi per 
             com<lb ed="#V" n="112" break="no"/>parationem ad terminum ad quem: Ideo et si non possit dici 
             <lb ed="#V" n="113"/>spiratio spiritus sancti esse temporalis: potest tamen aliqua 
@@ -156,7 +156,7 @@
           </p>
           <p xml:id="kzz7yh-a31730-d1e284">
             ¶ Ad tertium cum 
-            <lb ed="#V" n="115"/>dicitur quod nihiul procedit in rem vbi est etc. Dico quod verum est 
+            <lb ed="#V" n="115"/>dicitur quod nihil procedit in rem vbi est etc. Dico quod verum est 
             <lb ed="#V" n="116"/>de processione locali: sed de processione spirituali bene 
             pro<lb ed="#V" n="117" break="no"/>cedit persona spiritus sancti in rem in qua ante erat per hoc quod 
             <lb ed="#V" n="118"/>alio modo in illa re esse incipit: immo vt proprius loquar per 
@@ -294,8 +294,8 @@
             <lb ed="#V" n="67"/>non concludunt. tamen quin differant secundum rationem: et 
             <!--00108.xml-->
             <cb ed="#P" n="b"/>
-            <lb ed="#V" n="68"/>etiam secundum eonnotatum quod est temporalis effectus in 
-            crea<lb ed="#V" n="69" break="no"/>tura quem connotat actu temproalis processio spiritus 
+            <lb ed="#V" n="68"/>etiam secundum connotatum quod est temporalis effectus in 
+            crea<lb ed="#V" n="69" break="no"/>tura quem connotat actu temporalis processio spiritus 
             san<lb ed="#V" n="70" break="no"/>cti: non sic autem processio eius eterna. et certum est quod ille 
             <lb ed="#V" n="71"/>effectus connotatus essentialiter differt ab eterna 
             processio<lb ed="#V" n="72" break="no"/>ne


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve07v1_kzz7yh-a31730.xml`.

## Applied changes

- p. 47r l. 70: sptussanctus: not in Latin word list — review needed
- p. 47r l. 110: Pocessio: not in Latin word list — review needed
- p. 47r l. 115: nihiul: not in Latin word list — review needed
- p. 47v l. 68: eonnotatum: not in Latin word list — review needed
- p. 47v l. 69: temproalis: not in Latin word list — review needed

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_