### PR TITLE
Transcription corrections: cod-ve07v1_kzz7yh-a32284.xml (14 changes)

### DIFF
--- a/kzz7yh-a32284/cod-ve07v1_kzz7yh-a32284.xml
+++ b/kzz7yh-a32284/cod-ve07v1_kzz7yh-a32284.xml
@@ -127,11 +127,11 @@
             <lb ed="#V" n="17"/>in sua domo: non propter hoc diceremus quod haberet illam 
             <lb ed="#V" n="18"/>pecuniam sicut rem suam. Unde non obstante quod illa 
             pecu<lb ed="#V" n="19" break="no"/>nia presens erat in domo pauperis: posset sibi dari de 
-            no<lb ed="#V" n="20" break="no"/>uo a diuite: quo sacto non tantummodo haberet eam per 
+            no<lb ed="#V" n="20" break="no"/>uo a diuite: quo facto non tantummodo haberet eam per 
             so<lb ed="#V" n="21" break="no"/>lam pecunie presentiam in domo: sed haberet eam sicut 
             re<lb ed="#V" n="22" break="no"/>suam. Asimili aliqualiter dico quod quamuis spiritus sanctus sit 
             <lb ed="#V" n="23"/>per essentiam presens omni rei: quia tamen peccator non 
-            ha<lb ed="#V" n="24" break="no"/>bet sacultate ad fruendum eo: ideo non obstante illa 
+            ha<lb ed="#V" n="24" break="no"/>bet facultatem ad fruendum eo: ideo non obstante illa 
             pre<lb ed="#V" n="25" break="no"/>sentia: potest a deo vere dari persona spiritus sancti: et 
             da<lb ed="#V" n="26" break="no"/>tur etiam creature rationali cum donum charitatis infunditur.
           </p>
@@ -149,7 +149,7 @@
             crea<lb ed="#V" n="34" break="no"/>to: non autem de dono increato: quia donum increatum 
             trans<lb ed="#V" n="35" break="no"/>sert accipientem in potestatem suam: vt liberalius ei seruiat: 
             <lb ed="#V" n="36"/>vel seruiat liberaliter qui ante seruiebat seruiliter. nec etiam 
-            <lb ed="#V" n="37"/>de bono creato habet propositio forte viverslaiter veritatem: quia anima 
+            <lb ed="#V" n="37"/>de bono creato habet propositio forte vniversaliter veritatem: quia anima 
             <lb ed="#V" n="38"/>datur corpori: nec tamen per hoc sit sub corporis 
             potesta<lb ed="#V" n="39" break="no"/>te. immo potius econuerso.
           </p>
@@ -223,10 +223,10 @@
             <!--TODO: fix line numbers--> 
             <lb ed="#V" n="80"/>actum gratie gratis dante. Sed proprie et simpliciter non datur 
             <lb ed="#V" n="81"/>nisi cum charitate: quia sine charitate non habemus 
-            facuita<lb ed="#V" n="82" break="no"/>tem fruendi spiritu sanctor quam faculitatem habemus 
+            facuita<lb ed="#V" n="82" break="no"/>tem fruendi spiritu sancto quam facultatem habemus 
             per<lb ed="#V" n="83" break="no"/>donum charitatis: quamuis imperfecte per charitatem 
-            que<lb ed="#V" n="84" break="no"/>est in vria: derfecte tamen habebimus eam der charitatis 
-            <lb ed="#V" n="85"/>perfectionem: quam habemus in patria. Per hoc patetr 
+            que<lb ed="#V" n="84" break="no"/>est in via: perfecte tamen habebimus eam der charitatis 
+            <lb ed="#V" n="85"/>perfectionem: quam habemus in patria. Per hoc patet 
             <lb ed="#V" n="86"/>quid dici debeat ad argumenta ad vtramque partem.
           </p>
           <p xml:id="kzz7yh-a32284-d1e415">

--- a/kzz7yh-a32284/cod-ve07v1_kzz7yh-a32284.xml
+++ b/kzz7yh-a32284/cod-ve07v1_kzz7yh-a32284.xml
@@ -197,7 +197,7 @@
             ¶ Item si non posset dari 
             spiri<lb ed="#V" n="64" break="no"/>tus sanctus sine charitate: tunc prius ordine nature 
             habe<lb ed="#V" n="65" break="no"/>remus charitatem quam spiritum sanctum: quia prius potest 
-            dari<lb ed="#V" n="66" break="no"/>sine posteriori: sed non habemus prorius ordine nature 
+            dari<lb ed="#V" n="66" break="no"/>sine posteriori: sed non habemus proprius ordine nature 
             cha<lb ed="#V" n="67" break="no"/>ritatem quam spiritum sanctum: quia spiritus sanctus ordine nature est prior 
             <!--00109.xml-->
             <cb ed="#P" n="b"/>
@@ -215,7 +215,7 @@
             <lb ed="#V" n="74"/>Aug. 15 de trini. c. 17. Deus igitur spiritus sanctus qui 
             proce<lb ed="#V" n="75" break="no"/>dit ex deo cum datus fuerit homini accedit eum in dilectionem dei 
             <lb ed="#V" n="76"/>et proximi et ipse dilectio est: cum ergo in sancta dei dilectione 
-            <lb ed="#V" n="77"/>et proximi sit charitas: non datur spitus sanctus sine charitate. 
+            <lb ed="#V" n="77"/>et proximi sit charitas: non datur spiritus sanctus sine charitate. 
           </p>
           <p xml:id="kzz7yh-a32284-d1e391">
             <lb ed="#V" n="78"/>Respondeo quod spiritus sanctus sine charitate potest
@@ -231,7 +231,7 @@
           </p>
           <p xml:id="kzz7yh-a32284-d1e415">
             <lb ed="#V" n="87"/>Ad primum cum dicitur quod mitti est cognosci esse 
-            <lb ed="#V" n="88"/>ab alio etc. Dico qod illud debet 
+            <lb ed="#V" n="88"/>ab alio etc. Dico quod illud debet 
             intel<lb ed="#V" n="89" break="no"/>ligi de cognitione perfecta formata per charitatem.
           </p>
           <p xml:id="kzz7yh-a32284-d1e424">
@@ -240,13 +240,13 @@
             <lb ed="#V" n="91"/>verum est sine donom priori efficiente: autem mouente. bee 
             <lb ed="#V" n="92"/>tamen datur donum posterius sine hoc quod detur donum 
             <lb ed="#V" n="93"/>prius donatione simpliciter que ordinatu ad habere. 
-            mon<lb ed="#V" n="94" break="no"/>entrim spiritus sanctus est ratio donandi quoduibet aliud 
+            mon<lb ed="#V" n="94" break="no"/>entrim spiritus sanctus est ratio donandi quodlibet aliud 
             do<lb ed="#V" n="95" break="no"/>num inquantum datus: sed inquantum procedens: vt 
             effici<lb ed="#V" n="96" break="no"/>ens: et exemplaraliorum donorum
           </p>
           <p xml:id="kzz7yh-a32284-d1e442">
             ¶ Tertium argumentum 
-            <lb ed="#V" n="97"/>non pius concliudit nisi quam potest dari improprie: et secundum quid 
+            <lb ed="#V" n="97"/>non pius concludit nisi quam potest dari improprie: et secundum quid 
             <lb ed="#V" n="98"/>sine charitate et hoc concessum est.
           </p>
           <p xml:id="kzz7yh-a32284-d1e450">
@@ -254,15 +254,15 @@
             <lb ed="#V" n="99"/>dare ordinetur ad hambere: et creatura rationaluis habenat 
             fpi<lb ed="#V" n="100" break="no"/>ritum sanctum der hoc quod habet charitatem: quem est donum 
             <lb ed="#V" n="101"/>spirituisancto abpropriatum: quia per charitate est in 
-            creatu<lb ed="#V" n="102" break="no"/>a facultas ad ffuendum spiritu sancto: prius ordine 
+            creatu<lb ed="#V" n="102" break="no"/>a facultas ad fruendum spiritu sancto: prius ordine 
             natu<lb ed="#V" n="103" break="no"/>re habemus charitatem quam simpliciter habeamus 
-            spiritun<lb ed="#V" n="104" break="no"/>sanctum quam tamen notre charitatis causa efficiens est 
+            spiritun<lb ed="#V" n="104" break="no"/>sanctum quam tamen nostre charitatis causa efficiens est 
             spi<lb ed="#V" n="105" break="no"/>ritus sanctus dico quod brius ordine nature est in nobis 
             ompe<lb ed="#V" n="106" break="no"/>rans spiritus sanctus: quam charitatem habeamus: quia ipsam 
             <lb ed="#V" n="107"/>per spiritus sancti operationem habemus.
           </p>
           <p xml:id="kzz7yh-a32284-d1e472">
-            ¶ Argumentuam 
+            ¶ Argumentum 
             <lb ed="#V" n="108"/>ad dartem aliam conciludunt: quia spiritus sanctus non 
             de<lb ed="#V" n="109" break="no"/>tur simpiciter sine charitate: duod concessum est. 
           </p>
@@ -281,17 +281,17 @@
             san<lb ed="#V" n="117" break="no"/>ctum
           </p>
           <p xml:id="kzz7yh-a32284-d1e504">
-            ¶ Item cormpus illuminatum potest aliud 
-            illumi<lb ed="#V" n="118" break="no"/>nare: et ininiammatum aliud inulammare. ergo et sanctus 
-            ho<lb ed="#V" n="119" break="no"/>mo charitate inslammatus potest alium hominem charitate 
+            ¶ Item corpus illuminatum potest aliud 
+            illumi<lb ed="#V" n="118" break="no"/>nare: et inflammatum aliud inulammare. ergo et sanctus 
+            ho<lb ed="#V" n="119" break="no"/>mo charitate inflammatus potest alium hominem charitate 
             <lb ed="#V" n="120"/>mnammare
           </p>
           <p xml:id="kzz7yh-a32284-d1e513">
             ¶ Item Ioant. 3o Dedit saluator aposiolis 
             po<lb ed="#V" n="121" break="no"/>testatem remittendi deccata. Cum dicit: Accipite 
             spiri<lb ed="#V" n="122" break="no"/>tumsanctum quorum remiseritis etc. Sed non remittit 
-            pec<lb ed="#V" n="123" break="no"/>catum homini: nosi cum sibi datur spiritus sanctus: 
-            ergo<lb ed="#V" n="124" break="no"/>acceperunt dotestatem dandi spiritum sanctum. 
+            pec<lb ed="#V" n="123" break="no"/>catum homini: nisi cum sibi datur spiritus sanctus: 
+            ergo<lb ed="#V" n="124" break="no"/>acceperunt potestatem dandi spiritum sanctum. 
             <!--TODO: insert para break-->
             <lb ed="#V" n="125"/>Contra Augustinus 15. de trinitate ca. 26. Quomodo deus non
             <lb ed="#V" n="126"/>est qui dat spiritum sanctum ergo nullus dat 
@@ -300,7 +300,7 @@
           <p xml:id="kzz7yh-a32284-d1e531">
             ¶ Item nullus potest dare 
             <lb ed="#V" n="128"/>rem que est supra se: sed spiritussanctus est supia ommnem 
-            <lb ed="#V" n="129"/>hominem ergo nullus homo potest spiritum samctum dare. 
+            <lb ed="#V" n="129"/>hominem ergo nullus homo potest spiritum sanctum dare. 
           </p>
           <p xml:id="kzz7yh-a32284-d1e539">
             <lb ed="#V" n="130"/>Respondeo quod dare spiritum sanctum per modum 


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve07v1_kzz7yh-a32284.xml`.

## Applied changes

- p. 48r l. 66: prorius: not in Latin word list — review needed
- p. 48r l. 77: spitus: not in Latin word list — review needed
- p. 48r l. 88: qod: not in Latin word list — review needed
- p. 48r l. 94: quoduibet: not in Latin word list — review needed
- p. 48r l. 97: concliudit: not in Latin word list — review needed
- p. 48r l. 102: ffuendum: not in Latin word list — review needed
- p. 48r l. 104: notre: not in Latin word list — review needed
- p. 48r l. 107: Argumentuam: not in Latin word list — review needed
- p. 48r l. 117: cormpus: not in Latin word list — review needed
- p. 48r l. 118: ininiammatum: not in Latin word list — review needed
- p. 48r l. 119: inslammatus: not in Latin word list — review needed
- p. 48r l. 123: nosi: not in Latin word list — review needed
- p. 48r l. 124: dotestatem: not in Latin word list — review needed
- p. 48r l. 129: samctum: not in Latin word list — review needed

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_