### PR TITLE
Transcription corrections: cod-ve07v1_kzz7yh-a35437.xml (2 changes)

### DIFF
--- a/kzz7yh-a35437/cod-ve07v1_kzz7yh-a35437.xml
+++ b/kzz7yh-a35437/cod-ve07v1_kzz7yh-a35437.xml
@@ -232,11 +232,11 @@
           <head>Praeambulum</head> -->
         <p xml:id="kzz7yh-a35437-d1e470">
           <lb ed="#V" n="17"/>Distinctio. XVII 
-          <lb ed="#V" n="18"/>Unc de spiritu sancto videndum etc. 
+          <lb ed="#V" n="18"/>Nunc de spiritu sancto videndum etc. 
           Supe<lb ed="#V" n="19" break="no"/>rius determinauit magister de 
           tempo<lb ed="#V" n="20" break="no"/>rali processione spiritus sancti et eius missione per 
           <lb ed="#V" n="21"/>comparationem ad principium a quo: et ostendit 
-          <lb ed="#V" n="22"/>etiam fiium missum fuisse visibiliter et inuisibiliter.
+          <lb ed="#V" n="22"/>etiam filium missum fuisse visibiliter et inuisibiliter.
         </p>
         <p xml:id="kzz7yh-a35437-d1e486">
           ¶ 


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve07v1_kzz7yh-a35437.xml`.

## Applied changes

- p. 53r l. 18: Unc: not in Latin word list — review needed
- p. 53r l. 22: fiium: not in Latin word list — review needed

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_