### PR TITLE
Transcription corrections: cod-ve07v1_kzz7yh-a36910.xml (1 change)

### DIFF
--- a/kzz7yh-a36910/cod-ve07v1_kzz7yh-a36910.xml
+++ b/kzz7yh-a36910/cod-ve07v1_kzz7yh-a36910.xml
@@ -76,7 +76,7 @@
           <lb ed="#V" n="29"/>sermo extendendus nec proferendus nisi cum sana 
           deter<lb ed="#V" n="30" break="no"/>minatione. (Cui innascibilitatis.) Tunc expone sic. cui id est 
           <lb ed="#V" n="31"/>filio. (Innascibilitatis id est patris qui est innascibilis. (
-          Im<lb ed="#V" n="32" break="no"/>partit.) idest dat. (Esse imaginem sacram natiuitatis.) idest 
+          Im<lb ed="#V" n="32" break="no"/>partit.) id est dat. (Esse imaginem sacram natiuitatis.) idest 
           <lb ed="#V" n="33"/>sacra et secreta natiuitatis.
         </p>
         <p xml:id="kzz7yh-a36910-d1e147">


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve07v1_kzz7yh-a36910.xml`.

## Applied changes

- p. 54v l. 32: idest: not in Latin word list — review needed

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_