### PR TITLE
Transcription corrections: cod-ve07v1_kzz7yh-a39614.xml (15 changes)

### DIFF
--- a/kzz7yh-a39614/cod-ve07v1_kzz7yh-a39614.xml
+++ b/kzz7yh-a39614/cod-ve07v1_kzz7yh-a39614.xml
@@ -470,7 +470,7 @@
             <lb ed="#V" n="79"/>pluribus speribus elicitis ex charitate. Pro quibus operibus: 
             <lb ed="#V" n="80"/>homo etiam guo ad praemium essentiale remunerabitur. Premium enim 
             <lb ed="#V" n="81"/>essentiale correspondebit non tantummodo habitui charitatis 
-            <lb ed="#V" n="82"/>vie: sed etam habitibus et actibus simul.
+            <lb ed="#V" n="82"/>vie: sed etiam habitibus et actibus simul.
           </p>
           <p xml:id="kzz7yh-a39614-d1e854">
             ¶ Ad 2m cum 
@@ -855,7 +855,7 @@
             quali<lb ed="#V" n="78" break="no"/>tate totus eius feruor tolleretur etc. Dicunt aliqui quod non opoe: 
             <lb ed="#V" n="79"/>quia semper nouus feruor generatur: quamdiu manet ipse 
             habi<lb ed="#V" n="80" break="no"/>tus: qui est radix feruori illius: sicut cum herba abscinditur 
-            <lb ed="#V" n="81"/>de radice remanente pusulat alia. Potest et aliter dici secundum 
+            <lb ed="#V" n="81"/>de radice remanente pululat alia. Potest et aliter dici secundum 
             <lb ed="#V" n="82"/>alios quod feruor charitatis aut nominat frequentationem actus 
             <lb ed="#V" n="83"/>aut intensionem actus: aut promptitudinem ad actum. 
             Inten<lb ed="#V" n="84" break="no"/>sio autem in actu diligendi et promptitudo non tantum est ex 

--- a/kzz7yh-a39614/cod-ve07v1_kzz7yh-a39614.xml
+++ b/kzz7yh-a39614/cod-ve07v1_kzz7yh-a39614.xml
@@ -120,7 +120,7 @@
             auge<lb ed="#V" n="106" break="no"/>ri.
           </p>
           <p xml:id="kzz7yh-a39614-d1e203">
-            ¶ Item experimnto didicimus quod actus charitati augetur in 
+            ¶ Item experimento didicimus quod actus charitati augetur in 
             no<lb ed="#V" n="107" break="no"/>bis: sed actus proportionatur habitibus. ergo habitus charitati augetur. 
           </p>
           <p xml:id="kzz7yh-a39614-d1e208">
@@ -177,7 +177,7 @@
         </div>
         <div xml:id="kzz7yh-a39614-Dd1e304">
           <head xml:id="kzz7yh-a39614-Hd1e306">Quaestio 2</head>
-          <head xml:id="kzz7yh-a39614-Hd1e318" type="question-title">Utrum charitas augetur per addititonem nove charitatis</head>
+          <head xml:id="kzz7yh-a39614-Hd1e318" type="question-title">Utrum charitas augetur per additionem nove charitatis</head>
           <p xml:id="kzz7yh-a39614-d1e308">
             <lb ed="#V" n="10"/>¶ Questio. II. 
             <lb ed="#V" n="11"/>SEcundo queritur. Utrum charitas 
@@ -376,7 +376,7 @@
             <lb ed="#V" n="15"/>sit de essentia in gradu cui sit additio quam in gradu addito 
             <lb ed="#V" n="16"/>Et videtur primus gradus plus habere de ratione 
             possibili<lb ed="#V" n="17" break="no"/>tatis: vel saltem hoc certum est quod in charitate constituta ex 
-            praeceden<lb ed="#V" n="18" break="no"/>te. et gradu addito non tanummodo ibi est plus de essentia 
+            praeceden<lb ed="#V" n="18" break="no"/>te. et gradu addito non tantummodo ibi est plus de essentia 
             cha<lb ed="#V" n="19" break="no"/>ritatis quam antea: sed imperfectius saluatur ibi diffinitio charitatis 
             <lb ed="#V" n="20"/>quam antea: quod non posset dici de linea: ita enim perfecte 
             <lb ed="#V" n="21"/>saluatur diffinitio linee in linea bipedali: sicut tripedali. 
@@ -469,25 +469,25 @@
             <lb ed="#V" n="78"/>efficitur etc. Dico quod non est verum secundum quod magis charus dicitur a 
             <lb ed="#V" n="79"/>pluribus speribus elicitis ex charitate. Pro quibus operibus: 
             <lb ed="#V" n="80"/>homo etiam guo ad praemium essentiale remunerabitur. Premium enim 
-            <lb ed="#V" n="81"/>essentiale cdorrespondebit non tantummodo habitui charitatis 
+            <lb ed="#V" n="81"/>essentiale correspondebit non tantummodo habitui charitatis 
             <lb ed="#V" n="82"/>vie: sed etam habitibus et actibus simul.
           </p>
           <p xml:id="kzz7yh-a39614-d1e854">
             ¶ Ad 2m cum 
             di<lb ed="#V" n="83" break="no"/>quod per qualibet actum charitatis charitas inest anime 
             perfe<lb ed="#V" n="84" break="no"/>ctius etc. Dico quod inesse perfectius potest intelligi dupliciter. 
-            <lb ed="#V" n="85"/>Unomodo vt idem sit quod firmius inesse: et sic per quemlibet 
-            <lb ed="#V" n="86"/>actum chrritatis charitas inest anime perfectius. Sed sic 
+            <lb ed="#V" n="85"/>Uno modo vt idem sit quod firmius inesse: et sic per quemlibet 
+            <lb ed="#V" n="86"/>actum charitatis charitas inest anime perfectius. Sed sic 
             acci<lb ed="#V" n="87" break="no"/>piendo inesse perfectius non est verum: quod quandocumque charitas 
-            <lb ed="#V" n="88"/>inest perfactius quod augeatur. Alio modo vt idem sit quod inesse 
+            <lb ed="#V" n="88"/>inest perfectius quod augeatur. Alio modo vt idem sit quod inesse 
             <lb ed="#V" n="89"/>intensius. et sic non est verum quod per quemlibet actum 
             cha<lb ed="#V" n="90" break="no"/>ritatis charitas insit perfectius: sic enim oporteret quod in 
-            <lb ed="#V" n="91"/>actu quoibet augeretur.
+            <lb ed="#V" n="91"/>actu quolibet augeretur.
           </p>
           <p xml:id="kzz7yh-a39614-d1e876">
             ¶ Ad tertium cum dicitur quod 
             <lb ed="#V" n="92"/>per quemlibet actum dilectionis acquisite habitus illius 
-            <lb ed="#V" n="93"/>dilections augetur etc. Dicunt aliqui quod falsum est: nisi 
+            <lb ed="#V" n="93"/>dilectionis augetur etc. Dicunt aliqui quod falsum est: nisi 
             <lb ed="#V" n="94"/>loquendo de illo actu correspondente habitui quantum 
             <lb ed="#V" n="95"/>ad intensionem. dicunt enim quod per actus debiliores ille 
             ha<lb ed="#V" n="96" break="no"/>bitus non augetur quamuis per tales actus non prohibeantur 
@@ -601,7 +601,7 @@
             ca<lb ed="#V" n="32" break="no"/>pacior efficitur. Et ideo quanto plus recipit: tanto plus potest 
             <lb ed="#V" n="33"/>recipere: quia non est simile de capacitate rerum spiritualiu: et rerum 
             <lb ed="#V" n="34"/>materialium: quia capacitas rerum materialium limitatur ex materia. et ideo 
-            <lb ed="#V" n="35"/>uon possunt recipere nisi secundum exigentiam materie: sed 
+            <lb ed="#V" n="35"/>non possunt recipere nisi secundum exigentiam materie: sed 
             substan<lb ed="#V" n="36" break="no"/>tie spirituales non limitantur ex materia: sed magis secundum 
             quanti<lb ed="#V" n="37" break="no"/>tatem diuine bonitatis in eis percepte. Et ideo quanto plus 
             <lb ed="#V" n="38"/>additur de bonitate: tanto magis est de potentia ad 
@@ -667,8 +667,8 @@
             <lb ed="#V" n="83"/>charitatem magis est apta ad susceptionem amplioris 
             charita<lb ed="#V" n="84" break="no"/>tis quam quando nihil habebat de charitate etc. Dico quod non 
             <lb ed="#V" n="85"/>tantum potest capere quantum posset: si nihil de ea haberet: tamen 
-            <lb ed="#V" n="86"/>magis apta est et digna vt sibi detur illud quod potest cape 
-            <lb ed="#V" n="87"/>re quam antequam nihil haberet sicut res calefacta non tantum potest 
+            <lb ed="#V" n="86"/>magis apta est et digna vt sibi detur illud quod potest 
+            cape<lb ed="#V" n="87" break="no"/>re quam antequam nihil haberet sicut res calefacta non tantum potest 
             <lb ed="#V" n="88"/>adhuc capere de caliditate quantum si nihil haberet: quia 
             <lb ed="#V" n="89"/>antequam nihil haberet: poterat capere caliditatem: quam 
             mo<lb ed="#V" n="90" break="no"/>do habet: et illud quod residuum est: tamen cum est calefacta 
@@ -750,7 +750,7 @@
           <p xml:id="kzz7yh-a39614-d1e1361">
             ¶ Item Aug. lib. 83. q. q. 36. Perfectio 
             cha<lb ed="#V" n="4" break="no"/>ritatis est nulla cupiditas. ergo imperfectio charitatis 
-            ali<lb ed="#V" n="5" break="no"/>qua cupiditas. ergo quandoncumque cupiditas augetur que 
+            ali<lb ed="#V" n="5" break="no"/>qua cupiditas. ergo quandocumque cupiditas augetur que 
             totali<lb ed="#V" n="6" break="no"/>ter charitatem non destruit: ipsa charitas minuitur.
           </p>
           <p xml:id="kzz7yh-a39614-d1e1371">
@@ -799,7 +799,7 @@
             <lb ed="#V" n="35"/>tribuit cum homo de congruo per liberum arbitrium se disponit: 
             <lb ed="#V" n="36"/>sed charitatem datam: seu aliquid de eius essentia conseruare non 
             <lb ed="#V" n="37"/>desinit: nisi quando homo se totaliter per auersionem indignum 
-            cha<lb ed="#V" n="38" break="no"/>ritate reddit. Et tunc deus totancharitatem illorum conseruare 
+            cha<lb ed="#V" n="38" break="no"/>ritate reddit. Et tunc deus totam charitatem illorum conseruare 
             <lb ed="#V" n="39"/>desinit. et sic non minuitur: sed destruitur. Ex quo patet 
             consequen<lb ed="#V" n="40" break="no"/>ter quod per peccatum mortale non minuitur: sed destruitur. 
             Pa<lb ed="#V" n="41" break="no"/>tet etiam vlterius quod per peccatum veniale essentia 
@@ -873,7 +873,7 @@
             ca<lb ed="#V" n="96" break="no"/>lor secundum quantitatem: in iuuenibus vero secundum qualitatem. hoc est 
             di<lb ed="#V" n="97" break="no"/>ctu quod in iuuenibus magis est acutus secundum quod exponit 
             ci<lb ed="#V" n="98" break="no"/>to post. et huius signum est: quia magis sunt dispositi ad 
-            infu<lb ed="#V" n="99" break="no"/>mitates que veniut ex calida et sicca causa.
+            infu<lb ed="#V" n="99" break="no"/>mitates que veniunt ex calida et sicca causa.
           </p>
           <p xml:id="kzz7yh-a39614-d1e1604">
             ¶ Ad 4m cum 
@@ -903,7 +903,7 @@
             <lb ed="#V" n="118"/>liter consumeretur cum certa demonstratione possit ostendi 
             an<lb ed="#V" n="119" break="no"/>gulum rectilineum quantumcumque paruum esse maiorem angulo 
             <lb ed="#V" n="120"/>contingentie. Uel potest dici quod supposita veritate propositionis 
-            <lb ed="#V" n="121"/>philosophi generaliter quod adhuc secundum istam opiionem non sequeretur 
+            <lb ed="#V" n="121"/>philosophi generaliter quod adhuc secundum istam opinionem non sequeretur 
             cha<lb ed="#V" n="122" break="no"/>ritatem posse destrui nisi interueniente peccato mortali: quia 
             <lb ed="#V" n="123"/>per quodlibet peccatum veniale non diminuitur aliquid de 
             essen<lb ed="#V" n="124" break="no"/>tia charitatis: sed postquam praecesserunt multa venialia: 


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve07v1_kzz7yh-a39614.xml`.

## Applied changes

- p. 58v l. 106: experimnto: not in Latin word list — review needed
- p. 59r l. 9: addititonem: not in Latin word list — review needed
- p. 59v l. 18: tanummodo: not in Latin word list — review needed
- p. 59v l. 81: cdorrespondebit: not in Latin word list — review needed
- p. 59v l. 85: Unomodo: not in Latin word list — review needed
- p. 59v l. 86: chrritatis: not in Latin word list — review needed
- p. 59v l. 88: perfactius: not in Latin word list — review needed
- p. 59v l. 91: quoibet: not in Latin word list — review needed
- p. 59v l. 93: dilections: not in Latin word list — review needed
- p. 60r l. 35: uon: not in Latin word list — review needed
- p. 60r l. 87: 'cape' + 're' split across line break without break="no" on lb n=87
- p. 60v l. 5: quandoncumque: not in Latin word list — review needed
- p. 60v l. 38: totancharitatem: not in Latin word list — review needed
- p. 60v l. 99: veniut: not in Latin word list — review needed
- p. 60v l. 121: opiionem: not in Latin word list — review needed

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_