### PR TITLE
Transcription corrections: cod-ve07v1_kzz7yh-a41973.xml (9 changes)

### DIFF
--- a/kzz7yh-a41973/cod-ve07v1_kzz7yh-a41973.xml
+++ b/kzz7yh-a41973/cod-ve07v1_kzz7yh-a41973.xml
@@ -79,7 +79,7 @@
           <lb ed="#V" n="85"/>omnia alia dona.
         </p>
         <p xml:id="kzz7yh-a41973-d1e137">
-          ¶ Sexto vtrum spitus sanctus possit dici 
+          ¶ Sexto vtrum spiritus sanctus possit dici 
           do<lb ed="#V" n="86" break="no"/>num nostrum et spiritus noster.
         </p>
         <p xml:id="kzz7yh-a41973-d1e142">
@@ -314,7 +314,7 @@
             <lb ed="#V" n="115"/>proprietas idem sunt secundum rem. Sed loquendo de identitate 
             <lb ed="#V" n="116"/>secundum rationem: si ablatiuus dicit habitudinem quod in ratione forme: sic 
             <lb ed="#V" n="117"/>non eo donum est quo deus: quia deitate deus est: et 
-            proprieta<lb ed="#V" n="118" break="no"/>te donum. Proprietas autem et essentia secundum rationem differut: si autem 
+            proprieta<lb ed="#V" n="118" break="no"/>te donum. Proprietas autem et essentia secundum rationem differunt: si autem 
             <lb ed="#V" n="119"/>ablatiuus importet habitudinem principiationis: sic eo donum 
             <lb ed="#V" n="120"/>est quo deus: quia processionem habet et essentiam et proprietatem. 
           </p>
@@ -395,7 +395,7 @@
             <lb ed="#V" n="30"/>non. sic se habet donum ad dari: sicut verbum ad proferri. Sed 
             <lb ed="#V" n="31"/>ita debes concludere: filius non fuit verbum antequam proferretur. 
             <lb ed="#V" n="32"/>ergo spiritus sanctus non fuit donum antequam procederet per talem 
-            <lb ed="#V" n="33"/>modum: quod sibi ex suo modo procedendi conuenitus prima 
+            <lb ed="#V" n="33"/>modum: quod sibi ex suo modo procedendi conuenitur prima 
             ra<lb ed="#V" n="34" break="no"/>tio doni que est amor: ex hoc enim habet quod sit donum.
           </p>
           <p xml:id="kzz7yh-a41973-d1e713">
@@ -486,7 +486,7 @@
           <p xml:id="kzz7yh-a41973-d1e864">
             ¶ Ad 3m cum dicitur quod filius non videtur esse datus 
             <lb ed="#V" n="88"/>per spiritum sanctum etc. Dico quod immo: nec tamen propter 
-            <lb ed="#V" n="89"/>hoc oportet quod habeat auctolitatem super filium sed super 
+            <lb ed="#V" n="89"/>hoc oportet quod habeat auctoritatem super filium sed super 
             <lb ed="#V" n="90"/>effectum per donationem filii connotatum scilicet super 
             effe<lb ed="#V" n="91" break="no"/>ctum incarnationis.
           </p>
@@ -572,7 +572,7 @@
           </p>
           <p xml:id="kzz7yh-a41973-d1e1017">
             ¶ 
-            Ra<lb ed="#V" n="5" break="no"/>tio autem quare spiritus sanctus est noster: est: quia tunc hoec pronomen 
+            Ra<lb ed="#V" n="5" break="no"/>tio autem quare spiritus sanctus est noster: est: quia tunc haec pronomen 
             <lb ed="#V" n="6"/>noster dicit habitudinem talem spiritus sancti ad nos qualem habet 
             <lb ed="#V" n="7"/>habitum respectu habentis. Omnes autem iusti habent 
             spiritu<lb ed="#V" n="8" break="no"/>sanctum. Unde Aug. 15 de trini. c. 19. dicit de donis quod ipsum 
@@ -592,8 +592,8 @@
             habi<lb ed="#V" n="20" break="no"/>tudinem talem qualem habet habitum respectu habentis. quamuis 
             <lb ed="#V" n="21"/>autem spiritus sanctus a nobis non possideatur: tamen a nobis 
             <lb ed="#V" n="22"/>habetur et ideo aliquo modo potest dici spiritus sanctus est 
-            no<lb ed="#V" n="23" break="no"/>ster. Quando aute adiungitur alicui non mediante 
-            compositio<lb ed="#V" n="24" break="no"/>ne: vt cum dicimus amcus noster: tunc importat 
+            no<lb ed="#V" n="23" break="no"/>ster. Quando autem adiungitur alicui non mediante 
+            compositio<lb ed="#V" n="24" break="no"/>ne: vt cum dicimus amicus noster: tunc importat 
             habi<lb ed="#V" n="25" break="no"/>tudinem secundum exigentiam termini cui adiungitur. Unde cum 
             di<lb ed="#V" n="26" break="no"/>citur spiritus noster importat talem habitudinem qualem hoc 
             <lb ed="#V" n="27"/>spirans ad illud in quod spirat vel qualem habet in spiratum 
@@ -631,7 +631,7 @@
             <lb ed="#V" n="46"/>SEptimo queritur. Utrum spiritus sanctus a 
             <lb ed="#V" n="47"/>patre detur ipsi filio. Et 
             vide<lb ed="#V" n="48" break="no"/>tur quod sic: quia quod procedit secundum rationem amoris 
-            proce<lb ed="#V" n="49" break="no"/>dit vt donum: sed spitus sanctus procedit a patre in 
+            proce<lb ed="#V" n="49" break="no"/>dit vt donum: sed spiritus sanctus procedit a patre in 
             <lb ed="#V" n="50"/>filium: vt amor. ergo in procedendo a patre in filium 
             <lb ed="#V" n="51"/>datur filio.
           </p>
@@ -713,7 +713,7 @@
             <lb ed="#V" n="99"/>propter hoc potest dici habere spiritum sanctum eo modo quo habet 
             <lb ed="#V" n="100"/>vim spiratiuam: et alia que ad similitudinem forme sunt in 
             <lb ed="#V" n="101"/>eo. Unde non ita proprie dici potest quod pater generando dedit 
-            <lb ed="#V" n="102"/>filio spiritum sactum: sicut quod dedit filio vim spiratiuam per quam a deo 
+            <lb ed="#V" n="102"/>filio spiritum sanctum: sicut quod dedit filio vim spiratiuam per quam a deo 
             <lb ed="#V" n="103"/>procedit spiritus sanctus.
           </p>
           <p xml:id="kzz7yh-a41973-d1e1281">

--- a/kzz7yh-a41973/cod-ve07v1_kzz7yh-a41973.xml
+++ b/kzz7yh-a41973/cod-ve07v1_kzz7yh-a41973.xml
@@ -454,10 +454,9 @@
             <lb ed="#V" n="64"/>est spiritui sancto appropriatur: eo quod sibi ex suo modo 
             proce<lb ed="#V" n="65" break="no"/>dendi conuenit. prima ratio doni: vt supra visum est: nec 
             <lb ed="#V" n="66"/>tamen datur simpliciter cum quolibet dono suo: sed tantum cum 
-            <lb ed="#V" n="67"/>charitate. semper enim cum datur charitas: datur et ¬ 
+            <lb ed="#V" n="67"/>charitate. semper enim cum datur charitas: datur et
             <!--00139.xml-->
-            <cb ed="#P" n="b"/>
-            spiri<lb ed="#V" n="68" break="no"/>tus sanctus: quod satis patet ex verbo apostoli ad <ref xml:id="kzz7yh-a41973-Rd1e854">Rom. 5</ref> dicens: 
+            spiri<cb ed="#P" n="b"/><lb ed="#V" n="68" break="no"/>tus sanctus: quod satis patet ex verbo apostoli ad <ref xml:id="kzz7yh-a41973-Rd1e854">Rom. 5</ref> dicens: 
             <lb ed="#V" n="69"/><quote xml:id="kzz7yh-a41973-Qd1e858" source="http://scta.info/resource/rom5_5@6-19">Charitas dei diffusa est in cordibus nostris per spiritum 
               <lb ed="#V" n="70"/>sanctum qui datus est nobis</quote>. Ecce hic dicit simul 
             chari<lb ed="#V" n="71" break="no"/>tatem datam: et spiritum sanctum datum.

--- a/kzz7yh-a41973/cod-ve07v1_kzz7yh-a41973.xml
+++ b/kzz7yh-a41973/cod-ve07v1_kzz7yh-a41973.xml
@@ -454,10 +454,10 @@
             <lb ed="#V" n="64"/>est spiritui sancto appropriatur: eo quod sibi ex suo modo 
             proce<lb ed="#V" n="65" break="no"/>dendi conuenit. prima ratio doni: vt supra visum est: nec 
             <lb ed="#V" n="66"/>tamen datur simpliciter cum quolibet dono suo: sed tantum cum 
-            <lb ed="#V" n="67"/>charitate. semper enim cum datur charitas: datur et spiri¬ 
+            <lb ed="#V" n="67"/>charitate. semper enim cum datur charitas: datur et ¬ 
             <!--00139.xml-->
             <cb ed="#P" n="b"/>
-            <lb ed="#V" n="68"/>tus sanctus: quod satis patet ex verbo apostoli ad <ref xml:id="kzz7yh-a41973-Rd1e854">Rom. 5</ref> dicens: 
+            spiri<lb ed="#V" n="68" break="no"/>tus sanctus: quod satis patet ex verbo apostoli ad <ref xml:id="kzz7yh-a41973-Rd1e854">Rom. 5</ref> dicens: 
             <lb ed="#V" n="69"/><quote xml:id="kzz7yh-a41973-Qd1e858" source="http://scta.info/resource/rom5_5@6-19">Charitas dei diffusa est in cordibus nostris per spiritum 
               <lb ed="#V" n="70"/>sanctum qui datus est nobis</quote>. Ecce hic dicit simul 
             chari<lb ed="#V" n="71" break="no"/>tatem datam: et spiritum sanctum datum.


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve07v1_kzz7yh-a41973.xml`.

## Applied changes

- p. 62r l. 85: spitus: not in Latin word list — review needed
- p. 62v l. 118: differut: not in Latin word list — review needed
- p. 63r l. 33: conuenitus: not in Latin word list — review needed
- p. 63r l. 89: auctolitatem: not in Latin word list — review needed
- p. 63v l. 5: hoec: not in Latin word list — review needed
- p. 63v l. 23: aute → aure: not in word list (OCR transform matched)
- p. 63v l. 24: amcus: not in Latin word list — review needed
- p. 63v l. 49: spitus: not in Latin word list — review needed
- p. 63v l. 102: sactum → sacrum: t/r transposition; spiratiuam: not in Latin word list — review needed

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_