### PR TITLE
Transcription corrections: cod-ve07v1_kzz7yh-a45695.xml (13 changes)

### DIFF
--- a/kzz7yh-a45695/cod-ve07v1_kzz7yh-a45695.xml
+++ b/kzz7yh-a45695/cod-ve07v1_kzz7yh-a45695.xml
@@ -152,12 +152,12 @@
             vni<lb ed="#V" n="16" break="no"/>tate ideo vere est in diuinis trinitas personarum. Et si dicis 
             vl<lb ed="#V" n="17" break="no"/>tra tres vnitates personales plures sunt quam vna: dico quod verum 
             <lb ed="#V" n="18"/>est: sed tamen non sunt plures in essentiam. Totum autem integrale plus 
-            <lb ed="#V" n="19"/>est in essentia quam aliqui eius pars: et omnio tres vnitates personales 
+            <lb ed="#V" n="19"/>est in essentia quam aliqui eius pars: et omnino tres vnitates personales 
             <lb ed="#V" n="20"/>non sunt totum integrale. Uides ergo ex praedictis: quod quuis in 
             di<lb ed="#V" n="21" break="no"/>uinis vere sit numerus personarum: tamen ille numerus de 
-            plena<lb ed="#V" n="22" break="no"/>ratione numeri dinuit: et ideo simpliciter ista non est concedenda quod in 
+            plena<lb ed="#V" n="22" break="no"/>ratione numeri diminuit: et ideo simpliciter ista non est concedenda quod in 
             <lb ed="#V" n="23"/>divinis sit totum numerale: sed numerus nisi cum hac additione 
-            perso<lb ed="#V" n="24" break="no"/>narum. Et expredictis patet solutio ad illam questionem 
+            perso<lb ed="#V" n="24" break="no"/>narum. Et ex predictis patet solutio ad illam questionem 
             <lb ed="#V" n="25"/>qua quaeri posset vtrum in divinis sit totum numerale.
           </p>
         </div>
@@ -184,7 +184,7 @@
           </p>
           <p xml:id="kzz7yh-a45695-d1e326">
             ¶ Item vniuersale et particulare differunt sicut commune 
-            <lb ed="#V" n="35"/>et proprium: sed in diuis est commne scilicet essentia et proprium scilicet proprietas 
+            <lb ed="#V" n="35"/>et proprium: sed in diuis est commune scilicet essentia et proprium scilicet proprietas 
             perso<lb ed="#V" n="36" break="no"/>nalis. Ergo in diuis est vniversale et particulare.
           </p>
           <p xml:id="kzz7yh-a45695-d1e334">
@@ -195,14 +195,14 @@
             <lb ed="#V" n="40"/>particulare.
           </p>
           <p xml:id="kzz7yh-a45695-d1e345">
-            ¶ Contra omnis natura in quae est vniversale et particlare est in genere 
-            <lb ed="#V" n="41"/>determinato: sed supertus ostensum est quod deus non est in genere: ergo in deo non est 
+            ¶ Contra omnis natura in quae est vniversale et particulare est in genere 
+            <lb ed="#V" n="41"/>determinato: sed superius ostensum est quod deus non est in genere: ergo in deo non est 
             <lb ed="#V" n="42"/>vniversale: nec particlalare.
           </p>
           <p xml:id="kzz7yh-a45695-d1e352">
             ¶ Item magister dic in littera nomine essentia non 
             signi<lb ed="#V" n="43" break="no"/>ficat genus nec nomine persone speciem. Dicit est postea in eadem. Di. 
-            <lb ed="#V" n="44"/>quod tres persone non sunt indiuidua: et essentia species: ergo ipsa essetia vniversale 
+            <lb ed="#V" n="44"/>quod tres persone non sunt indiuidua: et essentia species: ergo ipsa essentia vniversale 
             <lb ed="#V" n="45"/>non est.
           </p>
           <p xml:id="kzz7yh-a45695-d1e361">
@@ -238,7 +238,7 @@
             <lb ed="#V" n="70"/>quod non erat eis ex: fiunt enim vniuersale: et fiunt genus et 
             <lb ed="#V" n="71"/>difitera etc. nec est ipsa essentia: vt vniuersalis est informat 
             in<lb ed="#V" n="72" break="no"/>tellectum: sed eius similitudo qui representat ipsam essentiam 
-            <lb ed="#V" n="73"/>nonsub ratione qua vna numero vel plures numero. Unde 
+            <lb ed="#V" n="73"/>non sub ratione qua vna numero vel plures numero. Unde 
             <lb ed="#V" n="74"/>essentia vt vniuersalis est non est in intellectu subacntiectiue 
             ni<lb ed="#V" n="75" break="no"/>si sicut obiectum. Aliter enim non praedicaretur de pluribus habentibus 
             <lb ed="#V" n="76"/>esse reale extra animam. Nihil enim informans intellectum de talibus 
@@ -255,7 +255,7 @@
             <lb ed="#V" n="84"/>reale multiplicatur in indiuiduis: quapropter Abraam: Isaac: et 
             Ia<lb ed="#V" n="85" break="no"/>cob non possunt vere dici vnus homo: sed tres homines. 
             diuina<lb ed="#V" n="86" break="no"/>autem essentia secundum suum esse reale non multiplicatur in personis. 
-            <lb ed="#V" n="87"/>Unde pater et filius et spiritus sanctus non dicutur tres dii sed 
+            <lb ed="#V" n="87"/>Unde pater et filius et spiritus sanctus non dicuntur tres dii sed 
             <lb ed="#V" n="88"/>vnus deus: ergo diuina essentia non est aliquid vniuersale. 
           </p>
           <p xml:id="kzz7yh-a45695-d1e467">
@@ -298,7 +298,7 @@
             <lb ed="#V" n="117"/>quod quanto aliqua forma est simplicior: tanto est vniversalior etc. 
             <lb ed="#V" n="118"/>dico quod loquendo de vniuersali: quod dicitur vniuersale: quia 
             predi<lb ed="#V" n="119" break="no"/>cabile de pluribus numero differentibus secundum plenam rationem 
-            <lb ed="#V" n="120"/>numeri: de quo vniversali modo est sermo propotio habet veritatem 
+            <lb ed="#V" n="120"/>numeri: de quo vniversali modo est sermo proportio habet veritatem 
             <lb ed="#V" n="121"/>de illa forus que in suppositis nata est multiplicari. essentia 
             <lb ed="#V" n="122"/>vero diuina non est huiusmodni.
           </p>
@@ -390,7 +390,7 @@
             <lb ed="#V" n="37"/>intellecte: quarum quilibet vera vna tamen veritate scilicet illa quae deus est. 
             <!--TODO: insert paragraph break-->
             <lb ed="#V" n="38"/>Sed contra hoc sic potest argui: reprobi damnabuntur: et 
-            ele<lb ed="#V" n="39" break="no"/>cti saluabuntur praeter illud esse quod humerunt in deo ab 
+            ele<lb ed="#V" n="39" break="no"/>cti saluabuntur praeter illud esse quod habuerunt in deo ab 
             <lb ed="#V" n="40"/>eterno per suas rationes non habuerunt esse nisi esse intellecte. 
             <lb ed="#V" n="41"/>Certum est autem quod rationes eorum idem sunt re in deo sola 
             ratio<lb ed="#V" n="42" break="no"/>ne differentes: quia realiter idem sunt: quod ipse deus: vnde vere 
@@ -419,13 +419,13 @@
             <lb ed="#V" n="63"/>verus vel homo verus et diuina essentia vera. Sic etiam dico quod 
             <lb ed="#V" n="64"/>ab eterno non fuit nisi vna veritas secundum rem scilicet veritas diuine 
             <lb ed="#V" n="65"/>essentie: quia ab eterno non fuit aliqua essentia nisi diuina: et ideo 
-            <lb ed="#V" n="66"/>ab eteno non fuit aliqua veritas: prout attenditur in ipsa re 
+            <lb ed="#V" n="66"/>ab eterno non fuit aliqua veritas: prout attenditur in ipsa re 
             <lb ed="#V" n="67"/>nisi illa veritas qui est in diuina essentia: et illa non est nisi vna: 
             <lb ed="#V" n="68"/>quia realiter est idem quod ipsa essentia diuina quamuis autem ab 
             <!--00150.xml-->
             <cb ed="#P" n="b"/>
             <lb ed="#V" n="69"/>eterno non fuerit pluralitas veritatum: tamen ab eterno 
-            plu<lb ed="#V" n="70" break="no"/>res veritates fuerut intellecte: siue loquamur de veritate 
+            plu<lb ed="#V" n="70" break="no"/>res veritates fuerunt intellecte: siue loquamur de veritate 
             <lb ed="#V" n="71"/>secundum quod est in intellectu per comparationem ad rem: siue in re per 
             com<lb ed="#V" n="72" break="no"/>parationem ad intellectu. Sicut enim essentie omnium creaturarum 
             <lb ed="#V" n="73"/>ab eterno fuerunt intellecte a diuino intellectu: quamuis ab 

--- a/kzz7yh-a45695/cod-ve07v1_kzz7yh-a45695.xml
+++ b/kzz7yh-a45695/cod-ve07v1_kzz7yh-a45695.xml
@@ -60,7 +60,7 @@
           <lb ed="#V" n="100"/>illa in quibus est totum et pars. Et circa hec quaeruntur tria. 
         </p>
         <p xml:id="kzz7yh-a45695-d1e112">
-          <lb ed="#V" n="101"/>¶ Primo vtrumi dius sit totum integrale.
+          <lb ed="#V" n="101"/>¶ Primo vtrum dius sit totum integrale.
         </p>
         <p xml:id="kzz7yh-a45695-d1e117">
           ¶ 2o vtrum ibi 
@@ -75,7 +75,7 @@
           <p xml:id="kzz7yh-a45695-d1e129">
             <lb ed="#V" n="103"/>PRimo igitur ostendo quod in deo sit totum 
             integra<lb ed="#V" n="104" break="no"/>le. quia natura totius integralis est priori de omnibus 
-            <lb ed="#V" n="105"/>partibus suis simul et de nulla per se: sed sic se habet trininitas ad 
+            <lb ed="#V" n="105"/>partibus suis simul et de nulla per se: sed sic se habet <sic>trininitas</sic> ad 
             <lb ed="#V" n="106"/>personas ergo est totum integrale.
           </p>
           <p xml:id="kzz7yh-a45695-d1e140">
@@ -217,7 +217,7 @@
             <lb ed="#V" n="51"/>nominatur nomine vniversalitatis non est actu in aliquo esse reali extra 
             <lb ed="#V" n="52"/>intellectum: neque est in intellectu realiter informans: quamuis 
             <lb ed="#V" n="53"/>eius similitudine informetur intellectus. Unde suum esse 
-            sub<lb ed="#V" n="54" break="no"/>ratione qua sibi conuenit intentio supraedicta est diminutum esse 
+            sub<lb ed="#V" n="54" break="no"/>ratione qua sibi conuenit intentio supra dicta est diminutum esse 
             <lb ed="#V" n="55"/>quia sub ratione praedicta suum esse est apprehendi ab intellectu: vel 
             re<lb ed="#V" n="56" break="no"/>pesentari intellectui non sub ratione vnitatis: neque sub ratione 
             <lb ed="#V" n="57"/>multitudinis: et ideo vt sic intellectam noni repugnat sibi 

--- a/kzz7yh-a45695/cod-ve07v1_kzz7yh-a45695.xml
+++ b/kzz7yh-a45695/cod-ve07v1_kzz7yh-a45695.xml
@@ -60,7 +60,7 @@
           <lb ed="#V" n="100"/>illa in quibus est totum et pars. Et circa hec quaeruntur tria. 
         </p>
         <p xml:id="kzz7yh-a45695-d1e112">
-          <lb ed="#V" n="101"/>¶ Primo vtrum dius sit totum integrale.
+          <lb ed="#V" n="101"/>¶ Primo vtrum in divinis sit totum integrale.
         </p>
         <p xml:id="kzz7yh-a45695-d1e117">
           ¶ 2o vtrum ibi 
@@ -217,7 +217,7 @@
             <lb ed="#V" n="51"/>nominatur nomine vniversalitatis non est actu in aliquo esse reali extra 
             <lb ed="#V" n="52"/>intellectum: neque est in intellectu realiter informans: quamuis 
             <lb ed="#V" n="53"/>eius similitudine informetur intellectus. Unde suum esse 
-            sub<lb ed="#V" n="54" break="no"/>ratione qua sibi conuenit intentio supra dicta est diminutum esse 
+            sub<lb ed="#V" n="54" break="no"/>ratione qua sibi conuenit intentio supradicta est diminutum esse 
             <lb ed="#V" n="55"/>quia sub ratione praedicta suum esse est apprehendi ab intellectu: vel 
             re<lb ed="#V" n="56" break="no"/>pesentari intellectui non sub ratione vnitatis: neque sub ratione 
             <lb ed="#V" n="57"/>multitudinis: et ideo vt sic intellectam noni repugnat sibi 


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve07v1_kzz7yh-a45695.xml`.

## Applied changes

- p. 68r l. 19: omnio: not in Latin word list — review needed
- p. 68r l. 22: dinuit: not in Latin word list — review needed
- p. 68r l. 24: expredictis: not in Latin word list — review needed
- p. 68r l. 35: commne: not in Latin word list — review needed
- p. 68r l. 40: particlare: not in Latin word list — review needed
- p. 68r l. 41: supertus: not in Latin word list — review needed
- p. 68r l. 44: essetia: not in Latin word list — review needed
- p. 68r l. 73: nonsub: not in Latin word list — review needed
- p. 68r l. 87: dicutur: not in Latin word list — review needed
- p. 68r l. 120: propotio: not in Latin word list — review needed
- p. 68v l. 39: humerunt: not in Latin word list — review needed
- p. 68v l. 66: eteno: not in Latin word list — review needed
- p. 68v l. 70: fuerut: not in Latin word list — review needed

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_