### PR TITLE
Transcription corrections: cod-ve07v1_kzz7yh-a47778.xml (14 changes)

### DIFF
--- a/kzz7yh-a47778/cod-ve07v1_kzz7yh-a47778.xml
+++ b/kzz7yh-a47778/cod-ve07v1_kzz7yh-a47778.xml
@@ -179,7 +179,7 @@
             <lb ed="#V" n="19"/>huiusmodi est quia nullus terius ad adiunctus substantiuo immediate 
             <lb ed="#V" n="20"/>quantum est de se dat intelligem compositioni virtute verborum: tamen ad 
             <lb ed="#V" n="21"/>veritatem propositionis in qua adiectiuum immediate adiungitur 
-            sub<lb ed="#V" n="22" break="no"/>stantiuo sequitur illa expotmo quandoque. Unde si dicam homo albus currit: 
+            sub<lb ed="#V" n="22" break="no"/>stantiuo sequitur illa expositio quandoque. Unde si dicam homo albus currit: 
             <lb ed="#V" n="23"/>sequitur hominem esse album quia non posset esse verum quod albus 
             ho<lb ed="#V" n="24" break="no"/>mo curreret nisi esset homo albus tamen non est veritate huius quod 
             <lb ed="#V" n="25"/>dico homo albus: quia si dicam homo albus non currit non implicatur 
@@ -266,7 +266,7 @@
           <p xml:id="kzz7yh-a47778-d1e468">
             <lb ed="#V" n="76"/>Ad primum in oppositum dico quod philosophus non intendebat negare quin 
             di<lb ed="#V" n="77" break="no"/>ctio exclusiua addita principio excludat principiatum 
-            <lb ed="#V" n="78"/>sed quod ponendo videtur tantum: quod est principium ponebant impossibitia: quia non est 
+            <lb ed="#V" n="78"/>sed quod ponendo videtur tantum: quod est principium ponebant impossibilia: quia non est 
             <lb ed="#V" n="79"/>principium nisi sit principiatum et perdictionem exclusiuam 
             additan<lb ed="#V" n="80" break="no"/>printia excludebant principiatum et ita ponebant et negabant prim 
             <lb ed="#V" n="81"/>cipiatum.
@@ -308,7 +308,7 @@
           </p>
           <p xml:id="kzz7yh-a47778-d1e541">
             ¶ Item substantia non 
-            <lb ed="#V" n="101"/>est rlautio etiam in diuinis quia sicut dicit Boetius in libro de tri. c. x. 
+            <lb ed="#V" n="101"/>est relatio etiam in diuinis quia sicut dicit Boetius in libro de tri. c. x. 
             <lb ed="#V" n="102"/>Substantia continet vnitatem relatio multiplicat trinitatem: sed deus 
             <lb ed="#V" n="103"/>signt substantiam: pater signat rlutionem. ergo deus non est pater: cum ergo 
             in<lb ed="#V" n="104" break="no"/>cludatur ab ista solus deus est pater: falsa est hec solus deus est patr. 
@@ -349,7 +349,7 @@
           </p>
           <p xml:id="kzz7yh-a47778-d1e617">
             ¶ Ad tertium 
-            di<lb ed="#V" n="130" break="no"/>co quod ralatio in divinis est comparata ad divinam substantiam realiter est idem 
+            di<lb ed="#V" n="130" break="no"/>co quod relatio in divinis est comparata ad divinam substantiam realiter est idem 
             <lb ed="#V" n="131"/>cum ea. Unde bene dicitur. diuina substantia est 
             pater<lb ed="#V" n="132" break="no"/>nitas comparata tamen ad relationem oppositam 
             distin<lb ed="#V" n="133" break="no"/>guitur ab ea vnde paternitas non est filiatio nec pater 
@@ -367,7 +367,7 @@
             <pb ed="#V" n="71-v"/>
             <cb ed="#P" n="a"/>
             <lb ed="#V" n="1"/>phylosophum ii. per hyer. Nomina et verba transposita idem 
-            <lb ed="#V" n="2"/>siguificat: sed hec est falsa trinitas est deus solus ergo et ista 
+            <lb ed="#V" n="2"/>significat: sed hec est falsa trinitas est deus solus ergo et ista 
             <lb ed="#V" n="3"/>trinitas est solus deus.
           </p>
           <p xml:id="kzz7yh-a47778-d1e655">
@@ -382,7 +382,7 @@
             ¶ Item propositio in qua hoc siguimentum 
             <lb ed="#V" n="9"/>omnis additur praedicato false est vnde false sunt iste homo est 
             <lb ed="#V" n="10"/>omnis homo: et omnis homo est omnis homo. ergo a simili et de hac 
-            distin<lb ed="#V" n="11" break="no"/>ctione solus cum sit nata esse dispotmo subiti in compositione ad 
+            distin<lb ed="#V" n="11" break="no"/>ctione solus cum sit nata esse dispositio subiti in compositione ad 
             praedi<lb ed="#V" n="12" break="no"/>catum sicut hoc signum omnis: sed in ista trinitas est solus deus 
             <lb ed="#V" n="13"/>hec dictio solus additur predicato: ergo est falsa. 
           </p>
@@ -393,7 +393,7 @@
           <p xml:id="kzz7yh-a47778-d1e689">
             ¶ Item hoc 
             <lb ed="#V" n="16"/>idem dicit magister in littera. Ait enim sic esse solum 
-            de<lb ed="#V" n="17" break="no"/>um dicimns patrem et filium et spiritum sanctum. 
+            de<lb ed="#V" n="17" break="no"/>um dicimus patrem et filium et spiritum sanctum. 
           </p>
           <p xml:id="kzz7yh-a47778-d1e696">
             <lb ed="#V" n="18"/>Respondeo quod iste quattuor differunt aliquo modo trinitas 
@@ -440,8 +440,8 @@
             ¶ Hec aut trinitas est vnus solus deus est vera: et 
             <lb ed="#V" n="54"/>omnibus aliis euidentius propria: tunc enim clarum est quid per eam ex 
             <lb ed="#V" n="55"/>cluditur. Excludit enim deorum pluralitatem: ita vt sit sensus: 
-            <lb ed="#V" n="56"/>trinitas est vnus deus tamen plures dii et sic expediebat dice 
-            <lb ed="#V" n="57"/>re contra aliquos hereticos qui ponebant tres personas esse tres 
+            <lb ed="#V" n="56"/>trinitas est vnus deus tamen plures dii et sic expediebat 
+            dice<lb ed="#V" n="57" break="no"/>re contra aliquos hereticos qui ponebant tres personas esse tres 
             <lb ed="#V" n="58"/>deos.
           </p>
           <p xml:id="kzz7yh-a47778-d1e792">
@@ -452,7 +452,7 @@
           </p>
           <p xml:id="kzz7yh-a47778-d1e801">
             <lb ed="#V" n="62"/>Ad primum in oppositum cum dicitur quod nomina et verba 
-            transpo<lb ed="#V" n="63" break="no"/>sita idem signunt etc. Dico quod in dictione 
+            transpo<lb ed="#V" n="63" break="no"/>sita idem signant etc. Dico quod in dictione 
             <lb ed="#V" n="64"/>exclusiua non habet veritatem ratione negationis implicite quia 
             <lb ed="#V" n="65"/>differunt preponere et postponere negationem ipsi 
             termi<lb ed="#V" n="66" break="no"/>no. Unde quamuis non differat dicere homo albus: albus homo: non 
@@ -464,8 +464,8 @@
           <p xml:id="kzz7yh-a47778-d1e824">
             ¶ Ad 2m cum dicitur quod hec propotio est falsa: 
             tri<lb ed="#V" n="69" break="no"/>nitas est ille qui solus est deus etc dico quod immo est vera: et cum 
-            <lb ed="#V" n="70"/>dicis quod hoc pronomen ille dicit aliquod suppsium dico quod verum est 
-            <lb ed="#V" n="71"/>vocando fuppsium ipsum quod est hoc est diuinam essentiam signatam 
+            <lb ed="#V" n="70"/>dicis quod hoc pronomen ille dicit aliquod suppositum dico quod verum est 
+            <lb ed="#V" n="71"/>vocando suppositum ipsum quod est hoc est diuinam essentiam signatam 
             <lb ed="#V" n="72"/>vt in suppositione: et sic signatur hoc nomen deus. Unde cum dicitur 
             <lb ed="#V" n="73"/>trinitas est ille qui solus est deus: sensus est: trinitas est ille 
             <lb ed="#V" n="74"/>deus qui solus est deus.
@@ -473,16 +473,16 @@
           <p xml:id="kzz7yh-a47778-d1e840">
             ¶ Ad tertium cum dicitur quod propotio est 
             fal<lb ed="#V" n="75" break="no"/>sa in qua hoc signum omnis additur praedicato. Unde ista est 
-            fal<lb ed="#V" n="76" break="no"/>sa: omnis homoest: omnis homo etc dico quod verum est: sed hoc non est: quod 
+            fal<lb ed="#V" n="76" break="no"/>sa: omnis homo est: omnis homo etc dico quod verum est: sed hoc non est: quod 
             <lb ed="#V" n="77"/>terminus in praedicato non posset stare nisi pro forma quia estimo 
-            <lb ed="#V" n="78"/>quod terminus siue aperte subieti siue a parte praedicati potest stare: vel 
+            <lb ed="#V" n="78"/>quod terminus siue aperte subiecti siue a parte praedicati potest stare: vel 
             pro<lb ed="#V" n="79" break="no"/>supposito vel pro forma et pro quocumque verificetur. propotio 
             vera<lb ed="#V" n="80" break="no"/>debet dici simpliciter est ergo ista falsa omnis homo est omnis homo quod 
             <lb ed="#V" n="81"/>et aperte subiecnti et aperte predicati distribuitur iste terminus homo 
             pro<lb ed="#V" n="82" break="no"/>omnibus suis suppositis: vnde sensus est quod Paulus est Petrum 
             <lb ed="#V" n="83"/>et Ioannes est Andreas. Et sic de omnibus aliis hominibus. Unde 
             <lb ed="#V" n="84"/>simpeliciter ista: omnis homo est omnis homo signtat vnum quenque hominiem: 
-            es<lb ed="#V" n="85" break="no"/>se quemliet hominem: quod falsum est. Unde aliquando hoc signum ominis 
+            es<lb ed="#V" n="85" break="no"/>se quemlibet hominem: quod falsum est. Unde aliquando hoc signum ominis 
             <lb ed="#V" n="86"/>potest addi praedicato et est propotio vera vt si dicam deus est omnis 
             <lb ed="#V" n="87"/>persona in creata quia deus est pater: deus est filius: deus est spiritus 
             <lb ed="#V" n="88"/>sanctus. Dico ergo quod hec dictio solus aliquando additur praeto: et est 

--- a/kzz7yh-a47778/cod-ve07v1_kzz7yh-a47778.xml
+++ b/kzz7yh-a47778/cod-ve07v1_kzz7yh-a47778.xml
@@ -189,7 +189,7 @@
           <p xml:id="kzz7yh-a47778-d1e331">
             <lb ed="#V" n="28"/>¶ Dico ergo ad quaestionem quod secundum ly solus tenetur sincathe 
             <lb ed="#V" n="29"/>goreumatice ista solus pater est pater: non hebetalium 
-            sensum<lb ed="#V" n="30" break="no"/>virtute verborum nisi istu pater est pater: et nullus alius a patre est 
+            sensum<lb ed="#V" n="30" break="no"/>virtute verborum nisi istum pater est pater: et nullus alius a patre est 
             <lb ed="#V" n="31"/>pater. et hoc verum est: si tamen virtute verborum heberet etiam istum 
             <lb ed="#V" n="32"/>sensum: Illle qui solus est pater est patr etiam in illo sensu vera 
             es<lb ed="#V" n="33" break="no"/>set. Unde secundum quod ly solus tenetur sincathegoreumatice. et ista 
@@ -199,13 +199,13 @@
             <lb ed="#V" n="35"/>Ad primum in oppositum cum dicitur quod dicendo solus pater est pater. Uidetur 
             <lb ed="#V" n="36"/>implicare solitudinem circa patrem etc. dico quod verum est: si 
             ly<lb ed="#V" n="37" break="no"/>solus acciperetur pro solitario. bene enim sequeretur solitarius 
-            <lb ed="#V" n="38"/>pater est patr. ergo pater est solitarius et in isto sensu propotio esset 
+            <lb ed="#V" n="38"/>pater est patr. ergo pater est solitarius et in isto sensu propositio esset 
             fal<lb ed="#V" n="39" break="no"/>sa propter falsam implicationem.
           </p>
           <p xml:id="kzz7yh-a47778-d1e362">
             ¶ Ad secundum cum dicitur quod cum hec 
             di<lb ed="#V" n="40" break="no"/>ctio solus adiungitur huic terimo pater simul iunguntur 
-            oppo<lb ed="#V" n="41" break="no"/>site signationes etc. dico quod non est verum secundum quodly solus non 
+            oppo<lb ed="#V" n="41" break="no"/>site signationes etc. dico quod non est verum secundum quodlibet solus non 
             di<lb ed="#V" n="42" break="no"/>cit solitudinem absolute circa patrem: sed respectu huius 
             praedi<lb ed="#V" n="43" break="no"/>cati quod est esse patrem. Non enim ista contradicunt quod. pater 
             <lb ed="#V" n="44"/>sit cum alio: et tamen nullus cum eo est pater.
@@ -249,7 +249,7 @@
           <p xml:id="kzz7yh-a47778-d1e433">
             <lb ed="#V" n="63"/>Respondeo quod si hec dictio solus accipiatur  
             cathego<lb ed="#V" n="64" break="no"/>reumatice sic a subiecto excludit consortium 
-            <lb ed="#V" n="65"/>simpliciter: et sub illo sensu propotio est falsa propter falsam praedicationem 
+            <lb ed="#V" n="65"/>simpliciter: et sub illo sensu propositio est falsa propter falsam praedicationem 
             <lb ed="#V" n="66"/>Si autem accipiatur secundum quod tenetur sincathegoreumatice sic 
             fa<lb ed="#V" n="67" break="no"/>cit exclusionem circa subiectum non simpliciter: sed respectu praedicati: 
             <lb ed="#V" n="68"/>vel compositionis implicite. sub hoc sensu: ille qui solus est pater est 
@@ -268,7 +268,7 @@
             di<lb ed="#V" n="77" break="no"/>ctio exclusiua addita principio excludat principiatum 
             <lb ed="#V" n="78"/>sed quod ponendo videtur tantum: quod est principium ponebant impossibilia: quia non est 
             <lb ed="#V" n="79"/>principium nisi sit principiatum et perdictionem exclusiuam 
-            additan<lb ed="#V" n="80" break="no"/>printia excludebant principiatum et ita ponebant et negabant prim 
+            additan<lb ed="#V" n="80" break="no"/>principio excludebant principiatum et ita ponebant et negabant prim 
             <lb ed="#V" n="81"/>cipiatum.
           </p>
           <p xml:id="kzz7yh-a47778-d1e484">
@@ -278,7 +278,7 @@
             <lb ed="#V" n="84"/>nouit filium nisi patur. quia per hanc dictione nemo non excluditur nisi 
             <lb ed="#V" n="85"/>illud quod est in essentia aliud a patre: sed per hanc dictionem 
             so<lb ed="#V" n="86" break="no"/>lus excluditur non tantummodo illud quod est aliud a patre in essentia 
-            <lb ed="#V" n="87"/>sed etiam illi qui sunt aliia patre in persona.
+            <lb ed="#V" n="87"/>sed etiam illi qui sunt alia patre in persona.
           </p>
           <p xml:id="kzz7yh-a47778-d1e500">
             ¶ Ad 3m cum dicitur quod 
@@ -331,7 +331,7 @@
           <p xml:id="kzz7yh-a47778-d1e582">
             <lb ed="#V" n="116"/>Ad primum in oppositum cum dicitur: quod ista solus pater est deus: quae 
             vi<lb ed="#V" n="117" break="no"/>detur esse conuersa istius est falsa etc. Dico quod illa solum 
-            <lb ed="#V" n="118"/>pater est deus non est illa: in quam conuertitur praedicta propotio cum enim 
+            <lb ed="#V" n="118"/>pater est deus non est illa: in quam conuertitur praedicta propositio cum enim 
             <lb ed="#V" n="119"/>sint plures: non debet conuerti vnica conuersione sed pluribus equal:m 
             <lb ed="#V" n="120"/>enim istis duabus: deus est pater: et nullus alius a deo est pater: 
             <lb ed="#V" n="121"/>et qualem istarum conuertitur in propositionem veram. Prima enim 
@@ -471,19 +471,19 @@
             <lb ed="#V" n="74"/>deus qui solus est deus.
           </p>
           <p xml:id="kzz7yh-a47778-d1e840">
-            ¶ Ad tertium cum dicitur quod propotio est 
+            ¶ Ad tertium cum dicitur quod propositio est 
             fal<lb ed="#V" n="75" break="no"/>sa in qua hoc signum omnis additur praedicato. Unde ista est 
             fal<lb ed="#V" n="76" break="no"/>sa: omnis homo est: omnis homo etc dico quod verum est: sed hoc non est: quod 
             <lb ed="#V" n="77"/>terminus in praedicato non posset stare nisi pro forma quia estimo 
             <lb ed="#V" n="78"/>quod terminus siue aperte subiecti siue a parte praedicati potest stare: vel 
-            pro<lb ed="#V" n="79" break="no"/>supposito vel pro forma et pro quocumque verificetur. propotio 
+            pro<lb ed="#V" n="79" break="no"/>supposito vel pro forma et pro quocumque verificetur. propositio 
             vera<lb ed="#V" n="80" break="no"/>debet dici simpliciter est ergo ista falsa omnis homo est omnis homo quod 
             <lb ed="#V" n="81"/>et aperte subiecnti et aperte predicati distribuitur iste terminus homo 
             pro<lb ed="#V" n="82" break="no"/>omnibus suis suppositis: vnde sensus est quod Paulus est Petrum 
             <lb ed="#V" n="83"/>et Ioannes est Andreas. Et sic de omnibus aliis hominibus. Unde 
             <lb ed="#V" n="84"/>simpeliciter ista: omnis homo est omnis homo signtat vnum quenque hominiem: 
             es<lb ed="#V" n="85" break="no"/>se quemlibet hominem: quod falsum est. Unde aliquando hoc signum ominis 
-            <lb ed="#V" n="86"/>potest addi praedicato et est propotio vera vt si dicam deus est omnis 
+            <lb ed="#V" n="86"/>potest addi praedicato et est propositio vera vt si dicam deus est omnis 
             <lb ed="#V" n="87"/>persona in creata quia deus est pater: deus est filius: deus est spiritus 
             <lb ed="#V" n="88"/>sanctus. Dico ergo quod hec dictio solus aliquando additur praeto: et est 
             <lb ed="#V" n="89"/>propotio falsa: aliquando additur praeto et est propotio vera sicut in proposito. 


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve07v1_kzz7yh-a47778.xml`.

## Applied changes

- p. 71r l. 22: expotmo: not in Latin word list — review needed
- p. 71r l. 78: impossibitia: not in Latin word list — review needed
- p. 71r l. 101: rlautio: not in Latin word list — review needed
- p. 71r l. 130: ralatio: not in Latin word list — review needed
- p. 71v l. 2: siguificat: not in Latin word list — review needed; hec: not in Latin word list — review needed
- p. 71v l. 11: dispotmo: not in Latin word list — review needed
- p. 71v l. 17: dicimns: not in Latin word list — review needed
- p. 71v l. 57: 'dice' + 're' split across line break without break="no" on lb n=57
- p. 71v l. 63: signunt: not in Latin word list — review needed
- p. 71v l. 70: suppsium: not in Latin word list — review needed
- p. 71v l. 71: fuppsium: not in Latin word list — review needed
- p. 71v l. 76: homoest: not in Latin word list — review needed
- p. 71v l. 78: subieti: not in Latin word list — review needed
- p. 71v l. 85: quemliet: not in Latin word list — review needed

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_