### PR TITLE
Transcription corrections: cod-ve07v1_kzz7yh-a48603.xml (1 change)

### DIFF
--- a/kzz7yh-a48603/cod-ve07v1_kzz7yh-a48603.xml
+++ b/kzz7yh-a48603/cod-ve07v1_kzz7yh-a48603.xml
@@ -204,7 +204,7 @@
         </p>
         <p xml:id="kzz7yh-a48603-d1e393">
           ¶ Primo agit de praedictis 
-          <lb ed="#V" n="93"/>nomibus in generali.
+          <lb ed="#V" n="93"/>nominibus in generali.
         </p>
         <p xml:id="kzz7yh-a48603-d1e398">
           ¶ Secundo de illis in speciali. xxiii. Di. ibi. 

--- a/kzz7yh-a48603/cod-ve07v1_kzz7yh-a48603.xml
+++ b/kzz7yh-a48603/cod-ve07v1_kzz7yh-a48603.xml
@@ -225,7 +225,7 @@
           regu<lb ed="#V" n="97" break="no"/>las de nominibus illis ibi. Certificandum est. Et ista in tres. 
         </p>
         <p xml:id="kzz7yh-a48603-d1e421">
-          <lb ed="#V" n="98"/>¶ In primo potesit differentiarum assignationem.
+          <lb ed="#V" n="98"/>¶ In prima potest differentiarum assignationem.
         </p>
         <p xml:id="kzz7yh-a48603-d1e426">
           ¶ In 2us affirmationem ibi. 


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve07v1_kzz7yh-a48603.xml`.

## Applied changes

- p. 72r l. 93: nomibus: not in Latin word list — review needed

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_