### PR TITLE
Transcription corrections: cod-ve07v1_kzz7yh-a50860.xml (3 changes)

### DIFF
--- a/kzz7yh-a50860/cod-ve07v1_kzz7yh-a50860.xml
+++ b/kzz7yh-a50860/cod-ve07v1_kzz7yh-a50860.xml
@@ -306,8 +306,8 @@
           <head>Praeambulum</head> -->
         <p xml:id="kzz7yh-a50860-d1e107">
           <lb ed="#V" n="99"/>PRedictis adunciendum est etc Superius 
-          de<lb ed="#V" n="100" break="no"/>terminauit magister de diuins 
-          <lb ed="#V" n="101"/>nonibus in generali. hic determinat de diuis nonibus 
+          de<lb ed="#V" n="100" break="no"/>terminauit magister de diuinis 
+          <lb ed="#V" n="101"/>nominibus in generali. hic determinat de diuis nonibus 
           <lb ed="#V" n="102"/>in speciali: et diuiditur pars ista in partes tris.
         </p>
         <p xml:id="kzz7yh-a50860-d1e628">
@@ -316,7 +316,7 @@
         </p>
         <p xml:id="kzz7yh-a50860-d1e634">
           ¶ In 2o de 
-          <lb ed="#V" n="104"/>nonibus numeralibus ibi. (hic diligenter inquiri oportet.)
+          <lb ed="#V" n="104"/>nominibus numeralibus ibi. (hic diligenter inquiri oportet.)
         </p>
         <p xml:id="kzz7yh-a50860-d1e639">
           ¶ In 3m 


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve07v1_kzz7yh-a50860.xml`.

## Applied changes

- p. 75v l. 100: diuins: not in Latin word list — review needed
- p. 75v l. 101: nonibus: not in Latin word list — review needed
- p. 75v l. 104: nonibus: not in Latin word list — review needed

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_