### PR TITLE
Transcription corrections: cod-ve07v1_kzz7yh-a52510.xml (19 changes)

### DIFF
--- a/kzz7yh-a52510/cod-ve07v1_kzz7yh-a52510.xml
+++ b/kzz7yh-a52510/cod-ve07v1_kzz7yh-a52510.xml
@@ -130,7 +130,7 @@
           </p>
           <p xml:id="kzz7yh-a52510-d1e226">
             ¶ Preterea vnitas dei et vnitas 
-            crea<lb ed="#V" n="27" break="no"/>ture noncostituunt numerum simpliciter: quia que constituunt 
+            crea<lb ed="#V" n="27" break="no"/>ture non constituunt numerum simpliciter: quia que constituunt 
             nume<lb ed="#V" n="28" break="no"/>rum simpliciter in aliquo vniuocantur: quia quecunque 
             simplici<lb ed="#V" n="29" break="no"/>ter numerantur sub aliquo communi numerantur. Nihil autem est 
             <lb ed="#V" n="30"/>vniuocum commune vnitati dei et vnitati creature. Unde non 
@@ -146,12 +146,12 @@
           <p xml:id="kzz7yh-a52510-d1e253">
             <lb ed="#V" n="37"/>¶ Ad 3m cum dicitur quod deus est numerus etc. dico quod ibi 
             acci<lb ed="#V" n="38" break="no"/>pitur numerus pro exemplari numeri. Unde Augu. 4 super gene. 
-            <lb ed="#V" n="39"/>longe post principium dicitur deus numerussine numero. 
+            <lb ed="#V" n="39"/>longe post principium dicitur deus numerus sine numero. 
           </p>
           <p xml:id="kzz7yh-a52510-d1e263">
             <lb ed="#V" n="40"/>¶ Ad 4m cum dicitur quod in deo est vnitas et vnitas etc. dico quod 
             <lb ed="#V" n="41"/>verum est: sed vnitas et vnitas non constituunt numerum 
-            sim<lb ed="#V" n="42" break="no"/>pliciter nisi sint vnitates separate inter se: ita quod nlla res vna 
+            sim<lb ed="#V" n="42" break="no"/>pliciter nisi sint vnitates separate inter se: ita quod nulla res vna 
             <lb ed="#V" n="43"/>numero sit de ratione vtriusque. Dina autem essentia realiter 
             <lb ed="#V" n="44"/>communis est tribus vnitatibus personalibus. Unde non sunt separate: quod 
             <lb ed="#V" n="45"/>attendens Boetius dicit. i. libo de triniate. ca. 3o quod in deo nullus 
@@ -182,7 +182,7 @@
           <p xml:id="kzz7yh-a52510-d1e313">
             ¶ Item secundum 
             <lb ed="#V" n="56"/>Phy. X. Metaphysice vnum est indiuisibile aut non 
-            diui<lb ed="#V" n="57" break="no"/>sum: in diuiso vero nihil ponit: sed remouerevidetur: ergo 
+            diui<lb ed="#V" n="57" break="no"/>sum: in diuiso vero nihil ponit: sed remouere videtur: ergo 
             <lb ed="#V" n="58"/>videtur quod vnitas in deo nihil ponit.
           </p>
           <p xml:id="kzz7yh-a52510-d1e323">
@@ -248,7 +248,7 @@
             <lb ed="#V" n="88"/>ratione vnitatis numeralis non consequitur ipsam essentiam secundum 
             <lb ed="#V" n="89"/>se et absolute intellectam: quia essentia potest a tali diuisione per 
             <lb ed="#V" n="90"/>intellectum abstrahi humanitas enim intellecta vt 
-            humani<lb ed="#V" n="91" break="no"/>tas tantum intelligitur vt quid determinabilem per vnitatatem vel 
+            humani<lb ed="#V" n="91" break="no"/>tas tantum intelligitur vt quid determinabilem per vnitatem vel 
             mul<lb ed="#V" n="92" break="no"/>titudinem. ergo oportet quod ipsa numeralis vnitas sit in ipsa 
             es<lb ed="#V" n="93" break="no"/>sentia que est vna res vel ratio positiua: vel ipsam 
             consequtur<lb ed="#V" n="94" break="no"/>ratione alicuius rei vel rationis positiue.
@@ -262,9 +262,9 @@
             <lb ed="#V" n="99"/>vna rem vel rationem positiuam: ideo dicunt aliqui quod vnitas 
             <lb ed="#V" n="100"/>super rem vnam addit rationem positiuam scilicet identitatem rei ad 
             <lb ed="#V" n="101"/>seipsam et si dicatur contra eos quod vna res est magis vna quam 
-            <lb ed="#V" n="102"/>alia: et tamen vna non est magis idem sibiipsi quam alia. 
+            <lb ed="#V" n="102"/>alia: et tamen vna non est magis idem sibi ipsi quam alia. 
             Sibiipsi<lb ed="#V" n="103" break="no"/>dicunt hoc esse falsum. Dicunt enim quod res que est magis 
-            <lb ed="#V" n="104"/>est vna magis est eadem sibiipsi quae illa que minus est vna sit 
+            <lb ed="#V" n="104"/>est vna magis est eadem sibi ipsi quae illa que minus est vna sit 
             <lb ed="#V" n="105"/>eadem sibupsi.
           </p>
           <p xml:id="kzz7yh-a52510-d1e457">
@@ -272,7 +272,7 @@
             <lb ed="#V" n="106"/>ipsi non tantum conuenit rei que est numero vna: sed etiam conue 
             <lb ed="#V" n="107"/>nit essentie intellecte praeter vnitatem et multitudinem 
             nume<lb ed="#V" n="108" break="no"/>ralem cui vt sic intellecta est: conuenit esse speciem vere enim 
-            <lb ed="#V" n="109"/>deus de specie hominis quod est eadem sibiipsi et quod non est eadem 
+            <lb ed="#V" n="109"/>deus de specie hominis quod est eadem sibi ipsi et quod non est eadem 
             <lb ed="#V" n="110"/>cum specie asini essentia: ergo idem igitur ipsi non est illud 
             <lb ed="#V" n="111"/>precise quod dicit: vnitas numeralis cum essentie quae est 
             nue<lb ed="#V" n="112" break="no"/>ro vna.
@@ -288,9 +288,9 @@
             ni<lb ed="#V" n="119" break="no"/>hil addit super speciem nisi indiuisionem. Unitas enim 
             huma<lb ed="#V" n="120" break="no"/>ne speciei est ipsa species humana sub ratione qua indiuisa in 
             <lb ed="#V" n="121"/>plures species: vnitas numeralis que conuenit Petro vel 
-            <lb ed="#V" n="122"/>Ioanni que proprie dicitur vnitas in diuidualis ponit super 
+            <lb ed="#V" n="122"/>Ioanni que proprie dicitur vnitas in indiuidualis ponit super 
             essenti<lb ed="#V" n="123" break="no"/>am rationem indiuiduationis sue que indiuiduatio super 
-            essen<lb ed="#V" n="124" break="no"/>tiam numero vnam ponit aliquid ab ea differnus secundum rem vel 
+            essen<lb ed="#V" n="124" break="no"/>tiam numero vnam ponit aliquid ab ea differens secundum rem vel 
             ratio<lb ed="#V" n="125" break="no"/>nem: quia ponit actualem existentiam etc. Eo enim ipso quo res actu 
             <lb ed="#V" n="126"/>existit: vna numero est. Unde Auice. 3. Metaphisi. c. iii. dicit 
             <lb ed="#V" n="127"/>quod esse est de essentia vnitatis. non subiectum. ei et quamuis 
@@ -333,7 +333,7 @@
             <lb ed="#V" n="22"/>positiuum super rem vnam: sed eius existentiam actualem: ideo 
             <lb ed="#V" n="23"/>si actualis existentia: diuine existentie ab ea non differt secundum 
             rem<lb ed="#V" n="24" break="no"/>vnitas eius que vere est singularis quamuis sibi non debeat 
-            <lb ed="#V" n="25"/>indidualis seu particularis vltra ipsam nihil. dicit positiuum 
+            <lb ed="#V" n="25"/>indiuidualis seu particularis vltra ipsam nihil. dicit positiuum 
             <lb ed="#V" n="26"/>differens ab ea secundum rem nec secundum rationem sicut vnitatem esse 
             <lb ed="#V" n="27"/>vnam nihil positiuum dicit vltra ipsam: sed ponit se tantum: et 
             <lb ed="#V" n="28"/>quia multi probabiliter ponunt diuinam essentiam et eius existentiam 
@@ -364,7 +364,7 @@
           <p xml:id="kzz7yh-a52510-d1e644">
             ¶ Ad 2m cum dicitur quod vnitas opponitur multitudini 
             <lb ed="#V" n="47"/>sicut priuatio habitui etc. dico quod hoc intelligendum est quantum 
-            <lb ed="#V" n="48"/>ad nostrum modum innotescendi et signndi: quia sicut dicit Aui. 
+            <lb ed="#V" n="48"/>ad nostrum modum innotescendi et signandi: quia sicut dicit Aui. 
             <lb ed="#V" n="49"/>3 libro Metaphy. c. 3. videtur quod multitudo notior sit apud nostram 
             <lb ed="#V" n="50"/>imaginationem quam vnum: et ideo vnitatem sigamus et 
             discribe<lb ed="#V" n="51" break="no"/>mus per remotionem diuisionis: quia tamen vnitas notior est quo 
@@ -397,7 +397,7 @@
             <cb ed="#P" n="b"/>
             <lb ed="#V" n="69"/>autem indiuisibilitate quodlibet indiuiduum est indisibile. Petrus 
             <lb ed="#V" n="70"/>enim diuidi non potest sine aliqua eius corruptione: nec 
-            vni<lb ed="#V" n="71" break="no"/>tas est constitutiua illius multitudis cuius est negatio quia non 
+            vni<lb ed="#V" n="71" break="no"/>tas est constitutiua illius multitudinis cuius est negatio quia non 
             <lb ed="#V" n="72"/>negat diuisionem nisi in re vna
           </p>
           <p xml:id="kzz7yh-a52510-d1e716">
@@ -442,15 +442,15 @@
           <p xml:id="kzz7yh-a52510-d1e776">
             ¶ Item 
             <lb ed="#V" n="91"/>omnia praedicamenta dicta de deo transeunt in substantiam praeterquam 
-            re<lb ed="#V" n="92" break="no"/>latio: vnde iustitia dicta de deo non materiet qualitas: sed rluatio in 
-            <lb ed="#V" n="93"/>deo manet rlautio ergo cum vnitas reducatur ad praedicamentum 
+            re<lb ed="#V" n="92" break="no"/>latio: vnde iustitia dicta de deo non materiet qualitas: sed relatio in 
+            <lb ed="#V" n="93"/>deo manet relatio ergo cum vnitas reducatur ad praedicamentum 
             <lb ed="#V" n="94"/>quantitatis ipsa dicta de deo transit in substantiam: non est 
             <lb ed="#V" n="95"/>ergo in deo vnitas nisi essentialis. 
           </p>
           <p xml:id="kzz7yh-a52510-d1e790">
             <lb ed="#V" n="96"/>Contra duo et tres plurificant significatum vnius sed non plurificant 
             <lb ed="#V" n="97"/>substantiam cum dicantur de deo quia secundum beatum Io. in 
-            prae<lb ed="#V" n="98" break="no"/>can. sua. c. 5 loquentem de patre et verbo et spiritusancto hi tres 
+            prae<lb ed="#V" n="98" break="no"/>can. sua. c. 5 loquentem de patre et verbo et spiritu sancto hi tres 
             <lb ed="#V" n="99"/>vnum sunt: ergo oportet in deo ponere aliquam vnitatem 
             perso<lb ed="#V" n="100" break="no"/>nalem.
           </p>
@@ -487,7 +487,7 @@
           <p xml:id="kzz7yh-a52510-d1e860">
             ¶ Ad 2m cum dicitur quod 
             <lb ed="#V" n="124"/>nihil personale commune est tribus personis etc. dico quod personale 
-            po<lb ed="#V" n="125" break="no"/>test signatri determinate: sicut per nomen paternitatis et filiationis 
+            po<lb ed="#V" n="125" break="no"/>test signari determinate: sicut per nomen paternitatis et filiationis 
             <lb ed="#V" n="126"/>vel indeterminate sicut per nomen persone et vnitatis. Primo 
             <lb ed="#V" n="127"/>modo nihil personale commune est tribus personis nec secundum rem nec 
             <lb ed="#V" n="128"/>secundum rationem: sed personale signatum. Secundo modo quamuis non 
@@ -497,11 +497,11 @@
           </p>
           <p xml:id="kzz7yh-a52510-d1e880">
             ¶ Ad 3m cum dicitur quod idem signt vnus et vnum etc. 
-            di<lb ed="#V" n="132" break="no"/>co quod propter modum signndi diuersum facta est appropriatio ita quod 
+            di<lb ed="#V" n="132" break="no"/>co quod propter modum signandi diuersum facta est appropriatio ita quod 
             <lb ed="#V" n="133"/>vnus secundum se dictu appropsiatur in diuinis ad signandum 
             vni<lb ed="#V" n="134" break="no"/>tatem personalem et vnum ad signndum vnitatem essentialem propter 
             <lb ed="#V" n="135"/>hoc quod masculinum genus signat per modum distinctum: et quod 
-            neu<lb ed="#V" n="136" break="no"/>trum genus signt indistincte. Sed tam vnus quam vnum cum 
+            neu<lb ed="#V" n="136" break="no"/>trum genus signat indistincte. Sed tam vnus quam vnum cum 
             <!--00170.xml-->
             <pb ed="#V" n="78-v"/>
             <cb ed="#P" n="a"/>

--- a/kzz7yh-a52510/cod-ve07v1_kzz7yh-a52510.xml
+++ b/kzz7yh-a52510/cod-ve07v1_kzz7yh-a52510.xml
@@ -141,7 +141,7 @@
             ali<lb ed="#V" n="35" break="no"/>qua contingit sub vno communi: de eis analogice dicto numerari. 
           </p>
           <p xml:id="kzz7yh-a52510-d1e248">
-            <lb ed="#V" n="36"/>¶ Ex dictis patet responsio ad duo primo argumta in oppositum. 
+            <lb ed="#V" n="36"/>¶ Ex dictis patet responsio ad duo prima argumenta in oppositum. 
           </p>
           <p xml:id="kzz7yh-a52510-d1e253">
             <lb ed="#V" n="37"/>¶ Ad 3m cum dicitur quod deus est numerus etc. dico quod ibi 
@@ -258,7 +258,7 @@
             di<lb ed="#V" n="95" break="no"/>uisio secundum rei veritatem est negatio vnum totum in partes 
             di<lb ed="#V" n="96" break="no"/>uidere est negatio coniunctionis pertium: sed indiuisio est 
             ne<lb ed="#V" n="97" break="no"/>gatio diuisionis: negatio autem negationis est affirmatio: ergo 
-            <lb ed="#V" n="98"/>in diuisio que est de ratione vnitatis potesit in essentia que est 
+            <lb ed="#V" n="98"/>in diuisio que est de ratione vnitatis ponit in essentia que est 
             <lb ed="#V" n="99"/>vna rem vel rationem positiuam: ideo dicunt aliqui quod vnitas 
             <lb ed="#V" n="100"/>super rem vnam addit rationem positiuam scilicet identitatem rei ad 
             <lb ed="#V" n="101"/>seipsam et si dicatur contra eos quod vna res est magis vna quam 


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve07v1_kzz7yh-a52510.xml`.

## Applied changes

- p. 77v l. 27: noncostituunt: not in Latin word list — review needed
- p. 77v l. 39: numerussine: not in Latin word list — review needed
- p. 77v l. 42: nlla: not in Latin word list — review needed
- p. 77v l. 57: remouerevidetur: not in Latin word list — review needed
- p. 77v l. 91: vnitatatem: not in Latin word list — review needed
- p. 77v l. 102: sibiipsi: not in Latin word list — review needed
- p. 77v l. 104: sibiipsi: not in Latin word list — review needed
- p. 77v l. 109: sibiipsi: not in Latin word list — review needed
- p. 77v l. 122: diuidualis: not in Latin word list — review needed
- p. 77v l. 124: differnus: not in Latin word list — review needed
- p. 78r l. 25: indidualis: not in Latin word list — review needed
- p. 78r l. 48: signndi: not in Latin word list — review needed
- p. 78r l. 71: multitudis: not in Latin word list — review needed
- p. 78r l. 92: rluatio: not in Latin word list — review needed
- p. 78r l. 93: rlautio: not in Latin word list — review needed
- p. 78r l. 98: spiritusancto: not in Latin word list — review needed
- p. 78r l. 125: signatri: not in Latin word list — review needed
- p. 78r l. 132: signndi: not in Latin word list — review needed
- p. 78r l. 136: signt: not in Latin word list — review needed; vnus: not in Latin word list — review needed; vnum: not in Latin word list — review needed

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_