### PR TITLE
Transcription corrections: cod-ve07v1_kzz7yh-a53338.xml (9 changes)

### DIFF
--- a/kzz7yh-a53338/cod-ve07v1_kzz7yh-a53338.xml
+++ b/kzz7yh-a53338/cod-ve07v1_kzz7yh-a53338.xml
@@ -275,7 +275,7 @@
           <p xml:id="kzz7yh-a53338-d1e466">
             <lb ed="#V" n="133"/>¶ Respondeo cum praedicti termini important aliquam realem 
             <lb ed="#V" n="134"/>distinctionem: et in divinis nulla sit realis 
-            distin<lb ed="#V" n="135" break="no"/>ctio in essentia: et persone realiter distinguntur ab inuicem i 
+            distin<lb ed="#V" n="135" break="no"/>ctpero in essentia: et persone realiter distinguuntur ab inuicem i 
             <lb ed="#V" n="136"/>relatiuas proprietates sequitur quod non dicunt in divinis rem absolu¬ 
             <!--00171.xml-->
             <pb ed="#V" n="79-r"/>

--- a/kzz7yh-a53338/cod-ve07v1_kzz7yh-a53338.xml
+++ b/kzz7yh-a53338/cod-ve07v1_kzz7yh-a53338.xml
@@ -96,7 +96,7 @@
           </p>
           <p xml:id="kzz7yh-a53338-d1e165">
             ¶ Item sicut se habet punctum ac 
-            <lb ed="#V" n="29"/>quantitatem continuam ita vnitas ad discretam. Sed omnis puctus 
+            <lb ed="#V" n="29"/>quantitatem continuam ita vnitas ad discretam. Sed omnis punctus 
             <lb ed="#V" n="30"/>reducitur ad quantitatem continuam: ergo omnis vnitas ad 
             quanti<lb ed="#V" n="31" break="no"/>tatem discretam: sed talis quantitas est accidens. Cum ergo 
             nu<lb ed="#V" n="32" break="no"/>merus constet ex vnitatibus. Omnis numerus est accidens. 
@@ -125,7 +125,7 @@
             <lb ed="#V" n="46"/>vnitas substantiae est ipsamet substantia sub ratione qua indiuisibilis vel 
             in<lb ed="#V" n="47" break="no"/>diuisa in plures res tales. Cum ergo ex quibusset vnitatibus 
             <lb ed="#V" n="48"/>constituatur numerus non omnis numerus est accidens secundum suum 
-            <lb ed="#V" n="49"/>esse quod habet in re extra sed currit omne conseqens: nec secundum suum 
+            <lb ed="#V" n="49"/>esse quod habet in re extra sed currit omne consequens: nec secundum suum 
             <lb ed="#V" n="50"/>esse intellectum: quia non tantum intelligimus vnitatem que est 
             ac<lb ed="#V" n="51" break="no"/>cidens: sed etiam illa que est substantia. Si autem loquamur de 
             nume<lb ed="#V" n="52" break="no"/>rosecundum suum esse imaginatum sic dico quod omnis numerus est accidens 
@@ -148,14 +148,14 @@
             ¶ Ad 2m quod arguitur per Aui. dico quod ibi opinio Aui. non 
             <lb ed="#V" n="62"/>est tenenda: et merito reprobatur a Coment. super. i10. Meta. 
             <lb ed="#V" n="63"/>vbi tractat aliquas rationes Auice. et ponit contra ipsum rationes 
-            <lb ed="#V" n="64"/>quas domino concedente ponemus lib. 2. vbi queretur ratio indiuidu 
-            <lb ed="#V" n="65"/>ationis.
+            <lb ed="#V" n="64"/>quas domino concedente ponemus lib. 2. vbi queretur ratio 
+            indiuidu<lb ed="#V" n="65" break="no"/>ationis.
           </p>
           <p xml:id="kzz7yh-a53338-d1e265">
             ¶ Ad 3m cum dicitur quod omnis numerus est quantitas 
             di<lb ed="#V" n="66" break="no"/>screta etc. Dico quod non est verum nisi de illo qui causatur ex 
             diui<lb ed="#V" n="67" break="no"/>sione continui vel ex partibus natis constituere continuum et de tali 
-            <lb ed="#V" n="68"/>loqutur philosophus cum dicit quod est discreta quantitas.
+            <lb ed="#V" n="68"/>loquitur philosophus cum dicit quod est discreta quantitas.
           </p>
           <p xml:id="kzz7yh-a53338-d1e274">
             ¶ Ad 4m cum 
@@ -231,7 +231,7 @@
             ¶ Ad 
             <lb ed="#V" n="111"/>2m cum dicitur quod vnitas dicit indiuisionem etc. dico quod verum est: 
             <lb ed="#V" n="112"/>sed non tantum quia vnitas essentialis dicit ipsam essentiam vt 
-            <lb ed="#V" n="113"/>indiuisam inseipsa et vnitas personalis dicit personam vt 
+            <lb ed="#V" n="113"/>indiuisam in se ipsa et vnitas personalis dicit personam vt 
             in<lb ed="#V" n="114" break="no"/>diuisum in seipsa.
           </p>
           <p xml:id="kzz7yh-a53338-d1e406">
@@ -268,7 +268,7 @@
             <lb ed="#V" n="130"/>dicunt substantialiter.
           </p>
           <p xml:id="kzz7yh-a53338-d1e459">
-            ¶ Item omen nomen signns 
+            ¶ Item omen nomen signans 
             <lb ed="#V" n="131"/>substantiam dicitur de qualibet persona per se: sed de nulla persona per se 
             pos<lb ed="#V" n="132" break="no"/>sunt dici termi numerales duo tres ergo nunquam signnt substantiam. 
           </p>
@@ -289,10 +289,10 @@
             <lb ed="#V" n="5"/>persone vt significate per hoc nomen tres non dicantur ad 
             ali<lb ed="#V" n="6" break="no"/>quid: tamen vt signata nominibus determinatis que sunt pater et 
             fili<lb ed="#V" n="7" break="no"/>us et spiritus sanctus dicuntur ad aliquid: immo vt verius dicam ad 
-            ali<lb ed="#V" n="8" break="no"/>quam vt pater ad filium: filius ad patrem et ideo non opetet quod 
+            ali<lb ed="#V" n="8" break="no"/>quam vt pater ad filium: filius ad patrem et ideo non oportet quod 
             <lb ed="#V" n="9"/>hoc nomen tres dicat substantiam sicut vides aliqualiter per simile. 
-            <lb ed="#V" n="10"/>Persone enim vt signate generali nomine non dicutur ad aliquid. 
-            <lb ed="#V" n="11"/>et tamen cum dicimus personas res ralatiuas significamus: que vt 
+            <lb ed="#V" n="10"/>Persone enim vt signate generali nomine non dicuntur ad aliquid. 
+            <lb ed="#V" n="11"/>et tamen cum dicimus personas res relatiuas significamus: que vt 
             <lb ed="#V" n="12"/>determinatis nominibus significate que sunt pater et filius et 
             <lb ed="#V" n="13"/>spiritus sanctus ad se inuicem referruntur.
           </p>


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve07v1_kzz7yh-a53338.xml`.

## Applied changes

- p. 78v l. 29: puctus: not in Latin word list — review needed
- p. 78v l. 49: conseqens: not in Latin word list — review needed
- p. 78v l. 65: indiuiduationis split across lines: add break="no"
- p. 78v l. 68: loqutur: not in Latin word list — review needed
- p. 78v l. 113: inseipsa: not in Latin word list — review needed
- p. 78v l. 130: signns: not in Latin word list — review needed
- p. 79r l. 8: opetet → operet: not in word list (OCR transform matched)
- p. 79r l. 10: dicutur: not in Latin word list — review needed
- p. 79r l. 11: ralatiuas: not in Latin word list — review needed

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_