### PR TITLE
Transcription corrections: cod-ve07v1_kzz7yh-a54866.xml (22 changes)

### DIFF
--- a/kzz7yh-a54866/cod-ve07v1_kzz7yh-a54866.xml
+++ b/kzz7yh-a54866/cod-ve07v1_kzz7yh-a54866.xml
@@ -325,7 +325,7 @@
             su<lb ed="#V" n="123" break="no"/>per speciem nobis ignote sunt.
           </p>
           <p xml:id="kzz7yh-a54866-d1e582">
-            ¶ Aliis autem commumus 
+            ¶ Aliis autem communius 
             <lb ed="#V" n="124"/>videtur dicendum quod persona signata vt hic homo signatus scilicet 
             Pe<lb ed="#V" n="125" break="no"/>trus vel Ioannes diffinibilis non est: loquendo de diffinitione 
             <lb ed="#V" n="126"/>eo modo quo de illa loquitur philosophus. 7. Meta. vbi probat nullum. 
@@ -372,7 +372,7 @@
             <lb ed="#V" n="20"/>non signata. In ista autem aliquis homo est species stat pro supposito non 
             <lb ed="#V" n="21"/>signata quod includit vnitate numeralem: quamuis non signatam: et ita 
             <lb ed="#V" n="22"/>mutatur termini suppotio. Dicit ergo quod ista aliqua spes est homo 
-            con<lb ed="#V" n="23" break="no"/>uertitur in hanc: potmo est aliqua species ita vt quod iste terminus 
+            con<lb ed="#V" n="23" break="no"/>uertitur in hanc: homo est aliqua species ita vt quod iste terminus 
             homo<lb ed="#V" n="24" break="no"/>supponat pro natura humana per intellectum abstracta ab omni 
             vni<lb ed="#V" n="25" break="no"/>tate numerali tam signata quam non signata. Terminus enim potest 
             sup<lb ed="#V" n="26" break="no"/>ponere pro supposito vt pro re signata: et per quecumque conueniat 

--- a/kzz7yh-a54866/cod-ve07v1_kzz7yh-a54866.xml
+++ b/kzz7yh-a54866/cod-ve07v1_kzz7yh-a54866.xml
@@ -81,8 +81,8 @@
             bo<lb ed="#V" n="83" break="no"/>nitas in deo nunquam significant hypostasin: ergo nec personam. 
           </p>
           <p xml:id="kzz7yh-a54866-d1e141">
-            <lb ed="#V" n="84"/>Contra Dama. lib. 3. c. 5 Indiuinitate vnam naturam 
-            <lb ed="#V" n="85"/>confitemur: et tres hypostases secundum vertiatatem 
+            <lb ed="#V" n="84"/>Contra Dama. lib. 3. c. 5 In diuinitate vnam naturam 
+            <lb ed="#V" n="85"/>confitemur: et tres hypostases secundum veritatem 
             <lb ed="#V" n="86"/>entis id est personas.
           </p>
           <p xml:id="kzz7yh-a54866-d1e151">
@@ -118,7 +118,7 @@
           </p>
           <p xml:id="kzz7yh-a54866-d1e207">
             ¶ Ad 3m cum dicitur 
-            <lb ed="#V" n="108"/>quod ad se dicitur persona etc. dico quod loqutur pro illo tempore quo 
+            <lb ed="#V" n="108"/>quod ad se dicitur persona etc. dico quod loquitur pro illo tempore quo 
             <lb ed="#V" n="109"/>nomen persone non erat in vsu nisi quantum ad illum 
             sen<lb ed="#V" n="110" break="no"/>sum in quo significat essentiam.
           </p>
@@ -153,7 +153,7 @@
           </p>
           <p xml:id="kzz7yh-a54866-d1e267">
             ¶ Item diffius est verbum: vnde Aug. 
-            <lb ed="#V" n="2"/>7. de trinitate. c. 10. Diffinio quid est intemporantia: et haec est verbum eius 
+            <lb ed="#V" n="2"/>7. de trinitate. c. 10. Diffinio quid est intemperantia: et haec est verbum eius 
             <lb ed="#V" n="3"/>apud me: sed nos possumus concipere verbum de divina persona cum 
             <lb ed="#V" n="4"/>possumus aliquo modo intelligere eam vt superius ostensum 
             <lb ed="#V" n="5"/>est Di. 3. ergo possumus diffinire diuinam personam. 
@@ -161,7 +161,7 @@
           <p xml:id="kzz7yh-a54866-d1e278">
             <lb ed="#V" n="6"/>Contra Auice. 5 Meta. c. 5. Diffinitio secundum hoc quod consentiunt 
             <lb ed="#V" n="7"/>auctores artis composita est ex genere et differentia: sed 
-            <lb ed="#V" n="8"/>diuina persona non est in genere nec est compomo cum sit deus: ergo 
+            <lb ed="#V" n="8"/>diuina persona non est in genere nec est compositio cum sit deus: ergo 
             <lb ed="#V" n="9"/>divina persona diffiniri non potest
           </p>
           <p xml:id="kzz7yh-a54866-d1e290">
@@ -181,7 +181,7 @@
             <lb ed="#V" n="17"/>Tunc autem res dcendo sinitlr: cu dicendo eius teri attinguntur. Terimos 
             <lb ed="#V" n="18"/>Autu divine persone dicendo attingem non possumus: quia cum sit 
             infinita<lb ed="#V" n="19" break="no"/>terios non habet: et ideo a nobis diffiniri non potest. Unde illud quod 
-            <lb ed="#V" n="20"/>dicit Boe. Quod persona est rationalis nature indidua substantia: et illud 
+            <lb ed="#V" n="20"/>dicit Boe. Quod persona est rationalis nature indiuidua substantia: et illud 
             <lb ed="#V" n="21"/>quod dicit Ricar. in libro de tri. libro 4. c. 18 scilicet quod persona est 
             intelle<lb ed="#V" n="22" break="no"/>ctualis nature incommunicabitu existentia: et illud quod dicunt magistri scilicet quod 
             <lb ed="#V" n="23"/>persona est hypostasis distincta proprietate ad dignitatem 
@@ -189,14 +189,14 @@
             <lb ed="#V" n="25"/>aliqualem similitudinem cum diffinitione: quia hypostasis: quam vocat 
             <lb ed="#V" n="26"/>Ricar. existentiam: et Boe. substantiam eo quod se habet ad similitudinem substantiae 
             <lb ed="#V" n="27"/>prime: habet aliqualem similitudinem cum genere: quia signt rem distinguibilem 
-            <lb ed="#V" n="28"/>per quam opetet proprietatem: sicut genus importat. aliquid deteriabile per 
+            <lb ed="#V" n="28"/>per quam oportet proprietatem: sicut genus importat. aliquid deteriabile per 
             <lb ed="#V" n="29"/>hanc differentiam vel per illam: et proprietas pertinens ad dignitatem habet aliquam 
             <lb ed="#V" n="30"/>lem similitudinem cum differentia in hoc quod distinguit sicut facit differentia. hec 
-            <lb ed="#V" n="31"/>aute duo in pes divina idem sunt per omnimodam simplicitatem. Similiter s 
+            <lb ed="#V" n="31"/>autem duo in pes divina idem sunt per omnimodam simplicitatem. Similiter s 
             <lb ed="#V" n="32"/>illa verba quie potesit Boe scilicet rationalis nature indiduam deteriant substantiam: 
-            <lb ed="#V" n="33"/>per hoc enim quod dicitur indidua deteriatur ad substantiam quae se habet ad similitudinem 
-            <lb ed="#V" n="34"/>substantiae prime: quae substantia est hypostasis: accepit enim indiduum pro 
-            incommunicabi<lb ed="#V" n="35" break="no"/>li: vnde vbi Boe. potesit indiduum Ricar. potesit incommunicabile. Per 
+            <lb ed="#V" n="33"/>per hoc enim quod dicitur indiuidua deteriatur ad substantiam quae se habet ad similitudinem 
+            <lb ed="#V" n="34"/>substantiae prime: quae substantia est hypostasis: accepit enim indiuiduum pro 
+            incommunicabi<lb ed="#V" n="35" break="no"/>li: vnde vbi Boe. potest indiduum Ricar. potesit incommunicabile. Per 
             <lb ed="#V" n="36"/>hoc autem quod dicitur rationalis nature separatur ab hypostasi que 
             <lb ed="#V" n="37"/>non est rationalis nature cui ratio persone non conuenit. 
             <!--TODO: insert para break here-->
@@ -281,7 +281,7 @@
             ¶ Item persona creata addit differentiam substantialem super 
             spe<lb ed="#V" n="93" break="no"/>ciem: aliter enim Petrus non differret substantialiter a Ioanne: 
             <lb ed="#V" n="94"/>ergo sicut species potest diffiniri communi diffinitione omnibus 
-            <lb ed="#V" n="95"/>indiduis quia addit differentiam substantialem super genus: ita videtur 
+            <lb ed="#V" n="95"/>indiuiduis quia addit differentiam substantialem super genus: ita videtur 
             <lb ed="#V" n="96"/>quod quelibet persona creata propria diffinitione sit diffinibilis: cum 
             <lb ed="#V" n="97"/>quelibet addat super speciem differentiam essentialem sibi propriam. 
           </p>
@@ -289,13 +289,13 @@
             <lb ed="#V" n="98"/>Contra per diffinitionem habetur scientia de diffinito: 
             <lb ed="#V" n="99"/>vnde dicit philosophus vii. Metaphi quod diffinitio 
             <lb ed="#V" n="100"/>est scientifica: sed vt ipse dicit. 3. Metaphi. et. 7. De 
-            singu<lb ed="#V" n="101" break="no"/>laribus est scientia: ergo cum quilibet persona sit quid singituirare nulla 
+            singu<lb ed="#V" n="101" break="no"/>laribus est scientia: ergo cum quilibet persona sit quid singulare nulla 
             <lb ed="#V" n="102"/>creata persona diffinibil est
           </p>
           <p xml:id="kzz7yh-a54866-d1e526">
             ¶ Item Aui. 5. Meta. sue. c. 5 dice 
-            <lb ed="#V" n="103"/>quod singitare non habet diffinitionem vllous. Sed quialibet persona est quid 
-            singitura<lb ed="#V" n="104" break="no"/>re: ergo idem vt prius. Item Boe. libro dionum dicit quod indidua 
+            <lb ed="#V" n="103"/>quod singulare non habet diffinitionem vllous. Sed quialibet persona est quid 
+            singitura<lb ed="#V" n="104" break="no"/>re: ergo idem vt prius. Item Boe. libro dionum dicit quod indiuidua 
             speci<lb ed="#V" n="105" break="no"/>ficis differentiis carens a diffinitione seclusa sunt. 
           </p>
           <p xml:id="kzz7yh-a54866-d1e535">
@@ -328,8 +328,8 @@
             ¶ Aliis autem commumus 
             <lb ed="#V" n="124"/>videtur dicendum quod persona signata vt hic homo signatus scilicet 
             Pe<lb ed="#V" n="125" break="no"/>trus vel Ioannes diffinibilis non est: loquendo de diffinitione 
-            <lb ed="#V" n="126"/>eo modo quo de illa loqutur philosophus. 7. Meta. vbi probat nullum. 
-            <lb ed="#V" n="127"/>singituiare diffiniri posse Diffinitio enim est oratio composita ex 
+            <lb ed="#V" n="126"/>eo modo quo de illa loquitur philosophus. 7. Meta. vbi probat nullum. 
+            <lb ed="#V" n="127"/>singulare diffiniri posse Diffinitio enim est oratio composita ex 
             ge<lb ed="#V" n="128" break="no"/>nere et differentia distincta: et plene indicans quid est diffinitum 
             ag<lb ed="#V" n="129" break="no"/>generans de illo scientiam: et cum diffinito conuertibilis tam in 
             <lb ed="#V" n="130"/>re quam in apprehensione nihil amplius continens quam id quod 
@@ -364,7 +364,7 @@
           </p>
           <p xml:id="kzz7yh-a54866-d1e656">
             ¶ Ad 2m dicendum quod minor est falsa 
-            <lb ed="#V" n="15"/>nec valet eius probomo: quia sicut patebit 2o quaestione sequantis 
+            <lb ed="#V" n="15"/>nec valet eius probatio: quia sicut patebit 2o quaestione sequantis 
             articu<lb ed="#V" n="16" break="no"/>li. Aliquis homo non potetur de singularibus eo modo quod species praetur de 
             <lb ed="#V" n="17"/>eis. Nec ista aliqua species est homo conuertitur in hanc: aliquis homo est 
             <lb ed="#V" n="18"/>species: quia in prima hic terminus homo signat naturam humanam in 
@@ -393,12 +393,12 @@
           </p>
           <p xml:id="kzz7yh-a54866-d1e705">
             ¶ Secundum autem opinionem 
-            pri<lb ed="#V" n="32" break="no"/>mam potest responderi ad argumentum in oppsipium per modum qui sequitur. 
+            pri<lb ed="#V" n="32" break="no"/>mam potest responderi ad argumentum in oppositum per modum qui sequitur. 
           </p>
           <p xml:id="kzz7yh-a54866-d1e710">
             <lb ed="#V" n="33"/>Ad primum cum dicitur quod secundum philosophum de singularibus non est scientia potest 
             <lb ed="#V" n="34"/>dici illud verbum non debere intelligi de singulari in 
-            <lb ed="#V" n="35"/>corruptibili: quia de illo possumusscire si est: et quid est: et quia est 
+            <lb ed="#V" n="35"/>corruptibili: quia de illo possumus scire si est: et quid est: et quia est 
             <lb ed="#V" n="36"/>et propter quid est: nec etiam de singulari corruptibili. nisi quo ad 
             <lb ed="#V" n="37"/>suum esse. De ipso enim scire possumus quid est in esse repraesentato: 
             <lb ed="#V" n="38"/>et intellecto: et quid est realiter si est: quamuis non possimus scire 
@@ -411,8 +411,8 @@
             ¶ Auctoritates autem allegate ad hanc partem intelligi 
             de<lb ed="#V" n="43" break="no"/>bent sic scilicet quod singulare a nobis diffiniri non potest: eo quod nos 
             <lb ed="#V" n="44"/>latent essentialis differentiae: quas super suas species addunt: quamuis 
-            si<lb ed="#V" n="45" break="no"/>cut species super genus addit differentia essentialem pluribus singltuaribus communem: 
-            <lb ed="#V" n="46"/>ita singituiare addat super speciem differentiam essentialem sibi soli propostiam.
+            si<lb ed="#V" n="45" break="no"/>cut species super genus addit differentia essentialem pluribus singularibus communem: 
+            <lb ed="#V" n="46"/>ita singulare addat super speciem differentiam essentialem sibi soli propostiam.
           </p>
         </div>
       </div>


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve07v1_kzz7yh-a54866.xml`.

## Applied changes

- p. 80v l. 84: Indiuinitate: not in Latin word list — review needed
- p. 80v l. 85: vertiatatem: not in Latin word list — review needed
- p. 80v l. 108: loqutur: not in Latin word list — review needed
- p. 81r l. 2: intemporantia: not in Latin word list — review needed
- p. 81r l. 8: compomo: not in Latin word list — review needed
- p. 81r l. 20: indidua: not in Latin word list — review needed
- p. 81r l. 28: opetet → operet: not in word list (OCR transform matched); deteriabile: not in Latin word list — review needed
- p. 81r l. 31: aute → aure: not in word list (OCR transform matched)
- p. 81r l. 33: indidua: not in Latin word list — review needed; deteriatur: not in Latin word list — review needed
- p. 81r l. 34: indiduum: not in Latin word list — review needed
- p. 81r l. 35: potesit: not in Latin word list — review needed; indiduum: not in Latin word list — review needed
- p. 81r l. 95: indiduis: not in Latin word list — review needed
- p. 81r l. 101: singituirare: not in Latin word list — review needed
- p. 81r l. 103: singitare: not in Latin word list — review needed; quialibet: not in Latin word list — review needed
- p. 81r l. 104: indidua: not in Latin word list — review needed
- p. 81r l. 126: loqutur: not in Latin word list — review needed
- p. 81r l. 127: singituiare: not in Latin word list — review needed
- p. 81v l. 15: probomo: not in Latin word list — review needed; sequantis: not in Latin word list — review needed
- p. 81v l. 32: oppsipium: not in Latin word list — review needed
- p. 81v l. 35: possumusscire: not in Latin word list — review needed
- p. 81v l. 45: singltuaribus: not in Latin word list — review needed
- p. 81v l. 46: singituiare: not in Latin word list — review needed

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_