### PR TITLE
Transcription corrections: cod-ve07v1_kzz7yh-a55514.xml (9 changes)

### DIFF
--- a/kzz7yh-a55514/cod-ve07v1_kzz7yh-a55514.xml
+++ b/kzz7yh-a55514/cod-ve07v1_kzz7yh-a55514.xml
@@ -100,7 +100,7 @@
             ¶ Item cum intellectus intelligit ens 
             in<lb ed="#V" n="66" break="no"/>quantum ens abstrahit ab ente creato et increato: hoc autem non 
             <lb ed="#V" n="67"/>esset nisi ens diceret quid commune creatori et creature: ergo a 
-            simili<lb ed="#V" n="68" break="no"/>persona potest nomiare quid commune persone create: et increate.
+            simili<lb ed="#V" n="68" break="no"/>persona potest nominare quid commune persone create: et increate.
           </p>
           <p xml:id="kzz7yh-a55514-d1e178">
             <!--00176.xml-->
@@ -125,8 +125,8 @@
             <lb ed="#V" n="81"/>persona: quia aliqua hitudine habet cum persona dina: tuc enim 
             ana<lb ed="#V" n="82" break="no"/>logice dicitur aliquid de aliquibus quando dicitur de vno et principaliter: et secundum se: 
             <lb ed="#V" n="83"/>de aliis autem non dicitur nisi inquantum habent quandam habitudinem ad 
-            il<lb ed="#V" n="84" break="no"/>lam rem: de quae dicitur principaliter et secndum se. vierum. gratia: quia ens principaliter 
-            <lb ed="#V" n="85"/>et secundum se conuenit deo. Creaturis autem non conuenit nisi inquaentum 
+            il<lb ed="#V" n="84" break="no"/>lam rem: de quae dicitur principaliter et secundum se. vierum. gratia: quia ens principaliter 
+            <lb ed="#V" n="85"/>et secundum se conuenit deo. Creaturis autem non conuenit nisi inquantum 
             <lb ed="#V" n="86"/>imitantur deum: ideo ens dicitur analogice de deo et creatura. Similiter 
             <lb ed="#V" n="87"/>quia ens creatum proposie principaliter et secundum se conuenit substantae: accidentibus 
             <lb ed="#V" n="88"/>autem non conuenit nisi inquantum habent quandam habitudinem ad substantiam 
@@ -158,8 +158,8 @@
             di<lb ed="#V" n="109" break="no"/>stinguentem que non dicitur vniuoce de persona creata et increata¬ 
           </p>
           <p xml:id="kzz7yh-a55514-d1e283">
-            <lb ed="#V" n="110"/>¶ Ad 3m cum dicitur quod ens dicit quid commune creatori et creatu 
-            <lb ed="#V" n="111"/>re etc. dico quod verum est loquendo communitate analogica non 
+            <lb ed="#V" n="110"/>¶ Ad 3m cum dicitur quod ens dicit quid commune creatori et 
+            creatu<lb ed="#V" n="111" break="no"/>re etc. dico quod verum est loquendo communitate analogica non 
             vniuo<lb ed="#V" n="112" break="no"/>ca: et de tali communi potest est intellectus facere conceptum generalem: non 
             <lb ed="#V" n="113"/>deterinando se ad aliquod illorum de quios dicitur.
           </p>
@@ -220,7 +220,7 @@
             <lb ed="#V" n="8"/>esset respectu earum species vel genus: quod falsum est. 
           </p>
           <p xml:id="kzz7yh-a55514-d1e390">
-            <lb ed="#V" n="9"/>Respondeo quod persona dicit rem commuem diuinis personis non 
+            <lb ed="#V" n="9"/>Respondeo quod persona dicit rem communem diuinis personis non 
             <lb ed="#V" n="10"/>communitate eiusdem rei in numero: quia sic 
             <lb ed="#V" n="11"/>quicquid est commune tribus personis est res absoluta: nec communitate 
             <lb ed="#V" n="12"/>speciei vel generis: quia nulla diuina persona est ingenere: quia 
@@ -291,11 +291,11 @@
             <!--00177.xml-->
             <cb ed="#P" n="b"/>
             <lb ed="#V" n="69"/>dine et vnitate numerali: sed secundum aliam et aliam rationem in 
-            nue<lb ed="#V" n="70" break="no"/>ro: quamuis indeterinate signatam. Et quia argumenta ad partem aliam 
+            nue<lb ed="#V" n="70" break="no"/>ro: quamuis indeterminate signatam. Et quia argumenta ad partem aliam 
             <lb ed="#V" n="71"/>videntur adduci ad concludendum quod persona de diuinis 
             <lb ed="#V" n="72"/>personis dicatur equiuoce soluenda sunt. 
             
-            <lb ed="#V" n="73"/>Ad primum cum dicitur quod incommuncabilitas repugnat communitati etc. dico quod 
+            <lb ed="#V" n="73"/>Ad primum cum dicitur quod incommunicabilitas repugnat communitati etc. dico quod 
             <lb ed="#V" n="74"/>incommunicabilitas secundum quodaccipitur in ratione persone non negat nisi 
             <lb ed="#V" n="75"/>communitatem eiusdem rei in nuero: et communitatem plene vniuocasa.
           </p>
@@ -305,7 +305,7 @@
             <lb ed="#V" n="77"/>ita quod dicat eandem rem numero communem illis et hoc est verum.
           </p>
           <p xml:id="kzz7yh-a55514-d1e557">
-            ¶ 3m argunum 
+            ¶ 3m argumentum 
             <lb ed="#V" n="78"/>non plus concludit nisi quod persona non dicit quid commune vniuoce 
             di<lb ed="#V" n="79" break="no"/>nis personis: sed secundum plenam rationem vniuocationis.
           </p>
@@ -323,7 +323,7 @@
             per<lb ed="#V" n="83" break="no"/>sonas ex eade essentia non dicimus Cuius ratio est: quia hec 
             <lb ed="#V" n="84"/>praepotmo eximportat aliquam habitudinem causae efficientis vel materialis. 
             <lb ed="#V" n="85"/>Dicimus tamen tres personas eiusdem essentie: quia genitus potest importare 
-            <lb ed="#V" n="86"/>hitudinem causae formalis: vel habitudine similem illi: divina autem 
+            <lb ed="#V" n="86"/>habitudinem causae formalis: vel habitudine similem illi: divina autem 
             <lb ed="#V" n="87"/>essentia quamuis non sit causa efficiens nec materialis divinarum. 
             persona<lb ed="#V" n="88" break="no"/>rum tamen sese habet ad divinas personas sicut essentia ad supposita. 
           </p>

--- a/kzz7yh-a55514/cod-ve07v1_kzz7yh-a55514.xml
+++ b/kzz7yh-a55514/cod-ve07v1_kzz7yh-a55514.xml
@@ -122,7 +122,7 @@
             <lb ed="#V" n="78"/>uoce: sed analogice: quia persona principaliter conuenit personis 
             incre<lb ed="#V" n="79" break="no"/>atis: sed ratio personalitatis conuenit personis creatis secundum quod habent 
             <lb ed="#V" n="80"/>aliquam habitudinem ad personas increatas. ideo enim Iosophus dicitur 
-            <lb ed="#V" n="81"/>persona: quia aliqua hitudine habet cum persona dina: tuc enim 
+            <lb ed="#V" n="81"/>persona: quia aliqua habitudinem habet cum persona dina: tuc enim 
             ana<lb ed="#V" n="82" break="no"/>logice dicitur aliquid de aliquibus quando dicitur de vno et principaliter: et secundum se: 
             <lb ed="#V" n="83"/>de aliis autem non dicitur nisi inquantum habent quandam habitudinem ad 
             il<lb ed="#V" n="84" break="no"/>lam rem: de quae dicitur principaliter et secundum se. vierum. gratia: quia ens principaliter 


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve07v1_kzz7yh-a55514.xml`.

## Applied changes

- p. 81v l. 68: nomiare: not in Latin word list — review needed
- p. 81v l. 84: secndum: not in Latin word list — review needed
- p. 81v l. 85: inquaentum: not in Latin word list — review needed
- p. 81v l. 111: 'creatu' + 're' split across line break without break="no" on lb n=111
- p. 82r l. 9: commuem: not in Latin word list — review needed
- p. 82r l. 70: indeterinate: not in Latin word list — review needed
- p. 82r l. 73: incommuncabilitas: not in Latin word list — review needed
- p. 82r l. 77: argunum: not in Latin word list — review needed
- p. 82r l. 86: hitudinem → hirudinem: t/r transposition

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_