### PR TITLE
Transcription corrections: cod-ve07v1_kzz7yh-a58763.xml (1 change)

### DIFF
--- a/kzz7yh-a58763/cod-ve07v1_kzz7yh-a58763.xml
+++ b/kzz7yh-a58763/cod-ve07v1_kzz7yh-a58763.xml
@@ -68,7 +68,7 @@
         </p>
         <p xml:id="kzz7yh-a58763-d1e123">
           ¶ (Dicimus donum donatoris:) : sed nunquid similiter 
-          dici<lb ed="#V" n="62" break="no"/>mus spiritum spiratoris: ergo ita apporet rlutio in nomine spiritus 
+          dici<lb ed="#V" n="62" break="no"/>mus spiritum spiratoris: ergo ita apparet relatio in nomine spiritus 
           <lb ed="#V" n="63"/>in nomine doni.
         </p>
         <p xml:id="kzz7yh-a58763-d1e130">


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve07v1_kzz7yh-a58763.xml`.

## Applied changes

- p. 86r l. 62: spiratoris: not in Latin word list — review needed; apporet: not in Latin word list — review needed; rlutio: not in Latin word list — review needed

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_