### PR TITLE
Transcription corrections: cod-ve07v1_kzz7yh-a58801.xml (2 changes)

### DIFF
--- a/kzz7yh-a58801/cod-ve07v1_kzz7yh-a58801.xml
+++ b/kzz7yh-a58801/cod-ve07v1_kzz7yh-a58801.xml
@@ -294,7 +294,7 @@
           <lb ed="#V" n="35"/>Hic queri potest etc. Superius determinauit 
           <lb ed="#V" n="36"/>magister de proprietatibus 
           persona<lb ed="#V" n="37" break="no"/>libus in generali: hic descendit ad specialem 
-          assigna<lb ed="#V" n="38" break="no"/>tionem. Hylarii et Augu. comperando vnam ad aliam 
+          assigna<lb ed="#V" n="38" break="no"/>tionem. Hylarii et Augu. comparando vnam ad aliam 
           <lb ed="#V" n="39"/>secundum conuenientiam et differentiam: et diuiditur in tres partes: quia primo super 
           <lb ed="#V" n="40"/>hoc mouet quaestionem.
         </p>
@@ -334,7 +334,7 @@
         <p xml:id="kzz7yh-a58801-d1e657">
           ¶ Quarto ex illa solutione elicit aliam 
           <lb ed="#V" n="53"/>regulam ibi. Et sciendum est. 
-          <lb ed="#V" n="54"/>Circa hanc distanitionem queruntur duo 
+          <lb ed="#V" n="54"/>Circa hanc distinctionem queruntur duo 
           princi<lb ed="#V" n="55" break="no"/>paliter.
         </p>
         <p xml:id="kzz7yh-a58801-d1e666">


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve07v1_kzz7yh-a58801.xml`.

## Applied changes

- p. 87r l. 38: Hylarii: not in Latin word list — review needed; comperando: not in Latin word list — review needed
- p. 87r l. 54: distanitionem: not in Latin word list — review needed

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_