### PR TITLE
Transcription corrections: cod-ve07v1_kzz7yh-a60828.xml (2 changes)

### DIFF
--- a/kzz7yh-a60828/cod-ve07v1_kzz7yh-a60828.xml
+++ b/kzz7yh-a60828/cod-ve07v1_kzz7yh-a60828.xml
@@ -314,7 +314,7 @@
           Dis. XXVIIII 
           <lb ed="#V" n="20"/>PReterea considerari oportet etc. Superius 
           deter<lb ed="#V" n="21" break="no"/>minauit magister de proprietatibus 
-          <lb ed="#V" n="22"/>personalibus idest personas constituentibus: hic 
+          <lb ed="#V" n="22"/>personalibus id est personas constituentibus: hic 
           determi<lb ed="#V" n="23" break="no"/>nat de proprietatibus notionalibus et non personalibus. et 
           di<lb ed="#V" n="24" break="no"/>uiditur pars ista in duas partes. In prima agit de 
           innascibili<lb ed="#V" n="25" break="no"/>tate. In secunda de communi spiratione secundum quam nomine principii 
@@ -346,7 +346,7 @@
         <p xml:id="kzz7yh-a60828-d1e689">
           ¶ 2o 
           <lb ed="#V" n="36"/>excludit errorem quorundam circa distinctionem geniti et 
-          inge<lb ed="#V" n="37" break="no"/>niti ibi. (Illud autem tacere non opoet.)
+          inge<lb ed="#V" n="37" break="no"/>niti ibi. (Illud autem tacere non oportet.)
         </p>
         <p xml:id="kzz7yh-a60828-d1e696">
           ¶ Tertio iuxta hoc 

--- a/kzz7yh-a60828/cod-ve07v1_kzz7yh-a60828.xml
+++ b/kzz7yh-a60828/cod-ve07v1_kzz7yh-a60828.xml
@@ -363,7 +363,7 @@
         </p>
         <p xml:id="kzz7yh-a60828-d1e717">
           ¶ In tertia ostendit quod imago aliquando 
-          <lb ed="#V" n="45"/>habet significationem essentialem: ibi. (Illud etiam scire opotet) 
+          <lb ed="#V" n="45"/>habet significationem essentialem: ibi. (Illud etiam scire oportet). 
         </p>
         <p xml:id="kzz7yh-a60828-d1e722">
           <lb ed="#V" n="46"/>CIrca hanc di. queruntur tria principaliter 


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve07v1_kzz7yh-a60828.xml`.

## Applied changes

- p. 90r l. 22: idest: not in Latin word list — review needed
- p. 90r l. 37: opoet: not in Latin word list — review needed

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_