### PR TITLE
Transcription corrections: cod-ve07v1_kzz7yh-a61465.xml (9 changes)

### DIFF
--- a/kzz7yh-a61465/cod-ve07v1_kzz7yh-a61465.xml
+++ b/kzz7yh-a61465/cod-ve07v1_kzz7yh-a61465.xml
@@ -112,10 +112,10 @@
           </p>
           <p xml:id="kzz7yh-a61465-d1e196">
             ¶ Alia qua refertur ad filium: et 
-            il<lb ed="#V" n="79" break="no"/>la est paternitas. Et alia qua refertur ad spirintum: et illa est 
+            il<lb ed="#V" n="79" break="no"/>la est paternitas. Et alia qua refertur ad spiritum: et illa est 
             spira<lb ed="#V" n="80" break="no"/>tio actiua: que communis est patri et filio: et iste non 
-            distinguun<lb ed="#V" n="81" break="no"/>tur per comperationem ad personam in qua sunt: nec inter se: 
-            <lb ed="#V" n="82"/>neque ab ipsa persona: quia comperate ad ipsam realiter idem 
+            distinguun<lb ed="#V" n="81" break="no"/>tur per comparationem ad personam in qua sunt: nec inter se: 
+            <lb ed="#V" n="82"/>neque ab ipsa persona: quia comparate ad ipsam realiter idem 
             <lb ed="#V" n="83"/>sunt cum ipsa: sed distinguuntur per hoc quod innascibilitas 
             inquan<lb ed="#V" n="84" break="no"/>tum est notio ab aliis distincta: significat negationem 
             rela<lb ed="#V" n="85" break="no"/>tionis realis secundum quod videtur velle Augu. 5 de trini. c. 7. 
@@ -152,13 +152,13 @@
             ¶ Ad 3m cum dicitur quod sicut 
             con<lb ed="#V" n="109" break="no"/>ditio nobilis in patre est non nasci: ita videtur quod conditio 
             no<lb ed="#V" n="110" break="no"/>bilis sit in patre et filio non spirari etc. Dico quod quamuis vtrumque 
-            <lb ed="#V" n="111"/>sit nobilitatis non tamen propter hoc opetet quod inspirabilitas: 
+            <lb ed="#V" n="111"/>sit nobilitatis non tamen propter hoc oportet quod inspirabilitas: 
             si<lb ed="#V" n="112" break="no"/>ue improcessibilitas dicat non communem distinctam ab 
             innascibili<lb ed="#V" n="113" break="no"/>tate: quia secundum quod innascibilitas est notio in patre non 
             tantummo<lb ed="#V" n="114" break="no"/>do negat natiuitatem a patre: sed negat simpliciter patrem esse 
             <lb ed="#V" n="115"/>ab alio: quia si non negaret nisi natiuitatem a patre: non esset 
-            <lb ed="#V" n="116"/>negatio ita determinata et spercialis quod deberet habere rationem 
-            <lb ed="#V" n="117"/>notionis: quia tunc esset negatio spercialis affirmationis: et 
+            <lb ed="#V" n="116"/>negatio ita determinata et specialis quod deberet habere rationem 
+            <lb ed="#V" n="117"/>notionis: quia tunc esset negatio specialis affirmationis: et 
             quan<lb ed="#V" n="118" break="no"/>to affirmatio est specialior: tanto negatio est vniuersalior. 
           </p>
           <p xml:id="kzz7yh-a61465-d1e293">
@@ -214,10 +214,10 @@
             <lb ed="#V" n="14"/>hec est paternitas. Unde se habet ad similitudinem differentie 
             consti<lb ed="#V" n="15" break="no"/>tutiue: seu forme substantialis in creaturis. Alie vero due scilicet 
             inna<lb ed="#V" n="16" break="no"/>scibilitas: et actiua spiratio non sunt proprietates personales. 
-            <lb ed="#V" n="17"/>Nuncautem ita est quod secundum numerum proprietatum personalium: oportet 
+            <lb ed="#V" n="17"/>Nunc autem ita est quod secundum numerum proprietatum personalium: oportet 
             <lb ed="#V" n="18"/>personas numerari: sicut secundum numerum formarum substantialium 
-            comple<lb ed="#V" n="19" break="no"/>tiuarum opetet substantias numerari in creaturis: secundum vero numerum 
-            <lb ed="#V" n="20"/>notionum non personalium non opetet: sic nec secundum numerum formarum quae 
+            comple<lb ed="#V" n="19" break="no"/>tiuarum oportet substantias numerari in creaturis: secundum vero numerum 
+            <lb ed="#V" n="20"/>notionum non personalium non oportet: sic nec secundum numerum formarum quae 
             <lb ed="#V" n="21"/>non sunt de constitutione suppositi oportet supposita numerari in 
             <lb ed="#V" n="22"/>creaturis: sic ergo pater propter vnitatem proprietatis constitutiue ipsius 
             <lb ed="#V" n="23"/>debet dici vnus: nec propter alias duas cum ista: cum non sint 


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve07v1_kzz7yh-a61465.xml`.

## Applied changes

- p. 90r l. 79: spirintum: not in Latin word list — review needed
- p. 90r l. 81: comperationem: not in Latin word list — review needed
- p. 90r l. 82: comperate: not in Latin word list — review needed
- p. 90r l. 111: opetet → operet: not in word list (OCR transform matched); inspirabilitas: not in Latin word list — review needed
- p. 90r l. 116: spercialis: not in Latin word list — review needed
- p. 90r l. 117: spercialis: not in Latin word list — review needed
- p. 90v l. 17: Nuncautem: not in Latin word list — review needed
- p. 90v l. 19: opetet → operet: not in word list (OCR transform matched)
- p. 90v l. 20: opetet → operet: not in word list (OCR transform matched)

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_