### PR TITLE
Transcription corrections: cod-ve07v1_kzz7yh-a61823.xml (7 changes)

### DIFF
--- a/kzz7yh-a61823/cod-ve07v1_kzz7yh-a61823.xml
+++ b/kzz7yh-a61823/cod-ve07v1_kzz7yh-a61823.xml
@@ -78,7 +78,7 @@
           </p>
           <p xml:id="kzz7yh-a61823-d1e139">
             ¶ Item in 
-            <lb ed="#V" n="53"/>diuinis persona non distinguitur a persona nisi per ralationem: sed 
+            <lb ed="#V" n="53"/>diuinis persona non distinguitur a persona nisi per relationem: sed 
             pa<lb ed="#V" n="54" break="no"/>ter distinguitur ab alia persona per innascibilitatem: ergo 
             innasci<lb ed="#V" n="55" break="no"/>bilitas est relatio.
           </p>
@@ -121,7 +121,7 @@
             <lb ed="#V" n="78"/>rei aperte haberi: est ergo ibi nota negationis. Negatio autem 
             <lb ed="#V" n="79"/>nullam rem ponit quantuncumque sit negatio rei specialis: non 
             <lb ed="#V" n="80"/>humanitas enim nullam rem. ponit: et ideo oportet concedere quod 
-            <lb ed="#V" n="81"/>quantum ad illud quod primo significat non significat ralationem 
+            <lb ed="#V" n="81"/>quantum ad illud quod primo significat non significat relationem 
             <lb ed="#V" n="82"/>realem: quantum tamen ad illud quod importat secundario dicit 
             <lb ed="#V" n="83"/>aliquam rem scilicet primitatem ad omnem emanationem que dicit 
             re<lb ed="#V" n="84" break="no"/>spectum habitualem ad primum. Unde videtur in se comprehendere 
@@ -134,7 +134,7 @@
             per<lb ed="#V" n="89" break="no"/>ticula non efficit vt illud quod sine ea 
             <lb ed="#V" n="90"/>secundum relationem dicitur eadem preposita substantialiter dicatur etc. 
             <lb ed="#V" n="91"/>Dico quod Aug. intendit quod negatio praeposita relationi: 
-            quam<lb ed="#V" n="92" break="no"/>uis prohibeat peraedicationem generis de re cui praeponitur: non 
+            quam<lb ed="#V" n="92" break="no"/>uis prohibeat praedicationem generis de re cui praeponitur: non 
             <lb ed="#V" n="93"/>tamen prohibet reductione ad illud genus. Ego autem bene 
             <lb ed="#V" n="94"/>concedo quod quamuis innascibilitas non sit relatio realis: tamen 
             <lb ed="#V" n="95"/>teducitur ad genus relationis realis eo modo quo negationes 
@@ -161,7 +161,7 @@
             <lb ed="#V" n="110"/>cum dicitur quod non genitus refertur ad non genitorem etc. 
             <lb ed="#V" n="111"/>dico quod hoc intelligi debet de ratione secundum rationem tantum. Ego 
             <lb ed="#V" n="112"/>autem non nego quin innascibilitas quantum ad illud quod 
-            pri<lb ed="#V" n="113" break="no"/>mo significat importat ralationem secundum rationem: quia negationes 
+            pri<lb ed="#V" n="113" break="no"/>mo significat importat relationem secundum rationem: quia negationes 
             <lb ed="#V" n="114"/>possunt dici res rationis inquantum apprehenduntur a ratione e 
             <lb ed="#V" n="115"/>suas affirmationes.
           </p>
@@ -217,7 +217,7 @@
             proprie<lb ed="#V" n="7" break="no"/>tas est innascibilitas: et paternitas. 
           </p>
           <p xml:id="kzz7yh-a61823-d1e395">
-            <lb ed="#V" n="8"/>Contra rationes distiguuntur penes terminos: quia secundum 
+            <lb ed="#V" n="8"/>Contra rationes distinguuntur penes terminos: quia secundum 
             <lb ed="#V" n="9"/>philosophum libro praedicamentorum. Relatiuorum esse est 
             <lb ed="#V" n="10"/>ad aliud se habere: sed innascibilitas negat principium a quo: 
             <lb ed="#V" n="11"/>sit ille qui est innascibilis paternitas importat principium alicuius 
@@ -263,7 +263,7 @@
             <lb ed="#V" n="43"/>quod primitas ad actum spirandi realiter idem est cum actiua 
             <lb ed="#V" n="44"/>spiratione: ita quod de intellectu spirationis actiue est primo 
             <lb ed="#V" n="45"/>secundum rationem intelligendi ipsa paternitas ad actum spirandi. 
-            De<lb ed="#V" n="46" break="no"/>inde actus spirandi. Tertio habitudo ad spiratum conseqens secundum 
+            De<lb ed="#V" n="46" break="no"/>inde actus spirandi. Tertio habitudo ad spiratum consequens secundum 
             <lb ed="#V" n="47"/>rationem intelligendi spirationem actiuam. De significato 
             <lb ed="#V" n="48"/>autem suo non sic est hypostasis sicut de significato paternitatis: 
             <lb ed="#V" n="49"/>quia quamuis realiter idem sit cum hypostasi cuius est actus: non 
@@ -316,7 +316,7 @@
           <p xml:id="kzz7yh-a61823-d1e586">
             ¶ Argumenta que sunt ad partem aliam 
             <lb ed="#V" n="85"/>nihil plus concludunt: nisi quod innascibilitas ratione huius quod 
-            <lb ed="#V" n="86"/>primo est de significato eius non est realtter eadem 
+            <lb ed="#V" n="86"/>primo est de significato eius non est realiter eadem 
             pro<lb ed="#V" n="87" break="no"/>prietas cum paternitate: et hoc est verum. 
           </p>
         </div>

--- a/kzz7yh-a61823/cod-ve07v1_kzz7yh-a61823.xml
+++ b/kzz7yh-a61823/cod-ve07v1_kzz7yh-a61823.xml
@@ -137,7 +137,7 @@
             quam<lb ed="#V" n="92" break="no"/>uis prohibeat praedicationem generis de re cui praeponitur: non 
             <lb ed="#V" n="93"/>tamen prohibet reductione ad illud genus. Ego autem bene 
             <lb ed="#V" n="94"/>concedo quod quamuis innascibilitas non sit relatio realis: tamen 
-            <lb ed="#V" n="95"/>teducitur ad genus relationis realis eo modo quo negationes 
+            <lb ed="#V" n="95"/><sic>teducitur</sic> ad genus relationis realis eo modo quo negationes 
             <lb ed="#V" n="96"/>reducuntur ad idem genus cum suis affirmationibus: per quas 
             <lb ed="#V" n="97"/>haberent cognosci: et hec reductio non est virtute negationis: 
             <lb ed="#V" n="98"/>que quantum est de se nihil ponit: sed ratione rei negate: quia 


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve07v1_kzz7yh-a61823.xml`.

## Applied changes

- p. 90v l. 53: ralationem → relationem: a/e misread
- p. 90v l. 81: ralationem → relationem: a/e misread
- p. 90v l. 92: peraedicationem → praedicationem: per-/prae- misread
- p. 90v l. 113: ralationem → relationem: a/e misread
- p. 91r l. 8: distiguuntur → distinguuntur: missing n
- p. 91r l. 46: conseqens → consequens: missing u
- p. 91r l. 86: realtter → realiter: lt transposition

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_