### PR TITLE
Transcription corrections: cod-ve07v1_kzz7yh-a63171.xml (11 changes)

### DIFF
--- a/kzz7yh-a63171/cod-ve07v1_kzz7yh-a63171.xml
+++ b/kzz7yh-a63171/cod-ve07v1_kzz7yh-a63171.xml
@@ -215,7 +215,7 @@
             ¶ Ad 2m 
             <lb ed="#V" n="126"/>3m potest dici quod ille auctor de maximis theolo. qui dicitur fuisse 
             <lb ed="#V" n="127"/>vocatus Alanus fuit huiusmodi opinionis quod pater et filius non 
-            <lb ed="#V" n="128"/>debeant dici idem principium spiritus sancti: et ideo qui vult tenem opionem 
+            <lb ed="#V" n="128"/>debeant dici idem principium spiritus sancti: et ideo qui vult tenere opinionem 
             <lb ed="#V" n="129"/>illam non debent recipere verba illius in proposito.
           </p>
         </div>
@@ -363,7 +363,7 @@
             ¶ Item in enchy. c. 13. In quibus rebus nihil 
             in<lb ed="#V" n="84" break="no"/>terest ad capscendum dei regnum vtrum credantur an non: vel 
             <lb ed="#V" n="85"/>vtrum vera siue sint: siue putentur an falsa in his errare et aliud 
-            <lb ed="#V" n="86"/>pro alio putare non est arbitrandum esse peccatum: aute si est mimum atque 
+            <lb ed="#V" n="86"/>pro alio putare non est arbitrandum esse peccatum: aut si est mimum atque 
             <lb ed="#V" n="87"/>breuissimum esse: sed aliquid tale est circa principiationem spiritus 
             <lb ed="#V" n="88"/>sancti: vtpote procedere per modum nexus: ergo videtur quod 
             <lb ed="#V" n="89"/>opinari contrarium non est peccatum: aut si est: est paruum. 

--- a/kzz7yh-a63171/cod-ve07v1_kzz7yh-a63171.xml
+++ b/kzz7yh-a63171/cod-ve07v1_kzz7yh-a63171.xml
@@ -67,7 +67,7 @@
         </p>
         <p xml:id="kzz7yh-a63171-d1e119">
           ¶ Tertio vtrum sit 
-          pec<lb ed="#V" n="34" break="no"/>catum conrie opinari de principiatione spiritus sancti.
+          pec<lb ed="#V" n="34" break="no"/>catum contrarie opinari de principiatione spiritus sancti.
         </p>
         <p xml:id="kzz7yh-a63171-d1e125">
           ¶ 
@@ -115,7 +115,7 @@
           <p xml:id="kzz7yh-a63171-d1e197">
             ¶ Item in commento super eandem propositionem dicitur quod non 
             <lb ed="#V" n="59"/>est concedendum patrem et filium esse aliquod principium spiritus sancti. 
-            <lb ed="#V" n="60"/>Sed si essent idem principium sptus sancti essent aliquod principium spiritus sciti: 
+            <lb ed="#V" n="60"/>Sed si essent idem principium spiritus sancti essent aliquod principium spiritus sciti: 
             <lb ed="#V" n="61"/>vt videtur: ergo non sunt idem principium spiritus sancti. 
           </p>
           <p xml:id="kzz7yh-a63171-d1e206">
@@ -164,7 +164,7 @@
           </p>
           <p xml:id="kzz7yh-a63171-d1e292">
             ¶ Qui vult hanc secundam opinionem tenere potest 
-            raspio<lb ed="#V" n="96" break="no"/>dere ad argumenta. In opposipium enim dicitur quod idem et diuersum sus 
+            raspio<lb ed="#V" n="96" break="no"/>dere ad argumenta. In oppositum enim dicitur quod idem et diuersum sus 
             <lb ed="#V" n="97"/>ficienter diuidunt ens. Dico quod verum est referendo ad ide 
           </p>
           <p xml:id="kzz7yh-a63171-d1e300">
@@ -253,7 +253,7 @@
             <lb ed="#V" n="11"/>rem: ergo vniuoce dicitur in vtroque. 
           </p>
           <p xml:id="kzz7yh-a63171-d1e446">
-            <lb ed="#V" n="12"/>Contra in commento sup. 51 propotionem de maximis 
+            <lb ed="#V" n="12"/>Contra in commento sup. 51 proportionem de maximis 
             <lb ed="#V" n="13"/>theologie: dicitur vniuoce videtur dici hoc nomen 
             <lb ed="#V" n="14"/>principium cum pater dicitur principium filii: et principium spiritus 
             <lb ed="#V" n="15"/>sancti: ergo multo fortius cum dicitur principium spiritus sancti et 
@@ -299,8 +299,8 @@
             eter<lb ed="#V" n="45" break="no"/>na: vel quando aliquid dicitur de vtroque in relatione ad 
             creatu<lb ed="#V" n="46" break="no"/>ram: vt si dicatur: deus est principium creature: pater est 
             prin<lb ed="#V" n="47" break="no"/>cipium creature: ratio principii vniuoce accipitur in vtroque. 
-            <lb ed="#V" n="48"/>Sed cum aliquid dicitur de persona in relatione adaliam 
-            perso<lb ed="#V" n="49" break="no"/>nam: et de essentia in relatione ad creaturam: non opetet quod 
+            <lb ed="#V" n="48"/>Sed cum aliquid dicitur de persona in relatione ad aliam 
+            perso<lb ed="#V" n="49" break="no"/>nam: et de essentia in relatione ad creaturam: non oportet quod 
             il<lb ed="#V" n="50" break="no"/>lud dicatur de deo vniuoce in vtroque.
           </p>
           <p xml:id="kzz7yh-a63171-d1e544">
@@ -328,7 +328,7 @@
             <lb ed="#V" n="61"/>Tertio queritur vtrum sit peccatum contrarium 
             opi<lb ed="#V" n="62" break="no"/>nari de principiatione spiritus sancti: et 
             vide<lb ed="#V" n="63" break="no"/>tur quod sic: quia Augu. ie. de trinitate c. 3. loquens de trini. 
-            <lb ed="#V" n="64"/>dicit quod non periculosius alicubrerratur sed 
+            <lb ed="#V" n="64"/>dicit quod non periculosius alicubi erratur sed 
             opinia<lb ed="#V" n="65" break="no"/>ri contrarium veritati: que est de processione spiritus sancti: est 
             er<lb ed="#V" n="66" break="no"/>rare circa trinitatem: ergo peccatum est contrarium opinari 
             <lb ed="#V" n="67"/>de principiatione spiritus sancti.
@@ -346,7 +346,7 @@
             ¶ Item omnis opinio contra veritatem peccatum 
             <lb ed="#V" n="72"/>est: quia tunc mens discordat a regula recta: ergo maxime 
             pec<lb ed="#V" n="73" break="no"/>catum est opinari contra veritatem fidei. Sed opinari 
-            con<lb ed="#V" n="74" break="no"/>trarium de pocessione spiritus sancti est opinari contra 
+            con<lb ed="#V" n="74" break="no"/>trarium de processione spiritus sancti est opinari contra 
             <lb ed="#V" n="75"/>veritatem fidei: ergo peccatum est. 
           </p>
           <p xml:id="kzz7yh-a63171-d1e621">
@@ -371,7 +371,7 @@
           <p xml:id="kzz7yh-a63171-d1e658">
             <lb ed="#V" n="90"/>¶ Item saluator in Euan. secundum Ioannem 15 c. Si non 
             ve<lb ed="#V" n="91" break="no"/>nissem et locutus ei non fuissem: peccatum non haberent. ergo 
-            <lb ed="#V" n="92"/>illi qubus nihil dictum est de aliquibus pertinentibus ad 
+            <lb ed="#V" n="92"/>illi quibus nihil dictum est de aliquibus pertinentibus ad 
             principia<lb ed="#V" n="93" break="no"/>tionem spiritus sancti: vtpote quod procedit per modum 
             ne<lb ed="#V" n="94" break="no"/>xus possunt opinari contrarium sine peccato. 
           </p>
@@ -415,13 +415,13 @@
           </p>
           <p xml:id="kzz7yh-a63171-d1e743">
             ¶ Argumenta ad 
-            <lb ed="#V" n="125"/>opposipium scilicet primum et tertium bene probant quod opinari contrarium 
+            <lb ed="#V" n="125"/>oppositum scilicet primum et tertium bene probant quod opinari contrarium 
             <lb ed="#V" n="126"/>alicui quod annexum est principiationi spus sancti quod non est 
             ex<lb ed="#V" n="127" break="no"/>pressum in scriptura: vel expresse determinatum ab ecclesia potest 
             <lb ed="#V" n="128"/>esse sine peccato: et hac est verum nisi postquam videret homo quod ad 
             <lb ed="#V" n="129"/>suam opinionem sequeretur contrarium alicui expresso in 
             scri<lb ed="#V" n="130" break="no"/>ptura. vel determinato ab ecclesia: et si illa opinio non 
-            proce<lb ed="#V" n="131" break="no"/>debat ex inquerendi negligentia nec erat cum pertinacia. 
+            proce<lb ed="#V" n="131" break="no"/>debat ex inquirendi negligentia nec erat cum pertinacia. 
           </p>
           <p xml:id="kzz7yh-a63171-d1e762">
             <lb ed="#V" n="132"/>¶ Secundum argumentum quo arguitur per auctoritatem Aug. procedit 


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve07v1_kzz7yh-a63171.xml`.

## Applied changes

- p. 92v l. 34: conrie → contrarie: missing letters
- p. 92v l. 60: sptus → spiritus: abbreviation garbled
- p. 92v l. 96: opposipium → oppositum: garbled
- p. 93r l. 12: propotionem → proportionem: missing r
- p. 93r l. 48: adaliam → ad aliam: missing space
- p. 93r l. 49: opetet → oportet: t/r transposition
- p. 93r l. 64: alicubrerratur → alicubi erratur: garbled
- p. 93r l. 74: pocessione → processione: p/pr confusion
- p. 93r l. 92: qubus → quibus: missing i
- p. 93r l. 125: opposipium → oppositum: garbled
- p. 93r l. 131: inquerendi → inquirendi: e/i misread

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_