### PR TITLE
Transcription corrections: cod-ve07v1_kzz7yh-a63932.xml (2 changes)

### DIFF
--- a/kzz7yh-a63932/cod-ve07v1_kzz7yh-a63932.xml
+++ b/kzz7yh-a63932/cod-ve07v1_kzz7yh-a63932.xml
@@ -206,7 +206,7 @@
         </p>
         <p xml:id="kzz7yh-a63932-d1e397">
           ¶ Tertio determinat modum quo ista de deo 
-          <lb ed="#V" n="31"/>dicuntur ibi. (Quomdo ergo obtinebim).
+          <lb ed="#V" n="31"/>dicuntur ibi. (Quomodo ergo obtinebimus.
         </p>
         <p xml:id="kzz7yh-a63932-d1e403">
           ¶ Quarto soluit 

--- a/kzz7yh-a63932/cod-ve07v1_kzz7yh-a63932.xml
+++ b/kzz7yh-a63932/cod-ve07v1_kzz7yh-a63932.xml
@@ -181,9 +181,9 @@
         <p xml:id="kzz7yh-a63932-d1e359">
           Distinctio XXX 
           <lb ed="#V" n="20"/>SUnt enim quedam etc. Superius 
-          determi<lb ed="#V" n="21" break="no"/>nauit magister de nomibus quae dicuntur 
+          determi<lb ed="#V" n="21" break="no"/>nauit magister de nominibus quae dicuntur 
           <lb ed="#V" n="22"/>de deo relatiue secundum rem et modum signndi. Hic 
-          deter<lb ed="#V" n="23" break="no"/>minat de nonibus que de deo dicuntur relatiue secundum 
+          deter<lb ed="#V" n="23" break="no"/>minat de nominibus que de deo dicuntur relatiue secundum 
           mo<lb ed="#V" n="24" break="no"/>dum signandi tantum: vel secundum dici: et diuiditur in partes duas: quia 
           pri<lb ed="#V" n="25" break="no"/>mo determinat de his que important relationem ad 
           creatu<lb ed="#V" n="26" break="no"/>ras.


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve07v1_kzz7yh-a63932.xml`.

## Applied changes

- p. 94r l. 21: nomibus → nominibus: missing in (split stem)
- p. 94r l. 23: nonibus → nominibus: garbled

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_