### PR TITLE
Transcription corrections: cod-ve07v1_kzz7yh-a64242.xml (17 changes)

### DIFF
--- a/kzz7yh-a64242/cod-ve07v1_kzz7yh-a64242.xml
+++ b/kzz7yh-a64242/cod-ve07v1_kzz7yh-a64242.xml
@@ -228,7 +228,7 @@
           </p>
           <p xml:id="kzz7yh-a64242-d1e378">
             ¶ Item accidens est quod adest 
-            <lb ed="#V" n="119"/>et abest preter subitecnti corruptionem. Sed ea que dicuntur de deo ex 
+            <lb ed="#V" n="119"/>et abest preter subiecti corruptionem. Sed ea que dicuntur de deo ex 
             <lb ed="#V" n="120"/>tempore possunt abesse et adesse praeter dei corruptionem: ergo prosentur 
             de<lb ed="#V" n="121" break="no"/>deo secundum accidens.
           </p>
@@ -245,7 +245,7 @@
             <lb ed="#V" n="128"/>dicuntur de deo dicuntur de ipso per se.
           </p>
           <p xml:id="kzz7yh-a64242-d1e408">
-            ¶ Item omene quod dicitur de 
+            ¶ Item omne quod dicitur de 
             ali<lb ed="#V" n="129" break="no"/>quo per accidens: ponit in ipso mutationem in actu: vel in 
             po<lb ed="#V" n="130" break="no"/>tentia: sed deus mutari non potest: ergo nihil dicitur de eo 
             <lb ed="#V" n="131"/>per accidens.
@@ -267,12 +267,12 @@
             <lb ed="#V" n="7"/>vnita: aut quod sint accidentia in alio existentia: et sic creator et 
             <lb ed="#V" n="8"/>dominus dicuntur de deo per accidens: aut quantum ad illud quod 
             impor<lb ed="#V" n="9" break="no"/>tatur de eorum significato primo: aut ex consequenti: quia de 
-            eo<lb ed="#V" n="10" break="no"/>rum signato aut primo: aut ex conseqenti est quedam habitudo que 
+            eo<lb ed="#V" n="10" break="no"/>rum signato aut primo: aut ex consequenti est quedam habitudo que 
             <lb ed="#V" n="11"/>est in creatura secundum rem: et in deo secundum rationem et secundum dici. 
             Il<lb ed="#V" n="12" break="no"/>la autem relatio realis accidens est creature extendendo nomen 
             <lb ed="#V" n="13"/>accidentis ad omne illud quod non est substantia: nec pars substantiae: et ab 
             <lb ed="#V" n="14"/>illa relatione nominatur deus sub ratione qua creator: vel sub 
-            <lb ed="#V" n="15"/>ratione qua dominus: demtratum enim est supra quomon 
+            <lb ed="#V" n="15"/>ratione qua dominus: demtratum enim est supra quomodo 
             aliquan<lb ed="#V" n="16" break="no"/>do aliquid potest denominari ab eo quod est in alio realiter.
           </p>
           <p xml:id="kzz7yh-a64242-d1e465">
@@ -302,7 +302,7 @@
           <p xml:id="kzz7yh-a64242-d1e508">
             ¶ Ad 3m cum dicitur quod 
             <lb ed="#V" n="33"/>accidens est quod adest et abest etc. dico quod illud est accidens 
-            <lb ed="#V" n="34"/>rei de quae dicitur si sibi inhereat: aliter non: illa autem hitudo realiter a 
+            <lb ed="#V" n="34"/>rei de quae dicitur si sibi inhereat: aliter non: illa autem habitudo realiter a 
             <lb ed="#V" n="35"/>qua deus denominatur creator: vel dominus: non est aliquid deo 
             in<lb ed="#V" n="36" break="no"/>herens.
           </p>
@@ -318,7 +318,7 @@
           </p>
           <p xml:id="kzz7yh-a64242-d1e537">
             ¶ Uel potest dici quod 
-            il<lb ed="#V" n="44" break="no"/>lud verbum philosophi non tenet nisi de his que peredicantur de 
+            il<lb ed="#V" n="44" break="no"/>lud verbum philosophi non tenet nisi de his que praedicantur de 
             <lb ed="#V" n="45"/>creaturis vbi reperitur genus et diffinitio. Deus autem nec 
             ge<lb ed="#V" n="46" break="no"/>nus habet nec diffinitionem. 
             <!--TODO: insert paragraph break here-->
@@ -358,7 +358,7 @@
             significa<lb ed="#V" n="64" break="no"/>rent aliquam rationem illa relatio esset dei ad creaturas. Sed 
             <lb ed="#V" n="65"/>talis relatio communis esset tribus personis. Cum ergo aliqua 
             <lb ed="#V" n="66"/>dicantur de deo ex tempore que non conueniunt tribus personis vt 
-            <lb ed="#V" n="67"/>esse incarnatum: esse missum: videtur quod non signrent relationem. 
+            <lb ed="#V" n="67"/>esse incarnatum: esse missum: videtur quod non signarent relationem. 
           </p>
           <p xml:id="kzz7yh-a64242-d1e606">
             <lb ed="#V" n="68"/>¶ Item non potest negari quin ista nomina creator et guberna¬ 
@@ -366,10 +366,10 @@
             <cb ed="#P" n="b"/>
             <lb ed="#V" n="69"/>tor dicant divinam substantiam cum de qualem dicantur persona. Sed 
             <lb ed="#V" n="70"/>sicut dicit magister supra Di. 22. c. sciendum que relatiue dicuntur 
-            <lb ed="#V" n="71"/>substantialiter non dicuntur: ergo ista nomina dominus et creator non signnt ralationem. 
+            <lb ed="#V" n="71"/>substantialiter non dicuntur: ergo ista nomina dominus et creator non significant ralationem. 
           </p>
           <p xml:id="kzz7yh-a64242-d1e622">
-            <lb ed="#V" n="72"/>Contra nomina que non signt substantiam significant relationem. 
+            <lb ed="#V" n="72"/>Contra nomina que non significant substantiam significant relationem. 
             <lb ed="#V" n="73"/>Sed ea que conueniunt deo ex tempore non videtur 
             <lb ed="#V" n="74"/>significare divinam substantiam: quia ab eterno conuenit deo ergo 
             signi<lb ed="#V" n="75" break="no"/>ficant rationem.
@@ -394,7 +394,7 @@
             <lb ed="#V" n="86"/>connotat habitudinem in actu: et quae est in creatura secundum rem: 
             <lb ed="#V" n="87"/>et opposita habitudo est in deo secundum rationem. Quedam 
             impo<lb ed="#V" n="88" break="no"/>nuntur ad signandum ipsam habitudinem: vt ista nomina dominus 
-            <lb ed="#V" n="89"/>et superior: et ista signnt rationem: que est in deo secundum rationem. Cutus 
+            <lb ed="#V" n="89"/>et superior: et ista signnt rationem: que est in deo secundum rationem. Cuius 
             <lb ed="#V" n="90"/>opposita relatio est in creatura secundum rem: et ex consequenti dant 
             in<lb ed="#V" n="91" break="no"/>telligere divinam substantiam tanquam rem que a tali habitudine 
             de<lb ed="#V" n="92" break="no"/>nominatur.
@@ -402,7 +402,7 @@
           <p xml:id="kzz7yh-a64242-d1e679">
             ¶ Quedam autem significant divinam actionem passiuo 
             <lb ed="#V" n="93"/>modo significatam: vt incarnatus: missus: et dant intelligere 
-            <lb ed="#V" n="94"/>realem rluationem persone ad personam: vt persone misse ad 
+            <lb ed="#V" n="94"/>realem relationem persone ad personam: vt persone misse ad 
             perso<lb ed="#V" n="95" break="no"/>nam a qua emanat quia non mittitur nisi persona emanans. 
             In<lb ed="#V" n="96" break="no"/>carnatus etiam dat intelligere habitudinem vnius persone ad aliam: 
             <lb ed="#V" n="97"/>que soli filio conuenit. Connotant etiam illa nomina relationem 
@@ -460,7 +460,7 @@
             <lb ed="#V" n="133"/>hominem dictum de deo det intelligere relationem in natura 
             hu<lb ed="#V" n="134" break="no"/>mana ad filium dei: vt ad principium a quo est: et etiam ad divinam substantiam 
             <lb ed="#V" n="135"/>tamen quia prius significat relationem in natura humana ad filium dei: vt 
-            <lb ed="#V" n="136"/>ad suppositum in quo est: et ideo non opetet quod conueniat pluribus personis
+            <lb ed="#V" n="136"/>ad suppositum in quo est: et ideo non oportet quod conueniat pluribus personis
           </p>
         </div>
         <div xml:id="kzz7yh-a64242-Dd1e794">
@@ -528,7 +528,7 @@
             <lb ed="#V" n="36"/>non ponunt in deo aliquam realem relationem ad creaturam. 
           </p>
           <p xml:id="kzz7yh-a64242-d1e906">
-            <lb ed="#V" n="37"/>Respondeo quod ea que de deo dicuentur ex tempore non ponunt 
+            <lb ed="#V" n="37"/>Respondeo quod ea que de deo dicentur ex tempore non ponunt 
             <lb ed="#V" n="38"/>in deo aliquam relationem realem ad 
             creatu<lb ed="#V" n="39" break="no"/>ram sed tantummodo secundum rationem et secundum dici. Ad cuius pleniorem 
             <lb ed="#V" n="40"/>intelligentiam sciendum quod cum relatio requirat duo extrema 
@@ -554,7 +554,7 @@
           <p xml:id="kzz7yh-a64242-d1e957">
             ¶ Quedam vero 
             <lb ed="#V" n="59"/>sunt relationes reales quantum ad vtrunque extremum: vt omnis 
-            <lb ed="#V" n="60"/>relatio conseqens extrema secundum esse reale: sicut duplum: et 
+            <lb ed="#V" n="60"/>relatio consequens extrema secundum esse reale: sicut duplum: et 
             dimi<lb ed="#V" n="61" break="no"/>dium: que consequuntur quantitatem: paternitas et filiatio quae 
             consequun<lb ed="#V" n="62" break="no"/>tur actionem et passionem et multe alie. Quandoque vero est 
             re<lb ed="#V" n="63" break="no"/>latio in vno extremorum secundum rem: et in alio secundum rationem tantum: et 
@@ -573,7 +573,7 @@
             <lb ed="#V" n="74"/>sed quia alia referuntur ad ipsa. Cum igitur deus sit extra 
             to<lb ed="#V" n="75" break="no"/>tum ordinem creature: et omnes creature ordinentur ad ipsum: et 
             <lb ed="#V" n="76"/>non econuerso manifestum est quod omnes creature referuntur ad 
-            <lb ed="#V" n="77"/>deum relatione reali: sed in deo non est realis rlautio ad creaturas: sed 
+            <lb ed="#V" n="77"/>deum relatione reali: sed in deo non est realis relatio ad creaturas: sed 
             <lb ed="#V" n="78"/>secundum rationem et secundum dici tantum inquantum scilicet creature referuntur ad ipsum.
           </p>
           <p xml:id="kzz7yh-a64242-d1e1007">
@@ -591,7 +591,7 @@
             <lb ed="#V" n="85"/>¶ Ad 3m cum dicitur quod dominium maneret in deo et si nullus 
             intel<lb ed="#V" n="86" break="no"/>lectus hoc apprehenderet etc. dico quod verum est quantum ad 
             po<lb ed="#V" n="87" break="no"/>testatem per quam sibi subiecit creaturam: non tamen quantum ad 
-            <lb ed="#V" n="88"/>respectum in ipso deo: tamen non est possibile quain apprehendatur 
+            <lb ed="#V" n="88"/>respectum in ipso deo: tamen non est possibile quin apprehendatur 
             <lb ed="#V" n="89"/>illud ab aliquo intellectu: quia semper intelligitur ab intellectu 
             <lb ed="#V" n="90"/>diuino.
           </p>
@@ -612,7 +612,7 @@
             <lb ed="#V" n="97"/>6m cum dicitur quod relatio realis potest aduenire aliter sine sui 
             mu<lb ed="#V" n="98" break="no"/>tatione etc. dico quod verum est sine mutatione secundum aliquid 
             abso<lb ed="#V" n="99" break="no"/>lutum non tamen sine mutatione secundum rem relatiuam: quia ante non 
-            <lb ed="#V" n="100"/>erat in ipso illa res relatima que postea in ipso est. Uel potest 
+            <lb ed="#V" n="100"/>erat in ipso illa res relatiua que postea in ipso est. Uel potest 
             <lb ed="#V" n="101"/>dici quod ratio quare non potest aduenire deo aliqua realis 
             <lb ed="#V" n="102"/>relatio de nouo non est tantum: quia mutaretur: sed etiam quia est extra 
             or<lb ed="#V" n="103" break="no"/>dinem creaturarum: quapropter non potest in ipso esse realit rlulo ad creaturam.

--- a/kzz7yh-a64242/cod-ve07v1_kzz7yh-a64242.xml
+++ b/kzz7yh-a64242/cod-ve07v1_kzz7yh-a64242.xml
@@ -236,7 +236,7 @@
             ¶ Item secundum philosophum idst topi. quatuor sunt praeta scilicet 
             ge<lb ed="#V" n="122" break="no"/>nus: diffinitio: proprium: accidens. Sed ea que dicuntur de deo ex 
             tem<lb ed="#V" n="123" break="no"/>pore: non dicuntur de deo tanquam genus: neque tanquam 
-            diffini<lb ed="#V" n="124" break="no"/>tio: neque omnia dicuntur de deo tamquam proprium: quia esse dicnum non conuertuntur 
+            diffini<lb ed="#V" n="124" break="no"/>tio: neque omnia dicuntur de deo tamquam proprium: quia esse debent non conuertuntur 
             <lb ed="#V" n="125"/>cum deo. Restat ergo quod saltem esse dominum dicitur de deo per accidens. 
           </p>
           <p xml:id="kzz7yh-a64242-d1e399">
@@ -387,7 +387,7 @@
           <p xml:id="kzz7yh-a64242-d1e648">
             <lb ed="#V" n="80"/>Respondeo quod ea que dicuntur de deo ex tempore rationem 
             <lb ed="#V" n="81"/>significant autem connotant: quia aut ipsam 
-            <lb ed="#V" n="82"/>relationem significant primo aute eam dant intelligere ex conseqenti. 
+            <lb ed="#V" n="82"/>relationem significant primo aut eam dant intelligere ex conseqenti. 
             <lb ed="#V" n="83"/>Eorum enim que dicuntur de deo ex tempore quedam significant rem 
             <lb ed="#V" n="84"/>supra quam fundatur habitudo: sicut creator et gubernator: 
             <lb ed="#V" n="85"/>que significant divinam actionem intrinsecam que deus est: et 
@@ -539,7 +539,7 @@
             in<lb ed="#V" n="45" break="no"/>telligit intellectus aliquid vnum: illo vtitur vt duobus. 
             Si<lb ed="#V" n="46" break="no"/>militer relatio que est inter ens et non ens: est res rationis tantum 
             <lb ed="#V" n="47"/>a parte vtriusque extremi. Non entis enim non potest esse 
-            ali<lb ed="#V" n="48" break="no"/>qua realis relatio vt subiteanti: quia sicut dicit Auice. i. Meta. c. 5. 
+            ali<lb ed="#V" n="48" break="no"/>qua realis relatio vt subiecti: quia sicut dicit Auice. i. Meta. c. 5. 
             <lb ed="#V" n="49"/>si proprietas fuit aliquid: tunc illud de quo illa dicitur: erit 
             ali<lb ed="#V" n="50" break="no"/>quid sine dubio. Sed non ens non est aliquid. Similiter non 
             <lb ed="#V" n="51"/>ens non potest esse terminus realis relationis: et ideo entis ad non 


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve07v1_kzz7yh-a64242.xml`.

## Applied changes

- p. 94r l. 119: subitecnti → subiecti: garbled
- p. 94r l. 128: omene → omne: extra e inserted
- p. 94v l. 10: conseqenti → consequenti: missing u
- p. 94v l. 15: demtratum → demonstratum; quomon → quomodo
- p. 94v l. 34: hitudo → habitudo: missing ha (theological term)
- p. 94v l. 44: peredicantur → praedicantur: per-/prae- misread
- p. 94v l. 67: signrent → signarent: missing a
- p. 94v l. 71: signnt → significant: garbled abbreviation
- p. 94v l. 72: signt → significant: garbled abbreviation
- p. 94v l. 89: signnt → significant; Cutus → Cuius
- p. 94v l. 94: rluationem → relationem: garbled
- p. 94v l. 136: opetet → oportet: t/r transposition
- p. 95r l. 37: dicuentur → dicentur: extra u
- p. 95r l. 60: conseqens → consequens: missing u
- p. 95r l. 77: rlautio → relatio: garbled
- p. 95r l. 88: quain → quin: extra a
- p. 95r l. 100: relatima → relatiua: m/u misread

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_