### PR TITLE
Transcription corrections: cod-ve07v1_kzz7yh-a66883.xml (3 changes)

### DIFF
--- a/kzz7yh-a66883/cod-ve07v1_kzz7yh-a66883.xml
+++ b/kzz7yh-a66883/cod-ve07v1_kzz7yh-a66883.xml
@@ -347,7 +347,7 @@
         <p xml:id="kzz7yh-a66883-d1e710">
           Distinctio XXXII 
           <lb ed="#V" n="8"/>Hic oritur quo ex praedictis deducta etc. Superius 
-          <lb ed="#V" n="9"/>determinauit magister nominum rlultorum significantium 
+          <lb ed="#V" n="9"/>determinauit magister nominum relatorum significantium 
           <lb ed="#V" n="10"/>relationem secundum rationem personarum inter se: signationem et 
           eorum<lb ed="#V" n="11" break="no"/>dem appropriationem. Hic iuxta hoc mouet incidenter 
           du<lb ed="#V" n="12" break="no"/>plicem dubitationem. Quia enim circa finem praecedenti Di. dixerat 
@@ -361,7 +361,7 @@
         </p>
         <p xml:id="kzz7yh-a66883-d1e736">
           ¶ 2o mouet aliam 
-          <lb ed="#V" n="17"/>isti aliquood consimilem: quamuis in rei veritate non sit similis ex toto scilicet 
+          <lb ed="#V" n="17"/>isti aliquod consimilem: quamuis in rei veritate non sit similis ex toto scilicet 
           <lb ed="#V" n="18"/>vtrum pater sit sapiens sapientia genita: ibi. (Presumptus diligenter 
           inuestiga<lb ed="#V" n="19" break="no"/>ri.)
         </p>
@@ -372,7 +372,7 @@
         </p>
         <p xml:id="kzz7yh-a66883-d1e752">
           ¶ In 2o quaestionem soluit: ibi. (Huic quaestioni). Secunda partem 
-          <lb ed="#V" n="22"/>que ibi incipit. (Preus diligenter inuestigari etc) et diuiditur in 
+          <lb ed="#V" n="22"/>que ibi incipit. (Praeterea diligenter inuestigari etc) et diuiditur in 
           <lb ed="#V" n="23"/>partes quattuor.
         </p>
         <p xml:id="kzz7yh-a66883-d1e759">

--- a/kzz7yh-a66883/cod-ve07v1_kzz7yh-a66883.xml
+++ b/kzz7yh-a66883/cod-ve07v1_kzz7yh-a66883.xml
@@ -361,7 +361,7 @@
         </p>
         <p xml:id="kzz7yh-a66883-d1e736">
           ¶ 2o mouet aliam 
-          <lb ed="#V" n="17"/>isti aliquod consimilem: quamuis in rei veritate non sit similis ex toto scilicet 
+          <lb ed="#V" n="17"/>isti aliquo modo consimilem: quamuis in rei veritate non sit similis ex toto scilicet 
           <lb ed="#V" n="18"/>vtrum pater sit sapiens sapientia genita: ibi. (Presumptus diligenter 
           inuestiga<lb ed="#V" n="19" break="no"/>ri.)
         </p>

--- a/kzz7yh-a66883/cod-ve07v1_kzz7yh-a66883.xml
+++ b/kzz7yh-a66883/cod-ve07v1_kzz7yh-a66883.xml
@@ -348,10 +348,10 @@
           Distinctio XXXII 
           <lb ed="#V" n="8"/>Hic oritur quo ex praedictis deducta etc. Superius 
           <lb ed="#V" n="9"/>determinauit magister nominum rlultorum significantium 
-          <lb ed="#V" n="10"/>relationem secundum rationem personarum inter se: signationem et eorum 
-          <lb ed="#V" n="11"/>dem appropriationem. Hic iuxta hoc mouet incidenter 
+          <lb ed="#V" n="10"/>relationem secundum rationem personarum inter se: signationem et 
+          eorum<lb ed="#V" n="11" break="no"/>dem appropriationem. Hic iuxta hoc mouet incidenter 
           du<lb ed="#V" n="12" break="no"/>plicem dubitationem. Quia enim circa finem praecedenti Di. dixerat 
-          <lb ed="#V" n="13"/>quod spiritus sanctus est amor quo pater diligit filium et silius patrem. Ido 
+          <lb ed="#V" n="13"/>quod spiritus sanctus est amor quo pater diligit filium et silius patrem. Ideo 
           oc<lb ed="#V" n="14" break="no"/>casione huius hic mouet ex illo verbo dubitationem et aliam sibi 
           <lb ed="#V" n="15"/>similem. Et diditur pars ista in tres partes
         </p>
@@ -377,7 +377,7 @@
         </p>
         <p xml:id="kzz7yh-a66883-d1e759">
           ¶ primo enim mouet istam quaestionem scilicet vtrum pater sit sapiens 
-          <lb ed="#V" n="24"/>sapientia genita: et eam deteriat in partem negatiuam.
+          <lb ed="#V" n="24"/>sapientia genita: et eam determinat in partem negatiuam.
         </p>
         <p xml:id="kzz7yh-a66883-d1e764">
           ¶ Secundo 


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve07v1_kzz7yh-a66883.xml`.

## Applied changes

- p. 99r l. 11: split word: add break="no" to lb
- p. 99r l. 13: Ido → Ideo: missing e
- p. 99r l. 24: deteriat → determinat: missing min

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_