### PR TITLE
Transcription corrections: cod-ve07v1_kzz7yh-a67606.xml (22 changes)

### DIFF
--- a/kzz7yh-a67606/cod-ve07v1_kzz7yh-a67606.xml
+++ b/kzz7yh-a67606/cod-ve07v1_kzz7yh-a67606.xml
@@ -107,10 +107,10 @@
           </p>
           <p xml:id="kzz7yh-a67606-d1e183">
             ¶ Item spiritus 
-            <lb ed="#V" n="66"/>sanctus non diligit semetipsum a seipo amore essentiali: quia dilige¬ 
+            <lb ed="#V" n="66"/>sanctus non diligit semetipsum a seipo amore essentiali: quia ¬ 
             <!--00211.xml-->
             <cb ed="#P" n="b"/>
-            <lb ed="#V" n="67"/>re essentialiter habet a patre: nec dilectione notionali: quia talis 
+            dilige<lb ed="#V" n="67" break="no"/>re essentialiter habet a patre: nec dilectione notionali: quia talis 
             dile<lb ed="#V" n="68" break="no"/>ctio emanat a diligente: ergo spiritus sanctus a seipso non 
             di<lb ed="#V" n="69" break="no"/>ligit se: non est ergo verum quod quilibet persona diligat se spiritusco. 
           </p>
@@ -131,7 +131,7 @@
           <p xml:id="kzz7yh-a67606-d1e223">
             <lb ed="#V" n="79"/>Respondeo quod quelem persona se et quamlibet aliam diligit 
             <lb ed="#V" n="80"/>spiritu sancto: quia pater diligit filium spiritu sancto: et 
-            <lb ed="#V" n="81"/>eocslusio <!--abbreviation-->: pater etiam diligit se spiritu sancto: et filius etiam diligit se spiritu sancto. 
+            <lb ed="#V" n="81"/>econverso <!--abbreviation-->: pater etiam diligit se spiritu sancto: et filius etiam diligit se spiritu sancto. 
             <lb ed="#V" n="82"/>Spiritus sanctus diligit se spiritu sancto: et pater et filius diligunt spiritum sanctum 
             <lb ed="#V" n="83"/>spiritu sancto. Quod autem pater diligat filium spiritu sancto et 
             <lb ed="#V" n="84"/>econuerso declaro sic.
@@ -149,7 +149,7 @@
             perso<lb ed="#V" n="93" break="no"/>nali denominari possunt pater et filius a quibus procedit: vnde 
             <lb ed="#V" n="94"/>si verbo diligendi significetur amor personalis vere dicitur quod 
             <lb ed="#V" n="95"/>pater diligit filium spiritusancto et econuerso: et tunc construitur ablatiuus non 
-            in<lb ed="#V" n="96" break="no"/>hitudine causae efficientis: nec hitudine cauale foralis: sed importat 
+            in<lb ed="#V" n="96" break="no"/>habitudine causae efficientis: nec hitudine cauale foralis: sed importat 
             hi<lb ed="#V" n="97" break="no"/>tudinem rei producte habentis actum forme in denominando: 
             <lb ed="#V" n="98"/>Si tamen verbo diligendi significetur amor essentialis: sic non 
             <lb ed="#V" n="99"/>est verum quod pater diligat filium spiritu sancto nec econuerso: 

--- a/kzz7yh-a67606/cod-ve07v1_kzz7yh-a67606.xml
+++ b/kzz7yh-a67606/cod-ve07v1_kzz7yh-a67606.xml
@@ -109,7 +109,7 @@
             ¶ Item spiritus 
             <lb ed="#V" n="66"/>sanctus non diligit semetipsum a seipo amore essentiali: quia
             <!--00211.xml-->
-            dilige <cb ed="#P" n="b"/><lb ed="#V" n="67" break="no"/>re essentialiter habet a patre: nec dilectione notionali: quia talis 
+            dilige<cb ed="#P" n="b"/><lb ed="#V" n="67" break="no"/>re essentialiter habet a patre: nec dilectione notionali: quia talis 
             dile<lb ed="#V" n="68" break="no"/>ctio emanat a diligente: ergo spiritus sanctus a seipso non 
             di<lb ed="#V" n="69" break="no"/>ligit se: non est ergo verum quod quilibet persona diligat se spiritusco. 
           </p>

--- a/kzz7yh-a67606/cod-ve07v1_kzz7yh-a67606.xml
+++ b/kzz7yh-a67606/cod-ve07v1_kzz7yh-a67606.xml
@@ -109,8 +109,7 @@
             ¶ Item spiritus 
             <lb ed="#V" n="66"/>sanctus non diligit semetipsum a seipo amore essentiali: quia
             <!--00211.xml-->
-            <cb ed="#P" n="b"/>
-            dilige<lb ed="#V" n="67" break="no"/>re essentialiter habet a patre: nec dilectione notionali: quia talis 
+            dilige <cb ed="#P" n="b"/><lb ed="#V" n="67" break="no"/>re essentialiter habet a patre: nec dilectione notionali: quia talis 
             dile<lb ed="#V" n="68" break="no"/>ctio emanat a diligente: ergo spiritus sanctus a seipso non 
             di<lb ed="#V" n="69" break="no"/>ligit se: non est ergo verum quod quilibet persona diligat se spiritusco. 
           </p>

--- a/kzz7yh-a67606/cod-ve07v1_kzz7yh-a67606.xml
+++ b/kzz7yh-a67606/cod-ve07v1_kzz7yh-a67606.xml
@@ -63,7 +63,7 @@
           <lb ed="#V" n="42"/>spiritu sancto.
         </p>
         <p xml:id="kzz7yh-a67606-d1e113">
-          ¶ Secundo vtrum queliet persona diligat nos spirituscuon¬. 
+          ¶ Secundo vtrum quelibet persona diligat nos spirituscuon¬. 
         </p>
         <div xml:id="kzz7yh-a67606-Dd1e115">
           <head xml:id="kzz7yh-a67606-Hd1e117">Quaestio 1</head>
@@ -92,13 +92,13 @@
             <lb ed="#V" n="57"/>sunt spiritu scilicet. Secundum etiam quod diligere accipitur 
             notionali<lb ed="#V" n="58" break="no"/>ter non videtur esse verum: quia tale diligere idem est quod 
             spi<lb ed="#V" n="59" break="no"/>rare: sed pater et filius non spirant spiritu sancto: non est ergo verum 
-            <lb ed="#V" n="60"/>quod quialibet persona diligat se et quamlibet aliam spiritu sancto.
+            <lb ed="#V" n="60"/>quod quelibet persona diligat se et quamlibet aliam spiritu sancto.
           </p>
           <p xml:id="kzz7yh-a67606-d1e166">
             ¶ Item eiusdem 
             <lb ed="#V" n="61"/>actus notionalis non potest esse idem terius a quo et in quem: cum 
-            <lb ed="#V" n="62"/>ergo dilectionis personalis qua pater diligit: ipse pater sit terius 
-            <lb ed="#V" n="63"/>a quo non potest esse illius terius in quem. Similiter potest argui de filio 
+            <lb ed="#V" n="62"/>ergo dilectionis personalis qua pater diligit: ipse pater sit tertius 
+            <lb ed="#V" n="63"/>a quo non potest esse illius tertius in quem. Similiter potest argui de filio 
             <lb ed="#V" n="64"/>ergo pater non diligit se spiritu sancto.
           </p>
           <p xml:id="kzz7yh-a67606-d1e178">
@@ -123,8 +123,8 @@
           </p>
           <p xml:id="kzz7yh-a67606-d1e212">
             ¶ Item non magis diligit pater filium: 
-            <lb ed="#V" n="75"/>nec filius patrem quam quam persona seipsam: et quamlet aliam: ergo 
-            dilecto<lb ed="#V" n="76" break="no"/>ne qua pater diligit filium et filius patrem: quialet persona diligit se et 
+            <lb ed="#V" n="75"/>nec filius patrem quam quam persona seipsam: et quamlibet aliam: ergo 
+            dilecto<lb ed="#V" n="76" break="no"/>ne qua pater diligit filium et filius patrem: quelibet persona diligit se et 
             <lb ed="#V" n="77"/>quanlibet aliam: cum ergo pater spiritu sancto diligat filium et ecoclusio: videtur 
             <lb ed="#V" n="78"/>quod quelibet persona diligat se et quamlem aliam spiritu sancto. 
           </p>
@@ -148,7 +148,7 @@
             <lb ed="#V" n="92"/>est enim amor emanans a patre et filio: ideo isto amore 
             perso<lb ed="#V" n="93" break="no"/>nali denominari possunt pater et filius a quibus procedit: vnde 
             <lb ed="#V" n="94"/>si verbo diligendi significetur amor personalis vere dicitur quod 
-            <lb ed="#V" n="95"/>pater diligit filium spiritusancto et econuso: et tunc construitur ablatiuus non 
+            <lb ed="#V" n="95"/>pater diligit filium spiritusancto et econuerso: et tunc construitur ablatiuus non 
             in<lb ed="#V" n="96" break="no"/>hitudine causae efficientis: nec hitudine cauale foralis: sed importat 
             hi<lb ed="#V" n="97" break="no"/>tudinem rei producte habentis actum forme in denominando: 
             <lb ed="#V" n="98"/>Si tamen verbo diligendi significetur amor essentialis: sic non 
@@ -180,7 +180,7 @@
             <lb ed="#V" n="122"/>etiam filius tantum spirat hunc amorem in patrem: vt in 
             obie<lb ed="#V" n="123" break="no"/>ctum: sed etiam in seipsum vt in obiectu: ideo hoc 
             amore<lb ed="#V" n="124" break="no"/>non tantum pater diligit filium: sed etiam seipsum: nec filius tantum 
-            <lb ed="#V" n="125"/>patrem: sed etiam seipsum. Dico etiam quod spitus sanctus diligit se spiritu 
+            <lb ed="#V" n="125"/>patrem: sed etiam seipsum. Dico etiam quod spiritus sanctus diligit se spiritu 
             <lb ed="#V" n="126"/>sancto loquendo de amore essentiali: non tamen a seipso: 
             <lb ed="#V" n="127"/>quia totum quicquid habet: habet a patre et filio. Sed diligit se 
             <lb ed="#V" n="128"/>per seipsum: secundum quod ly per dicit habitudinem quasi similem 
@@ -197,8 +197,8 @@
             <pb ed="#V" n="99-v"/>
             <cb ed="#P" n="a"/>
             <lb ed="#V" n="1"/>gendi et accusatiuum et ablatiuum eadem res signatur sed per actum 
-            <lb ed="#V" n="2"/>signatur vt actio: per accusatiuum vt terius actus per ablatiuum 
-            <lb ed="#V" n="3"/>est aliquomon similis actui formali in denominando: sicut cum 
+            <lb ed="#V" n="2"/>signatur vt actio: per accusatiuum vt tertius actus per ablatiuum 
+            <lb ed="#V" n="3"/>est aliquomodo similis actui formali in denominando: sicut cum 
             <lb ed="#V" n="4"/>dicitur intelligere actu intelligendi: quia per hoc quod dico 
             intel<lb ed="#V" n="5" break="no"/>ligo: significo idem vt actum quod significo per intelligere vt 
             <lb ed="#V" n="6"/>termini: et quod significo cum dico actu intelligendi: vt habens 
@@ -207,7 +207,7 @@
             <lb ed="#V" n="9"/>actum diligendi prior est secundum rationem intelligendi seipso signato 
             <lb ed="#V" n="10"/>vt est terius actus et inquantum signatur per istum ablatiuum 
             spi<lb ed="#V" n="11" break="no"/>sancto prior est secundum rationem intelligendi seipso signato per actum 
-            <lb ed="#V" n="12"/>et seipso signato vt est terius actus. Non enim est inconueniens 
+            <lb ed="#V" n="12"/>et seipso signato vt est tertius actus. Non enim est inconueniens 
             <lb ed="#V" n="13"/>vt idem sub diuersis rationibus sit prius seipso secundum rationem intelligendi.
           </p>
           <p xml:id="kzz7yh-a67606-d1e391">
@@ -230,18 +230,18 @@
             <lb ed="#V" n="24"/>spiritu sancto etc. dico quod verum est: sed ex hoc non sequitur quod pret 
             fi<lb ed="#V" n="25" break="no"/>lius non diligunt sptu sancto secundum quod diligere accipitur notiona 
             <lb ed="#V" n="26"/>liter: quia licet dligere notionaliter: et spirare spiritum sanctum idem 
-            <lb ed="#V" n="27"/>signnt in divinis non tamen eodem modo: quia diligere signt et 
+            <lb ed="#V" n="27"/>significant in divinis non tamen eodem modo: quia diligere signt et 
             emana<lb ed="#V" n="28" break="no"/>tionem et personam emanantem. Sed spirare non signat formaliter 
             <lb ed="#V" n="29"/>nisi ipsam emanationem sicut videmus quod in signato dicendi 
             in<lb ed="#V" n="30" break="no"/>cluditur emanatio verbi et verbum: non autem in signato generandi: 
-            <lb ed="#V" n="31"/>ideo concedimus quod pater dicit verbo: nec tamen generat verbo: et simliter 
-            <lb ed="#V" n="32"/>concedimus quod pater et filius diligunt spiritusancto: nec tamen spirant 
+            <lb ed="#V" n="31"/>ideo concedimus quod pater dicit verbo: nec tamen generat verbo: et similiter 
+            <lb ed="#V" n="32"/>concedimus quod pater et filius diligunt spiritu sancto: nec tamen spirant 
             spiritu<lb ed="#V" n="33" break="no"/>sancto.
           </p>
           <p xml:id="kzz7yh-a67606-d1e442">
             ¶ Ad 4m cum dicitur quod eiusdem actus notionalis non 
-            <lb ed="#V" n="34"/>potest esse idem terius a quo et in quem etc. dico quod verum est: si 
-            ter<lb ed="#V" n="35" break="no"/>minus in quem vocetur res spirata: non autem est verum si terius in 
+            <lb ed="#V" n="34"/>potest esse idem tertius a quo et in quem etc. dico quod verum est: si 
+            ter<lb ed="#V" n="35" break="no"/>minus in quem vocetur res spirata: non autem est verum si tertius in 
             <lb ed="#V" n="36"/>quem vocetur ille in quem spiratur: sicut in obiectum: pater autem spirat 
             <lb ed="#V" n="37"/>spiritum sanctum in seipsum: vt in obiectum amatum.
           </p>
@@ -251,7 +251,7 @@
             <lb ed="#V" n="39"/>generet verbum verbo.
           </p>
           <p xml:id="kzz7yh-a67606-d1e461">
-            ¶ Ad 6m cum dicitur quod spiritus sanctus a seipsc 
+            ¶ Ad 6m cum dicitur quod spiritus sanctus a seipso 
             <lb ed="#V" n="40"/>non diligit seipsum amore essentiali etc. dico quod falsum est: 
             quam<lb ed="#V" n="41" break="no"/>uis non diligat seipsum a seipso: quia quod diligat se hoc habet a pre: 
             <lb ed="#V" n="42"/>et filio amore ergo essentiali diligit seipsum a seipso id est per seipsum 
@@ -287,7 +287,7 @@
             san<lb ed="#V" n="58" break="no"/>ctus est amor patris et filii quo se inuicem amant 
             <lb ed="#V" n="59"/>et nos. Sed qua ratione pater et filius diligunt nos spiritu sancto: 
             <lb ed="#V" n="60"/>eadem ratione a fortiori spiritus sanctus amat nos spiritu sancto: 
-            er<lb ed="#V" n="61" break="no"/>go qualet persona diligit nos spiritu sancto.
+            er<lb ed="#V" n="61" break="no"/>go quelibet persona diligit nos spiritu sancto.
           </p>
           <p xml:id="kzz7yh-a67606-d1e528">
             ¶ Item pater eodem 
@@ -302,7 +302,7 @@
             <lb ed="#V" n="68"/>essentialis: et notionalis. Amor autem essentialis dei ad nos potest 
             <!--00212.xml-->
             <cb ed="#P" n="b"/>
-            <lb ed="#V" n="69"/>accipi duplciter vel ratione signati vel ratione effectus connotati. 
+            <lb ed="#V" n="69"/>accipi dupliciter vel ratione signati vel ratione effectus connotati. 
             Pri<lb ed="#V" n="70" break="no"/>moos non potest dici quod diligant nos spiritu sancto: quia prius est secundum 
             <lb ed="#V" n="71"/>rationem intelligendi amor essentialis quam spiritus sanctus. Si autem 
             <lb ed="#V" n="72"/>accipiatur pro connotato quod est collatio alicuius doni gratuiti. 
@@ -310,7 +310,7 @@
             appropria<lb ed="#V" n="74" break="no"/>te tamen: non proprie: quia collatio illius doni gratuiti est a 
             to<lb ed="#V" n="75" break="no"/>ta trinitate: sed appropriatur spiritui sancto. Si autem intelligatur de 
             <lb ed="#V" n="76"/>amore notionali secundum quod comprehendit emanationem et personam 
-            <lb ed="#V" n="77"/>verbaliter signtam: sic dico quod pater et filius diligunt nos spiritu 
+            <lb ed="#V" n="77"/>verbaliter signatam: sic dico quod pater et filius diligunt nos spiritu 
             san<lb ed="#V" n="78" break="no"/>cto: quia spirant in nos spum sanctum tanquam in obiectum. Sicut 
             <lb ed="#V" n="79"/>enim pater vnum verbum producit: quo se et omnia alia dicit: sic pater 
             <lb ed="#V" n="80"/>et filius spirant amorem quo se et omnia alia diligunt. Sed 
@@ -333,7 +333,7 @@
             amo<lb ed="#V" n="95" break="no"/>re essentiali.
           </p>
           <p xml:id="kzz7yh-a67606-d1e613">
-            ¶ Ad 2m cum dicitur quod deus non diligit cteaturam 
+            ¶ Ad 2m cum dicitur quod deus non diligit creaturam 
             <lb ed="#V" n="96"/>irrationalem sptu sancto etc. dico quod slum est: quia quamuis pater et filius 
             <lb ed="#V" n="97"/>non spirant in creaturam irrationalem spiritum sanctum vt in subiectum: 
             <lb ed="#V" n="98"/>spirant tamen ipsum in eam vt in obiectum.
@@ -344,7 +344,7 @@
             <lb ed="#V" n="100"/>ex hoc non sequitur quod non diligat nos spiritu sancto: quia 
             cognosce<lb ed="#V" n="101" break="no"/>re in divinis non accipitur nisi essentialiter tantum: diligere autem 
             acci<lb ed="#V" n="102" break="no"/>pitur et essentialiter et notionaliter. Uerum est autem quod pater non 
-            dili<lb ed="#V" n="103" break="no"/>git nos spiritsancto secundum quod diligere accipitur essentialiter 
+            dili<lb ed="#V" n="103" break="no"/>git nos spiritu sancto secundum quod diligere accipitur essentialiter 
             <lb ed="#V" n="104"/>nisi accipiatur dilectio essentialis ratione effectus 
             conno<lb ed="#V" n="105" break="no"/>tati: qui appropriatur spiritui sancto. 
           </p>

--- a/kzz7yh-a67606/cod-ve07v1_kzz7yh-a67606.xml
+++ b/kzz7yh-a67606/cod-ve07v1_kzz7yh-a67606.xml
@@ -107,7 +107,7 @@
           </p>
           <p xml:id="kzz7yh-a67606-d1e183">
             ¶ Item spiritus 
-            <lb ed="#V" n="66"/>sanctus non diligit semetipsum a seipo amore essentiali: quia ¬ 
+            <lb ed="#V" n="66"/>sanctus non diligit semetipsum a seipo amore essentiali: quia
             <!--00211.xml-->
             <cb ed="#P" n="b"/>
             dilige<lb ed="#V" n="67" break="no"/>re essentialiter habet a patre: nec dilectione notionali: quia talis 


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve07v1_kzz7yh-a67606.xml`.

## Applied changes

- p. 99r l. 42: queliet → quelibet: missing b
- p. 99r l. 60: quialibet → quelibet: ia/e misread
- p. 99r l. 62: terius → tertius: missing t
- p. 99r l. 63: terius → tertius: missing t
- p. 99r l. 75: quamlet → quamlibet: missing li
- p. 99r l. 76: quialet → quelibet: ia/e misread
- p. 99r l. 95: econuso → econuerso: missing er
- p. 99r l. 125: spitus → spiritus: missing r
- p. 99v l. 2: terius → tertius: missing t
- p. 99v l. 3: aliquomon → aliquomodo: missing do
- p. 99v l. 12: terius → tertius: missing t
- p. 99v l. 27: signnt → significant: garbled abbreviation
- p. 99v l. 31: simliter → similiter: missing i
- p. 99v l. 32: spiritusancto → spiritu sancto: missing space
- p. 99v l. 34: terius → tertius: missing t
- p. 99v l. 35: terius → tertius: missing t
- p. 99v l. 39: seipsc → seipso: c/o misread
- p. 99v l. 61: qualet → quelibet: al/eli misread
- p. 99v l. 69: duplciter → dupliciter: missing i
- p. 99v l. 77: signtam → signatam: missing a
- p. 99v l. 95: cteaturam → creaturam: extra t
- p. 99v l. 103: spiritsancto → spiritu sancto: garbled + missing space

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_