### PR TITLE
Transcription corrections: cod-ve07v1_kzz7yh-a69293.xml (10 changes)

### DIFF
--- a/kzz7yh-a69293/cod-ve07v1_kzz7yh-a69293.xml
+++ b/kzz7yh-a69293/cod-ve07v1_kzz7yh-a69293.xml
@@ -92,8 +92,8 @@
             <lb ed="#V" n="50"/>quam ipsam constituere personam.
           </p>
           <p xml:id="kzz7yh-a69293-d1e162">
-            ¶ Item proprietatem constitue 
-            <lb ed="#V" n="51"/>re personam importat ipsam esse in relatione ad hypostasim: sed 
+            ¶ Item proprietatem 
+            constitue<lb ed="#V" n="51" break="no"/>re personam importat ipsam esse in relatione ad hypostasim: sed 
             <lb ed="#V" n="52"/>proprietatem esse non importat ipsam esse in relatione ad 
             hypo<lb ed="#V" n="53" break="no"/>stasim. Cum ergo non relatum prius sit relato secundum rationem 
             <lb ed="#V" n="54"/>intelligendi. Prius est secundum rationem intelligendi proprietatem 
@@ -215,7 +215,7 @@
             <!--00217.xml-->
             <pb ed="#V" n="102-r"/>
             <cb ed="#P" n="a"/>
-            <lb ed="#V" n="1"/>ergo ipsa a actiua spiratio non est persona.
+            <lb ed="#V" n="1"/>ergo ipsa actiua spiratio non est persona.
           </p>
           <p xml:id="kzz7yh-a69293-d1e397">
             ¶ Item si 

--- a/kzz7yh-a69293/cod-ve07v1_kzz7yh-a69293.xml
+++ b/kzz7yh-a69293/cod-ve07v1_kzz7yh-a69293.xml
@@ -110,7 +110,7 @@
           <p xml:id="kzz7yh-a69293-d1e192">
             ¶ Item secundum philosophum 
             <lb ed="#V" n="62"/>vii. Metaphy. Forma non generatur: sed compositum 
-            er<lb ed="#V" n="63" break="no"/>go prius est compositum generari quam formam: et sic prins 
+            er<lb ed="#V" n="63" break="no"/>go prius est compositum generari quam formam: et sic prius 
             na<lb ed="#V" n="64" break="no"/>turaliter est compositum quam forma: ergo a simili secundum rationem 
             <lb ed="#V" n="65"/>intelligendi prius est persona constituta proprietate: quam 
             proprie<lb ed="#V" n="66" break="no"/>tas.
@@ -128,7 +128,7 @@
           </p>
           <p xml:id="kzz7yh-a69293-d1e225">
             ¶ Item quantum res 
-            <lb ed="#V" n="73"/>habet de esse tantu habet de perfectione: sed ratio perfecti prius 
+            <lb ed="#V" n="73"/>habet de esse tantum habet de perfectione: sed ratio perfecti prius 
             <lb ed="#V" n="74"/>secundum rationem intelligendi conuenit persone quam proprietati: ergo 
             <lb ed="#V" n="75"/>etiam esse secundum rationem intelligendi prius conuenit persone quam 
             <lb ed="#V" n="76"/>proprietati: quod non esset verum si proprietatem esse prius esset secundum 
@@ -141,7 +141,7 @@
             intelligen<lb ed="#V" n="81" break="no"/>di proprietatem esse quam ipsam constituere personam: sicut prius 
             <lb ed="#V" n="82"/>est formam esse in intellectu quam compositum. Possum enim 
             <lb ed="#V" n="83"/>intelligere formam apprehensione simpliciter que est sine 
-            com<lb ed="#V" n="84" break="no"/>positione et disione non intellecto composito: nec econuerso. 
+            com<lb ed="#V" n="84" break="no"/>positione et diuisione non intellecto composito: nec econuerso. 
             <lb ed="#V" n="85"/>Sed loquendo de esse actuali in re extra prius secundum rationem 
             <lb ed="#V" n="86"/>intelligendi est personam esse constitutam per proprietatem quam 
             proprie<lb ed="#V" n="87" break="no"/>tatem esse: vel idem important sine omni differentia: sicut dicunt 
@@ -173,7 +173,7 @@
           <p xml:id="kzz7yh-a69293-d1e310">
             ¶ Uidetur 
             <lb ed="#V" n="107"/>ergo dicendum quod forma vt intellecta per se intelligitur vt 
-            ha<lb ed="#V" n="108" break="no"/>bens imperfectu esse: vt autem intellecta actu pars compositi 
+            ha<lb ed="#V" n="108" break="no"/>bens imperfectum esse: vt autem intellecta actu pars compositi 
             <lb ed="#V" n="109"/>intelligitur vt habens perfectionem essendi que sibi conuenit. 
             <lb ed="#V" n="110"/>Dico ergo quod loquendo de esse primo prius natura est 
             for<lb ed="#V" n="111" break="no"/>ma quam compositu: et partes toto. Sed loquendo de esse secundo 
@@ -219,8 +219,8 @@
           </p>
           <p xml:id="kzz7yh-a69293-d1e397">
             ¶ Item si 
-            proprie<lb ed="#V" n="2" break="no"/>tas est person ia et inquantum est persona: non est relatio: videretur 
-            <lb ed="#V" n="3"/>verum dix isse Gylibertus poretanus quod relationes non 
+            proprie<lb ed="#V" n="2" break="no"/>tas est persona et inquantum est persona: non est relatio: videretur 
+            <lb ed="#V" n="3"/>verum dixisse Gylibertus poretanus quod relationes non 
             <lb ed="#V" n="4"/>sunt in per sonis quod falsum est. 
             <!--TODO: insert para break here-->
             <lb ed="#V" n="5"/>Contra <sic>propritas</sic> res aliqua est: ergo cum sit in 
@@ -244,7 +244,7 @@
             <lb ed="#V" n="16"/>Ad primum in oppositum cum dicitur quod multiplicatis 
             pro<lb ed="#V" n="17" break="no"/>prietatibus non multiplicatur persone secundum 
             <lb ed="#V" n="18"/>numerum earum etc. dico quod falsum est si loquaris de 
-            proprie<lb ed="#V" n="19" break="no"/>tatibus perso nalibus: sicut enim non sunt nisi tres persone: ita 
+            proprie<lb ed="#V" n="19" break="no"/>tatibus personalibus: sicut enim non sunt nisi tres persone: ita 
             <lb ed="#V" n="20"/>non sunt nisi tres proprietates personales: sed si nomen 
             proprie<lb ed="#V" n="21" break="no"/>tatis extendas ad notiones sic plures sunt proprietates quam 
             <lb ed="#V" n="22"/>persone. et tamen comparate ad personas in quibus sunt: realiter 
@@ -252,7 +252,7 @@
             <lb ed="#V" n="24"/>secundum rationem: id eo possunt esse plures personas manente vna 
             <lb ed="#V" n="25"/>sicut videmus quod quia persona secundum rationem differt ab essentia: et 
             <lb ed="#V" n="26"/>in modo se abendi. Uidemus quod essentia manente vna 
-            plu<lb ed="#V" n="27" break="no"/>res sunt perisone quamuis comperate ad essentiam: realiter idem 
+            plu<lb ed="#V" n="27" break="no"/>res sunt persone quamuis comperate ad essentiam: realiter idem 
             <lb ed="#V" n="28"/>sint cum ea.
           </p>
           <p xml:id="kzz7yh-a69293-d1e468">
@@ -267,7 +267,7 @@
           <p xml:id="kzz7yh-a69293-d1e484">
             ¶ Ad 3m cum 
             <lb ed="#V" n="35"/>dicitur quod vna proprietas non est due persone etc. dico quod si 
-            ex<lb ed="#V" n="36" break="no"/>tendas nomen proprietatis ad rlauationem falsum est. 
+            ex<lb ed="#V" n="36" break="no"/>tendas nomen proprietatis ad relationem falsum est. 
             Spiratio<lb ed="#V" n="37" break="no"/>enim actiua est realiter idem quod pater et filius.
           </p>
           <p xml:id="kzz7yh-a69293-d1e493">
@@ -279,7 +279,7 @@
             <lb ed="#V" n="42"/>est ad aliam. Unde patet Gylibertum poretanum male dixisse 
             <lb ed="#V" n="43"/>quando dixit proprietas non esse in personis. sed extrinse. 
             <lb ed="#V" n="44"/>cus assistentes: quia vere in personis sunt: et realiter sunt ipse 
-            <lb ed="#V" n="45"/>persone: in qunibus sunt: et tamen per comparationem ad 
+            <lb ed="#V" n="45"/>persone: in quibus sunt: et tamen per comparationem ad 
             <lb ed="#V" n="46"/>terminum vere manent relationes. 
           </p>
         </div>

--- a/kzz7yh-a69293/cod-ve07v1_kzz7yh-a69293.xml
+++ b/kzz7yh-a69293/cod-ve07v1_kzz7yh-a69293.xml
@@ -92,7 +92,7 @@
             <lb ed="#V" n="50"/>quam ipsam constituere personam.
           </p>
           <p xml:id="kzz7yh-a69293-d1e162">
-            ¶ Item proprietatem constitus 
+            ¶ Item proprietatem constitue 
             <lb ed="#V" n="51"/>re personam importat ipsam esse in relatione ad hypostasim: sed 
             <lb ed="#V" n="52"/>proprietatem esse non importat ipsam esse in relatione ad 
             hypo<lb ed="#V" n="53" break="no"/>stasim. Cum ergo non relatum prius sit relato secundum rationem 
@@ -183,7 +183,7 @@
             ha<lb ed="#V" n="115" break="no"/>bere esse perfectum: est ipsam esse partem compositi 
             haben<lb ed="#V" n="116" break="no"/>tis esse perfectum. Aliqualiter dico a simili quod quamuis in divinis 
             <lb ed="#V" n="117"/>non possit distingui de esse perfecto et imperfecto realiter: tamen 
-            <lb ed="#V" n="118"/>secundum rationem intelligendi perfectius intelligitur res inetellecta 
+            <lb ed="#V" n="118"/>secundum rationem intelligendi perfectius intelligitur res <sic>inetellecta</sic> 
             <lb ed="#V" n="119"/>sub ratione qua persona quam sub ratione qua proprietas tantum: 
             di<lb ed="#V" n="120" break="no"/>co ergo quod proprietatem esse sub ratione intelligendi 
             imperfe<lb ed="#V" n="121" break="no"/>cta prius est secundum rationem intelligendi: quam ipsum constituere 
@@ -215,7 +215,7 @@
             <!--00217.xml-->
             <pb ed="#V" n="102-r"/>
             <cb ed="#P" n="a"/>
-            <lb ed="#V" n="1"/>ergo ipsa a ctiua spiratio non est persona.
+            <lb ed="#V" n="1"/>ergo ipsa a actiua spiratio non est persona.
           </p>
           <p xml:id="kzz7yh-a69293-d1e397">
             ¶ Item si 
@@ -238,7 +238,7 @@
             <lb ed="#V" n="12"/>est persona cuius est: sed non est illa ad quam est. Unde concede 
             <lb ed="#V" n="13"/>quod paternitas realiter est ipse pater: et filiatio realiter est ipse 
             <lb ed="#V" n="14"/>filius: vnde proprietas inquantum subsistens sunt ipse 
-            per<lb ed="#V" n="15" break="no"/>sone: differi int tamen secundum rationem a personis.
+            per<lb ed="#V" n="15" break="no"/>sone: differunt tamen secundum rationem a personis.
           </p>
           <p xml:id="kzz7yh-a69293-d1e437">
             <lb ed="#V" n="16"/>Ad primum in oppositum cum dicitur quod multiplicatis 


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve07v1_kzz7yh-a69293.xml`.

## Applied changes

- p. 101v l. 63: prins → prius: n/u misread
- p. 101v l. 73: tantu → tantum: missing m
- p. 101v l. 84: disione → diuisione: missing ui
- p. 101v l. 108: imperfectu → imperfectum: missing m
- p. 102r l. 3: dix isse → dixisse: spurious space
- p. 102r l. 19: perso nalibus → personalibus: spurious space
- p. 102r l. 27: perisone → persone: extra i
- p. 102r l. 36: rlauationem → relationem: garbled
- p. 102r l. 45: qunibus → quibus: extra n
- p. 102r l. 2: person ia → persona: spurious space

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_