### PR TITLE
Transcription corrections: cod-ve07v1_kzz7yh-a69711.xml (5 changes)

### DIFF
--- a/kzz7yh-a69711/cod-ve07v1_kzz7yh-a69711.xml
+++ b/kzz7yh-a69711/cod-ve07v1_kzz7yh-a69711.xml
@@ -108,7 +108,7 @@
           </p>
           <p xml:id="kzz7yh-a69711-d1e185">
             <lb ed="#V" n="70"/>Respondeo quod proprietates suit ipsa diuina 
-            essen<lb ed="#V" n="71" break="no"/>tia: quia vt demtratum est in 
+            essen<lb ed="#V" n="71" break="no"/>tia: quia vt demonstratum est in 
             questio<lb ed="#V" n="72" break="no"/>ne precedenti proprietas realiter est persona cuius est. Sed 
             <lb ed="#V" n="73"/>vt superius dictum est et infra ostendetur persona realiter est ipsuam 
             <lb ed="#V" n="74"/>essentia ergo proprietas realiter est ipsa diuina essentia. Et 
@@ -126,8 +126,8 @@
           <p xml:id="kzz7yh-a69711-d1e219">
             ¶ Ad 2m cum dicitur quod quecunque sunt idem secundum rem in 
             <lb ed="#V" n="83"/>quocunque est vnum est aliud etc. Dico quod instantiam habet 
-            <lb ed="#V" n="84"/>quaendocunque illa identitas est cum differentia secundum rationem: et cum 
-            <lb ed="#V" n="85"/>differentia secundum modum se habendi. Et sic se habet propritas 
+            <lb ed="#V" n="84"/>quandocunque illa identitas est cum differentia secundum rationem: et cum 
+            <lb ed="#V" n="85"/>differentia secundum modum se habendi. Et sic se habet proprietas 
             <lb ed="#V" n="86"/>ad essentiam.
           </p>
           <p xml:id="kzz7yh-a69711-d1e230">
@@ -140,9 +140,9 @@
             ¶ Ad 
             <lb ed="#V" n="90"/>4 m dicitur quod illud quod est substantia: non est relatio etc. 
             <lb ed="#V" n="91"/>dico quod in diuinis habet instantiam. Relatio enim 
-            compera<lb ed="#V" n="92" break="no"/>ta ad rem in qua est: substantia est: et tamen per comparationem ad terium 
+            compera<lb ed="#V" n="92" break="no"/>ta ad rem in qua est: substantia est: et tamen per comparationem ad tertium 
             <lb ed="#V" n="93"/>manet relatio: cum ergo eadem sit relatio que est in vna persona 
-            <lb ed="#V" n="94"/>ad aliam: rlartio eadem vt in aliquo est substantia: vt ad alium manet rlaulo. 
+            <lb ed="#V" n="94"/>ad aliam: relatio eadem vt in aliquo est substantia: vt ad alium manet rlaulo. 
           </p>
         </div>
         <div xml:id="kzz7yh-a69711-Dd1e255">

--- a/kzz7yh-a69711/cod-ve07v1_kzz7yh-a69711.xml
+++ b/kzz7yh-a69711/cod-ve07v1_kzz7yh-a69711.xml
@@ -110,7 +110,7 @@
             <lb ed="#V" n="70"/>Respondeo quod proprietates suit ipsa diuina 
             essen<lb ed="#V" n="71" break="no"/>tia: quia vt demonstratum est in 
             questio<lb ed="#V" n="72" break="no"/>ne precedenti proprietas realiter est persona cuius est. Sed 
-            <lb ed="#V" n="73"/>vt superius dictum est et infra ostendetur persona realiter est ipsuam 
+            <lb ed="#V" n="73"/>vt superius dictum est et infra ostendetur persona realiter est ipsa 
             <lb ed="#V" n="74"/>essentia ergo proprietas realiter est ipsa diuina essentia. Et 
             <lb ed="#V" n="75"/>hoc sentit magister in presenti Di. c. Quod enim hanc 
             opinio<lb ed="#V" n="76" break="no"/>nem confirmans per <ref xml:id="kzz7yh-a69711-Rd1e208">Hyla. in. 7. lib. de tri.</ref> hanc sententiam dicentem.
@@ -132,7 +132,7 @@
           </p>
           <p xml:id="kzz7yh-a69711-d1e230">
             ¶ Ad 3m cum dicitur quod in eadem re impossibile est 
-            <lb ed="#V" n="87"/>eadem conueniter: et differre etc. dico quod instantiam habet 
+            <lb ed="#V" n="87"/>eadem conuenire: et differre etc. dico quod instantiam habet 
             quan<lb ed="#V" n="88" break="no"/>do aliqua ita idem sunt re quid secundum rationem differunt in 
             mo<lb ed="#V" n="89" break="no"/>do se habendi. Et sic idem sunt re proprietas et essentia.
           </p>


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve07v1_kzz7yh-a69711.xml`.

## Applied changes

- p. 102r l. 71: demtratum → demonstratum: missing ons
- p. 102r l. 84: quaendocunque → quandocunque: extra ae
- p. 102r l. 85: propritas → proprietas: missing e
- p. 102r l. 92: terium → tertium: missing t
- p. 102r l. 94: rlartio → relatio: garbled

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_