### PR TITLE
Transcription corrections: cod-ve07v1_kzz7yh-a69979.xml (3 changes)

### DIFF
--- a/kzz7yh-a69979/cod-ve07v1_kzz7yh-a69979.xml
+++ b/kzz7yh-a69979/cod-ve07v1_kzz7yh-a69979.xml
@@ -119,7 +119,7 @@
             pro<lb ed="#V" n="32" break="no"/>prie loquendo: quia actio est suppositi: quamuis per formam.
           </p>
           <p xml:id="kzz7yh-a69979-d1e213">
-            <lb ed="#V" n="33"/>Ad primum in  cum dicitur quod adiectiua 
+            <lb ed="#V" n="33"/>Ad primum in oppositum cum dicitur quod adiectiua 
             essentia<lb ed="#V" n="34" break="no"/>lia sunt ipsa essentia etc. dico quod ex hoc 
             <lb ed="#V" n="35"/>non sequitur propositum. Quod enim essentia predicetur de 
             proprie<lb ed="#V" n="36" break="no"/>tate: non autem intelligere vel velle: hoc non est propter 
@@ -212,11 +212,11 @@
             ¶ Ad 2m dico quod si ista 
             <lb ed="#V" n="92"/>concedatur: candor est candidus: non propter hoc sequitur quod ista 
             <lb ed="#V" n="93"/>debeat concedi: paternitas generat: quia esse candidum non 
-            di<lb ed="#V" n="94" break="no"/>cit actum significatum vt ab alio: sed vt in alio: vnde esse causa 
-            <lb ed="#V" n="95"/>didum significat actum vt in candore: generare autem 
+            di<lb ed="#V" n="94" break="no"/>cit actum significatum vt ab alio: sed vt in alio: vnde esse 
+            can<lb ed="#V" n="95" break="no"/>didum significat actum vt in candore: generare autem 
             signi<lb ed="#V" n="96" break="no"/>ficat actum vt ab alio. Potest tamen dici quod ista non est 
             <lb ed="#V" n="97"/>satis propria: candor enim est candidus: sed pro proprie dicendo 
-            <lb ed="#V" n="98"/>debemus dicem rem esse causam dictam per canadorem.
+            <lb ed="#V" n="98"/>debemus dicem rem esse candidam per candorem.
           </p>
           <p xml:id="kzz7yh-a69979-d1e396">
             ¶ Ad 3m cum dicitur quod 

--- a/kzz7yh-a69979/cod-ve07v1_kzz7yh-a69979.xml
+++ b/kzz7yh-a69979/cod-ve07v1_kzz7yh-a69979.xml
@@ -195,12 +195,12 @@
             signifi<lb ed="#V" n="79" break="no"/>cat actum: et per modum actus. Generatio vero non sic: sed 
             <lb ed="#V" n="80"/>per modum quasi cuiusdam forme: et quia actus sunt 
             supposi<lb ed="#V" n="81" break="no"/>torum quamuis per formas: non autem proprie ipsari im formarum 
-            <lb ed="#V" n="82"/>vt agentium: sed vt principiorum: per que supposite ragunt: ideo 
+            <lb ed="#V" n="82"/>vt agentium: sed vt principiorum: per que supposite agunt: ideo 
             <lb ed="#V" n="83"/><sic>quanuis</sic> hec sit concedenda: pater generat: hec tamen non 
             <lb ed="#V" n="84"/>est concedenda: paternitas generat.
           </p>
           <p xml:id="kzz7yh-a69979-d1e360">
-            <lb ed="#V" n="85"/>Ad primum in oppositum cum dicitur quod ca lidus ignis 
+            <lb ed="#V" n="85"/>Ad primum in oppositum cum dicitur quod ca calidus ignis 
             <lb ed="#V" n="86"/>calefacit etc. Dico quod he: est 
             impro<lb ed="#V" n="87" break="no"/>pria: non tamen sicut ista. paternitas generat eo quod caliditas 
             <lb ed="#V" n="88"/>est forma absoluta: paternitas vero forma relatiua. Et etiam 
@@ -215,7 +215,7 @@
             di<lb ed="#V" n="94" break="no"/>cit actum significatum vt ab alio: sed vt in alio: vnde esse causa 
             <lb ed="#V" n="95"/>didum significat actum vt in candore: generare autem 
             signi<lb ed="#V" n="96" break="no"/>ficat actum vt ab alio. Potest tamen dici quod ista non est 
-            <lb ed="#V" n="97"/>satis propria: candor enim est candidus: sed pro prie dicendo 
+            <lb ed="#V" n="97"/>satis propria: candor enim est candidus: sed pro proprie dicendo 
             <lb ed="#V" n="98"/>debemus dicem rem esse causadidam per canadorem.
           </p>
           <p xml:id="kzz7yh-a69979-d1e396">

--- a/kzz7yh-a69979/cod-ve07v1_kzz7yh-a69979.xml
+++ b/kzz7yh-a69979/cod-ve07v1_kzz7yh-a69979.xml
@@ -119,7 +119,7 @@
             pro<lb ed="#V" n="32" break="no"/>prie loquendo: quia actio est suppositi: quamuis per formam.
           </p>
           <p xml:id="kzz7yh-a69979-d1e213">
-            <lb ed="#V" n="33"/>Ad primum in oppotro cum dicitur quod adiectiua 
+            <lb ed="#V" n="33"/>Ad primum in  cum dicitur quod adiectiua 
             essentia<lb ed="#V" n="34" break="no"/>lia sunt ipsa essentia etc. dico quod ex hoc 
             <lb ed="#V" n="35"/>non sequitur propositum. Quod enim essentia predicetur de 
             proprie<lb ed="#V" n="36" break="no"/>tate: non autem intelligere vel velle: hoc non est propter 
@@ -194,7 +194,7 @@
             ge<lb ed="#V" n="78" break="no"/>nerare et generatio: tamen diuerso modo: quia generare 
             signifi<lb ed="#V" n="79" break="no"/>cat actum: et per modum actus. Generatio vero non sic: sed 
             <lb ed="#V" n="80"/>per modum quasi cuiusdam forme: et quia actus sunt 
-            supposi<lb ed="#V" n="81" break="no"/>torum quamuis per formas: non autem proprie ipsari im formarum 
+            supposi<lb ed="#V" n="81" break="no"/>torum quamuis per formas: non autem proprie  ipsarum formarum 
             <lb ed="#V" n="82"/>vt agentium: sed vt principiorum: per que supposite agunt: ideo 
             <lb ed="#V" n="83"/><sic>quanuis</sic> hec sit concedenda: pater generat: hec tamen non 
             <lb ed="#V" n="84"/>est concedenda: paternitas generat.
@@ -216,7 +216,7 @@
             <lb ed="#V" n="95"/>didum significat actum vt in candore: generare autem 
             signi<lb ed="#V" n="96" break="no"/>ficat actum vt ab alio. Potest tamen dici quod ista non est 
             <lb ed="#V" n="97"/>satis propria: candor enim est candidus: sed pro proprie dicendo 
-            <lb ed="#V" n="98"/>debemus dicem rem esse causadidam per canadorem.
+            <lb ed="#V" n="98"/>debemus dicem rem esse causam dictam per canadorem.
           </p>
           <p xml:id="kzz7yh-a69979-d1e396">
             ¶ Ad 3m cum dicitur quod 


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve07v1_kzz7yh-a69979.xml`.

## Applied changes

- p. 102v l. 82: ragunt → agunt: extra r
- p. 102v l. 85: lidus → calidus: missing ca at start
- p. 102v l. 97: prie → proprie: missing pro

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_