### PR TITLE
Transcription corrections: cod-ve07v1_kzz7yh-a72648.xml (46 changes)

### DIFF
--- a/kzz7yh-a72648/cod-ve07v1_kzz7yh-a72648.xml
+++ b/kzz7yh-a72648/cod-ve07v1_kzz7yh-a72648.xml
@@ -130,7 +130,7 @@
             existe<lb ed="#V" n="47" break="no"/>re naturaliter non tantum est intelligibilis sed etiam intellectus 
             <lb ed="#V" n="48"/>Deus autem est forma non informans: sed in se existens a materia 
             <lb ed="#V" n="49"/>et conditionibus materie separata cum sit purus actus: ergo non tantum 
-            in<lb ed="#V" n="50" break="no"/>telligibilis: sed etiam intelligens. Quod autem extpedire 
+            in<lb ed="#V" n="50" break="no"/>telligibilis: sed etiam intelligens. Quod autem <sic>extpedire</sic> 
             intelli<lb ed="#V" n="51" break="no"/>gat: oportet quia intelligere non expedite est propter nimiam 
             elon<lb ed="#V" n="52" break="no"/>gationem intellectus a perfectione actus: hoc autem includit 
             <lb ed="#V" n="53"/>intellectum esse possibilem: cum ergo in diuinis intellectum 
@@ -145,7 +145,7 @@
             in<lb ed="#V" n="62" break="no"/>telligendi: quia illa est essentia sua. res etiam intellecta non potest 
             <lb ed="#V" n="63"/>esse ratio carentie certitudinis in actu intelligendi illius 
             in<lb ed="#V" n="64" break="no"/>tellectus: qui per essentiam suam tantum intelligit cuiusmodi est 
-            <lb ed="#V" n="65"/>diuinus intellectus. restat etgo quod certitudinaliter intelligit: 
+            <lb ed="#V" n="65"/>diuinus intellectus. restat <sic>etgo</sic> quod certitudinaliter intelligit: 
             <lb ed="#V" n="66"/>et sic in generali ostensum est in deo esse scientiam. 
             <!--TODO: insert para break-->
             <lb ed="#V" n="67"/>Primum argumentum ad oppositum procedit de scientia secundum
@@ -225,7 +225,7 @@
             impedi<lb ed="#V" n="113" break="no"/>mento reflectionis perfecte: perfectius adhuc reflectit se super se: 
             <lb ed="#V" n="114"/>cum ergo diuinus intellectus non intelligat per organum: nec possit esse 
             <lb ed="#V" n="115"/>perfectio materie: et summe sit a conditionibus materie elongatus: oportet quod summe 
-            <lb ed="#V" n="116"/>perfecte intelligat se: et si summe perfecie intelligit se: 
+            <lb ed="#V" n="116"/><sic>perfecie</sic> intelligat se: et si summe perfecte intelligit se: 
             sequi<lb ed="#V" n="117" break="no"/>tur quod si intelligat certitudinaliter: et et expedite.
           </p>
           <p xml:id="kzz7yh-a72648-d1e406">
@@ -279,7 +279,7 @@
             <lb ed="#V" n="15"/>TErtio queritur vtrum deus sciat alia a se: et 
             vide<lb ed="#V" n="16" break="no"/>tur quod non quia secundum <ref xml:id="kzz7yh-a72648-Rd1e542">philosophum. 3. de anima.</ref> 
             Scien<lb ed="#V" n="17" break="no"/>tie secantur in res: sed dei non est nisi vna scientia: ergo 
-            <lb ed="#V" n="18"/>deus non scit nisi vnum: cum autem scieiat se: vt in 
+            <lb ed="#V" n="18"/>deus non scit nisi vnum: cum autem sciat se: vt in 
             prece<lb ed="#V" n="19" break="no"/>denti quaestione probatum est: videtur quod nesciat alia a se.
           </p>
           <p xml:id="kzz7yh-a72648-d1e511">
@@ -370,7 +370,7 @@
             <lb ed="#V" n="71"/>et videtur quod sic. Nihil est quod sciri non potest a quocumque 
             <lb ed="#V" n="72"/>intellectu: quia sicut dicit philosophus is poste. Quod non est: non 
             <lb ed="#V" n="73"/>est scire: sed ominia que deus scit sciuit ab eterno: ergo omnia 
-            <lb ed="#V" n="74"/>scita a deo habueruut ab eterno aliquid esse: sed non omnia 
+            <lb ed="#V" n="74"/>scita a deo <sic>habueruut</sic> ab eterno aliquid esse: sed non omnia 
             <lb ed="#V" n="75"/>habuerunt esse in actu: ergo habuerunt esse essentie.
           </p>
           <p xml:id="kzz7yh-a72648-d1e673">
@@ -388,7 +388,7 @@
             rea<lb ed="#V" n="83" break="no"/>le exemplar: vel est ipsum reale exemplar: ergo quicquid est 
             <lb ed="#V" n="84"/>scitum a deo non est nihil: sed quod non est nihil est res 
             ali<lb ed="#V" n="85" break="no"/>qua. Cum ergo quicquid est res aliqua hebeat effe essentie: et deus omnia 
-            <lb ed="#V" n="86"/>que modo scit ab eterno sciuit. Omne scitum a deo habumit ab 
+            <lb ed="#V" n="86"/>que modo scit ab eterno sciuit. Omne scitum a deo habuit ab 
             eter<lb ed="#V" n="87" break="no"/>no esse essentie.
           </p>
           <p xml:id="kzz7yh-a72648-d1e705">
@@ -440,7 +440,7 @@
           </p>
           <p xml:id="kzz7yh-a72648-d1e782">
             <lb ed="#V" n="115"/>Respondeo quod scitorum a deo quaedam sunt id quod est 
-            <lb ed="#V" n="116"/>impe: quia fcit essentiam suam et omnes 
+            <lb ed="#V" n="116"/>ipse: quia scit essentiam suam et omnes 
             perfectio<lb ed="#V" n="117" break="no"/>nes eius et divinas personas quae omnia sunt idem quod est ipse.
           </p>
           <p xml:id="kzz7yh-a72648-d1e791">
@@ -494,7 +494,7 @@
           <p xml:id="kzz7yh-a72648-d1e882">
             ¶ Preterea quamuis predicta opinio non ponat 
             <lb ed="#V" n="16"/>ideas eo modo quo Arist. imponit platoni eas posuisse: 
-            ta<lb ed="#V" n="17" break="no"/>men videtur illi opinioni sauere: et aliqualiter appropiniquare. 
+            ta<lb ed="#V" n="17" break="no"/>men videtur illi opinioni fauere: et aliqualiter appropiniquare. 
           </p>
           <p xml:id="kzz7yh-a72648-d1e890">
             <lb ed="#V" n="18"/>¶ Preterea a domino Gulielmo Pariensi episco excommunicatus est 
@@ -667,7 +667,7 @@
             determi<lb ed="#V" n="133" break="no"/>natione inclinante quia enim intellectus artificis per scientiam 
             <lb ed="#V" n="134"/>edificatiuam dictat quod lapides ponendi sunt deorsum et ligna 
             <lb ed="#V" n="135"/>sursum in edificando: ideo voluntas artificis: sic imperat faciendum. 
-            <lb ed="#V" n="136"/>Non sic autem se habebat scientia faciendi modondum in divino intellectum ad 
+            <lb ed="#V" n="136"/>Non sic autem se habebat scientia faciendi <sic>mondum</sic> in divino intellectum ad 
             <!--00229.xml-->
             <pb ed="#V" n="108-r"/>
             <cb ed="#P" n="a"/>
@@ -676,8 +676,8 @@
             <lb ed="#V" n="3"/>voluit creationem mundi futuram. ideo diuinus intellectus 
             dicta<lb ed="#V" n="4" break="no"/>bat rectum esse vt mundus crearetur: ita quod dictam intellectus non 
             <lb ed="#V" n="5"/>determinavit voluntatem ad hoc volendum: sed voluntas hoc 
-            vo<lb ed="#V" n="6" break="no"/>lendo deterinauit intellectum ad homo dictandum: quod sic patet. Dinus 
-            <lb ed="#V" n="7"/>enim intelleetus dictauit esse vt mundus fieret quia rectum erat vt 
+            vo<lb ed="#V" n="6" break="no"/>lendo determinavit intellectum ad homo dictandum: quod sic patet. Divinus 
+            <lb ed="#V" n="7"/>enim <sic>intelleetus</sic> dictauit esse vt mundus fieret quia rectum erat vt 
             fie<lb ed="#V" n="8" break="no"/>ret: nen ergo rectum erat vt fient mundus quia divinus intellectus 
             dicta<lb ed="#V" n="9" break="no"/>bat rectum esse vt fieret: aliter enim esset circulatio: ergo fuit 
             re<lb ed="#V" n="10" break="no"/>ctum vt mundus fieret. quia divina voluntas hoc volebat: 
@@ -686,14 +686,14 @@
             in<lb ed="#V" n="13" break="no"/>tellectus dictasset rectum esse vt mundus fieret: et hoc prius 
             <lb ed="#V" n="14"/>dictasset secundum rationem intelligendi quam voluntas hoc voluisset 
             <lb ed="#V" n="15"/>non potuisset dictasse contrarium: ergo cum voluntas divina a dictani 
-            <lb ed="#V" n="16"/>ne divini inteltectus discordare non possit de necessitate mundum 
+            <lb ed="#V" n="16"/>ne divini <sic>inteltectus</sic> discordare non possit de necessitate mundum 
             <lb ed="#V" n="17"/>creare voluisset quod falsum est: sic ergo prius secundum rationem 
             intel<lb ed="#V" n="18" break="no"/>ligendi diuinus intellectus proposuit et ostendit voluntati 
             factio<lb ed="#V" n="19" break="no"/>nem mundi non dictando hoc debere fieri vel debem non fieri. 
             <lb ed="#V" n="20"/>Secundo diuina voluntas voluit mundum fieri. Tertio diuinus 
             <lb ed="#V" n="21"/>intellectus dictauit esse rectum mundum fieri. sic ergo pte 
-            <lb ed="#V" n="22"/>quod scientia dei respectu aliorum a se non est plene pratica per 
-            compora<lb ed="#V" n="23" break="no"/>tionem ad voluntatem: nec tamen tam speculatiua: quia nisi 
+            <lb ed="#V" n="22"/>quod scientia dei respectu aliorum a se non est plene <sic>pratica</sic> per 
+            compara<lb ed="#V" n="23" break="no"/>tionem ad voluntatem: nec tamen tam speculatiua: quia nisi 
             intel<lb ed="#V" n="24" break="no"/>lectus ostendidisset voluntati factionem mundi divina voluntas non 
             <lb ed="#V" n="25"/>voluisset mundum fieri: quia velle secundum rationem intelligendi sequitur 
             <lb ed="#V" n="26"/>aliquam cognitionem: et si deus non voluisset mundum fieri: 
@@ -719,7 +719,7 @@
             <lb ed="#V" n="44"/>ipsam
           </p>
           <p xml:id="kzz7yh-a72648-d1e1308">
-            ¶ Ad 2m cum dicitur quod deus scit multa fcibilia quae 
+            ¶ Ad 2m cum dicitur quod deus scit multa factibilia quae 
             nuquan<lb ed="#V" n="45" break="no"/>faciet etc. dico quod verum est: et respectu illorum scientia dei non est 
             pra<lb ed="#V" n="46" break="no"/>ctica inquantum scientia dicitur practica propter sinem qui est 
             <lb ed="#V" n="47"/>operatio.
@@ -764,10 +764,10 @@
             cer<lb ed="#V" n="68" break="no"/>tam cognitionem de aliis a se.
           </p>
           <p xml:id="kzz7yh-a72648-d1e1381">
-            ¶ Item in Commen. super 8. propositio¬ 
+            ¶ Item in Commen. super 8. ¬ 
             <!--00229.xml-->
             <cb ed="#P" n="b"/>
-            <lb ed="#V" n="69"/>nem de causis dicitur quod omnis intelligentia non apprehendit res nisi 
+            propositio<lb ed="#V" n="69" break="no"/>nem de causis dicitur quod omnis intelligentia non apprehendit res nisi 
             <lb ed="#V" n="70"/>per modum sue substantie. Sed modus substantiae intelligentie increate quae 
             <lb ed="#V" n="71"/>deus est alius est quam modus rerum aliarum: ergo non intelligit 
             <lb ed="#V" n="72"/>alia a se secundum modum eorum sed qui non intelligit modum rei: non 
@@ -865,7 +865,7 @@
             in<lb ed="#V" n="131" break="no"/>telligndi omnia scita. 
           </p>
           <p xml:id="kzz7yh-a72648-d1e1560">
-            <lb ed="#V" n="132"/>Contra scire in potentia est scire impefecte vnde <ref xml:id="kzz7yh-a72648-Rd1e1679">Aui. 2o 
+            <lb ed="#V" n="132"/>Contra scire in potentia est scire imperfecte. vnde <ref xml:id="kzz7yh-a72648-Rd1e1679">Aui. 2o 
               me<lb ed="#V" n="133" break="no"/>ta. sue. c. ii.</ref> dicit quod potentia est imperfectom: sed deus nihil 
             <lb ed="#V" n="134"/>intelligit imperfecte: ergo semper est in actu intelligendi respectu omnium 
             <lb ed="#V" n="135"/>scitorum. Item quandoque est in actu quandoque in posmsus mutatur: sed deus est 
@@ -902,7 +902,7 @@
             <lb ed="#V" n="23"/>scita intelligit per vnum scilicet per essentiam suam: sed quando plura intelliguntur per 
             <lb ed="#V" n="24"/>pliuctera ab intellectu creato dimisso sue virtuti naturali: tunc 
             pro<lb ed="#V" n="25" break="no"/>positio non habet instantiam: si intelligatur de actu 
-            intelli<lb ed="#V" n="26" break="no"/>gendi quod aliquid intellgitur distincte et perfecte.
+            intelli<lb ed="#V" n="26" break="no"/>gendi quod aliquid <sic>intellgitur</sic> distincte et perfecte.
           </p>
           <p xml:id="kzz7yh-a72648-d1e1641">
             ¶ Ad 2m 

--- a/kzz7yh-a72648/cod-ve07v1_kzz7yh-a72648.xml
+++ b/kzz7yh-a72648/cod-ve07v1_kzz7yh-a72648.xml
@@ -148,7 +148,7 @@
             <lb ed="#V" n="65"/>diuinus intellectus. restat etgo quod certitudinaliter intelligit: 
             <lb ed="#V" n="66"/>et sic in generali ostensum est in deo esse scientiam. 
             <!--TODO: insert para break-->
-            <lb ed="#V" n="67"/>Primum argumentum ad oppositum perocedit de scientia secundum
+            <lb ed="#V" n="67"/>Primum argumentum ad oppositum procedit de scientia secundum
             <lb ed="#V" n="68"/>quod est habitus conclusionum: et bene concessum est 
             <!--00226.xml-->
             <cb ed="#P" n="b"/>
@@ -196,7 +196,7 @@
             pa<lb ed="#V" n="91" break="no"/>ti: ergo diuinus intellectus non potest intelligere se. 
           </p>
           <p xml:id="kzz7yh-a72648-d1e341">
-            <lb ed="#V" n="92"/>Contra 13a propostione de causis. Omnis intelligentia 
+            <lb ed="#V" n="92"/>Contra 13a propositione de causis. Omnis intelligentia 
             <lb ed="#V" n="93"/>intelligit essentiam suam: sed deus est 
             intelli<lb ed="#V" n="94" break="no"/>gentia increata: ergo intelligit essentiam suam.
           </p>
@@ -215,7 +215,7 @@
             <lb ed="#V" n="103"/>spiritus dei. Quod autem intelligat se patet per rationem sic. Quia 
             <lb ed="#V" n="104"/>secundum quod vult <ref xml:id="kzz7yh-a72648-Rd1e409">Auicen. 6 naturalium. c. 2.</ref> Ratio quare aliqua 
             po<lb ed="#V" n="105" break="no"/>tentia cognitiua: sicut est potentia sensitiua: non inflectitur 
-            <lb ed="#V" n="106"/>super se: est quia operatur per insttumentum: hoc est per 
+            <lb ed="#V" n="106"/>super se: est quia operatur per instrumentum: hoc est per 
             orga<lb ed="#V" n="107" break="no"/>num. Unde quia potentia intellectiua in nobis non operatur 
             <lb ed="#V" n="108"/>per organum: reflectit se super se: quia tamen est potentia 
             <lb ed="#V" n="109"/>substantie que actu informet sensibilem materiam: dum sic est non 
@@ -262,7 +262,7 @@
             <lb ed="#V" n="5"/>est passiuus et postea possibilis: in actum reductus: est actiuus 
             <lb ed="#V" n="6"/>ita quod realiter differunt intellectus: et sua passio in forma: a quae 
             <lb ed="#V" n="7"/>patitur: et actio que est ab eo iam reducto aliquo modo in actu 
-            <lb ed="#V" n="8"/>per passiuam intellectionem: ita aliquomon valde longinquo 
+            <lb ed="#V" n="8"/>per passiuam intellectionem: ita aliquomodo valde longinquo 
             <lb ed="#V" n="9"/>diuinus intellectus primo secundum rationem intelligendi est 
             passi<lb ed="#V" n="10" break="no"/>uus: secundo actiuus: ita tamen quod intellectus et forma: per quam 
             <lb ed="#V" n="11"/>intelligit et suum intelligere sunt res vna: nec potest ibi 
@@ -300,8 +300,8 @@
           <p xml:id="kzz7yh-a72648-d1e533">
             <lb ed="#V" n="26"/>Contra secundum <ref xml:id="kzz7yh-a72648-Rd1e580">philosophum. 2 physi.</ref> Naturalia agunt propter finem 
             <lb ed="#V" n="27"/>sed non determinant se propter illum sinem: quia 
-            <lb ed="#V" n="28"/>sic mouerentur a se: quod est contra philosophum. 7. physi. ergo ad illu 
-            <lb ed="#V" n="29"/>finem deteminantur ab alio: sed naturalia: que immediate tantum 
+            <lb ed="#V" n="28"/>sic mouerentur a se: quod est contra philosophum. 7. physi. ergo ad illud 
+            <lb ed="#V" n="29"/>finem determinantur ab alio: sed naturalia: que immediate tantum 
             proces<lb ed="#V" n="30" break="no"/>serunt a deo: a nullo alio quam a deo determinari poterunt ad finem 
             <lb ed="#V" n="31"/>propter quem agunt: ergo ad illum sinem determinata sunt 
             <lb ed="#V" n="32"/>a deo: sed determinare aliquid ad finem propter quem mouetur: 
@@ -322,7 +322,7 @@
           </p>
           <p xml:id="kzz7yh-a72648-d1e577">
             <lb ed="#V" n="44"/>Respondeo quod deus scit alia a se accipiendo scitam 
-            <lb ed="#V" n="45"/>modo supraedicto. Et ideo hius est: quia intellectus 
+            <lb ed="#V" n="45"/>modo supraedicto. Et ideo huius est: quia intellectus 
             <lb ed="#V" n="46"/>cognoscit illud cuius habet apud se similitudinem expressam: 
             <lb ed="#V" n="47"/>sed divina essentia non est tantummodo repraesentatiua sui ipsius: sed 
             <lb ed="#V" n="48"/>etiam creature: ergo cognoscit aliud a se: quanuis non per 
@@ -354,8 +354,8 @@
             in<lb ed="#V" n="63" break="no"/>telligibili et c. dico quod verum est de intellectu creato: qui secundaria 
             <lb ed="#V" n="64"/>perfectione perficitur vel per intelligibilem essentiam si est 
             intelligi<lb ed="#V" n="65" break="no"/>bile per essentiam suam intellectus informans: vel per 
-            intel<lb ed="#V" n="66" break="no"/>ligibilem similitudinem per viam superiorem vel inferiorem hitam 
-            <lb ed="#V" n="67"/>Diuinus autem intellectus nhil intelligit nisi per essentiam <sic>saum</sic>
+            intel<lb ed="#V" n="66" break="no"/>ligibilem similitudinem per viam superiorem vel inferiorem habitam 
+            <lb ed="#V" n="67"/>Diuinus autem intellectus nihil intelligit nisi per essentiam <sic>saum</sic>
             <lb ed="#V" n="68"/>que divino intellectui sufficienter exprimit omnia quae intelligit. 
           </p>
         </div>
@@ -376,9 +376,9 @@
           <p xml:id="kzz7yh-a72648-d1e673">
             ¶ Item 
             <lb ed="#V" n="76"/>quod ab eterno non habuit esse existentie: nec esse essentie non fuit 
-            <lb ed="#V" n="77"/>ab eterno aliud a deo: quia esse aliud: vel effe idem praesupponit 
-            <lb ed="#V" n="78"/>esse: sed creature ab eterno non humerunt esse existentie: ergo 
-            si<lb ed="#V" n="79" break="no"/>creature ab eterno non hunissent esse essentie non fuissent aliud 
+            <lb ed="#V" n="77"/>ab eterno aliud a deo: quia esse aliud: vel esse idem praesupponit 
+            <lb ed="#V" n="78"/>esse: sed creature ab eterno non habuerunt esse existentie: ergo 
+            si<lb ed="#V" n="79" break="no"/>creature ab eterno non habuissent esse essentie non fuissent aliud 
             <lb ed="#V" n="80"/>a deo: et sic deus ab eterno non sciuisset aliud a se: quod 
             <lb ed="#V" n="81"/>falsum est.
           </p>
@@ -423,7 +423,7 @@
               <lb ed="#V" n="103"/>libro de doctri.</ref> christius longe ante finem. Ueritas connexissionum 
             <lb ed="#V" n="104"/>non est instituta sed animaduersa est ab hominibus: nam 
             <lb ed="#V" n="105"/>est in rerum ratione perpetua et divinitus instituta: sed rerum connexio non 
-            po<lb ed="#V" n="106" break="no"/>tuisset fuisse perpetua: nisi res humisset ab eterno esse essentie. 
+            po<lb ed="#V" n="106" break="no"/>tuisset fuisse perpetua: nisi res habuisset ab eterno esse essentie. 
           </p>
           <p xml:id="kzz7yh-a72648-d1e759">
             <lb ed="#V" n="107"/>Contra. <ref xml:id="kzz7yh-a72648-Rd1e828">Ansel. libro de casu. diab. c. 12.</ref> dicit quod mundus 
@@ -446,16 +446,16 @@
           <p xml:id="kzz7yh-a72648-d1e791">
             ¶ 
             Que<lb ed="#V" n="118" break="no"/>dam non sunt id quod est ipse: vt creature. Certum est quod prima 
-            <lb ed="#V" n="119"/>scita non tantum humerunt ab eterno esse essentie: sed etiam esse 
+            <lb ed="#V" n="119"/>scita non tantum habuerunt ab eterno esse essentie: sed etiam esse 
             <lb ed="#V" n="120"/>existentie: quia perfectiones diuine essentie: et etiam persone 
             <lb ed="#V" n="121"/>divinae que omnia realiter idem sunt quod diuina essentia ab 
             eter<lb ed="#V" n="122" break="no"/>no fuerunt purum esse. sed vtrum scita que non sunt id quod 
-            <lb ed="#V" n="123"/>deus est ab eterno humerunt esse essentie dubium est. Quidam enim 
+            <lb ed="#V" n="123"/>deus est ab eterno habuerunt esse essentie dubium est. Quidam enim 
             <lb ed="#V" n="124"/>subtiliter et probabiliter dicunt quod sicut per voluntatem dei imperantem 
             <lb ed="#V" n="125"/>res esse sunt quiditates earum in affectu: sic per scientiam dei 
             in<lb ed="#V" n="126" break="no"/>quantum per eam se intelligit: vt exemplar rerum: habent 
             il<lb ed="#V" n="127" break="no"/>le res distincte esse essentie: et quia deus ab eterno intellexit 
-            essen<lb ed="#V" n="128" break="no"/>tiam suam: vt rerum exemplar: ideo humerunt ab eterno esse 
+            essen<lb ed="#V" n="128" break="no"/>tiam suam: vt rerum exemplar: ideo habuerunt ab eterno esse 
             <lb ed="#V" n="129"/>essentie: vt fuerunt res praedicamentales tunc esse in 
             effeeru<lb ed="#V" n="130" break="no"/>super essentiam non addit nisi relationem ad deum: vt ad causam 
             <lb ed="#V" n="131"/>efficientem: sic esse essentie vltra essentiam non dicit nisi relationem 
@@ -464,8 +464,8 @@
           </p>
           <p xml:id="kzz7yh-a72648-d1e828">
             ¶ Sed 
-            <lb ed="#V" n="134"/>contra hanc opinionem sic potest atgui. Creari est produci 
-            <lb ed="#V" n="135"/>non de aliquo sed si creatura ab eterno humisset esse essentie non 
+            <lb ed="#V" n="134"/>contra hanc opinionem sic potest argui. Creari est produci 
+            <lb ed="#V" n="135"/>non de aliquo sed si creatura ab eterno habuisset esse essentie non 
             <lb ed="#V" n="136"/>fuisset ex tempore producta non de aliquo: quia fuisset producta de esse 
             <!--00228.xml-->
             <pb ed="#V" n="107-v"/>
@@ -475,8 +475,8 @@
           <p xml:id="kzz7yh-a72648-d1e846">
             <lb ed="#V" n="2"/>¶ Preterea illi qui sunt opinionis contrarie ponunt: et 
             probabi<lb ed="#V" n="3" break="no"/>le est quod esse creature in effectu vltra essentiam creature: 
-            ni<lb ed="#V" n="4" break="no"/>hil dicunt reale absolutsi: sed relationem ad factorem. Si ergo res 
-            <lb ed="#V" n="5"/>ab eterno fuissent in esse essentie: nihillu secundum eos esset creatum in 
+            ni<lb ed="#V" n="4" break="no"/>hil dicunt reale absoluti: sed relationem ad factorem. Si ergo res 
+            <lb ed="#V" n="5"/>ab eterno fuissent in esse essentie: nihil secundum eos esset creatum in 
             <lb ed="#V" n="6"/>creatura nisi eius relatio ad factorem: quod irrationabile 
             vide<lb ed="#V" n="7" break="no"/>tur.
           </p>
@@ -484,7 +484,7 @@
             ¶ Premous sicut ab eterno fuit in deo exemplar essentia 
             crea<lb ed="#V" n="8" break="no"/>ture: ita fuit in eo exemplar actualis existentie creature et 
             <lb ed="#V" n="9"/>sic deus ab eterno intellexit creature essentiam: ita 
-            intelle<lb ed="#V" n="10" break="no"/>xit crcature actualem existentiam. Unde videtur quod non alio 
+            intelle<lb ed="#V" n="10" break="no"/>xit creature actualem existentiam. Unde videtur quod non alio 
             <lb ed="#V" n="11"/>modo fuit verum ab eterno essentiam asini esse essentiam 
             <lb ed="#V" n="12"/>quam actualem eius existentiam esse actualem existentiamus 
             <lb ed="#V" n="13"/>Sed certum est quod actualis existentia a sinistratis ab 
@@ -576,7 +576,7 @@
           <p xml:id="kzz7yh-a72648-d1e1034">
             ¶ Ad 6m dicendum quod 
             ma<lb ed="#V" n="74" break="no"/>ior est falsa: nec valet eius probatio. Intellectus enim distinguit 
-            <lb ed="#V" n="75"/>inter ea que nullo modo realiter differnt: quia quod est simpliciter vnum: 
+            <lb ed="#V" n="75"/>inter ea que nullo modo realiter differunt: quia quod est simpliciter vnum: 
             <lb ed="#V" n="76"/>re: potest esse plura secundum rationem. Unde sicut non potest ee color nisi 
             <lb ed="#V" n="77"/>per hoc quod est aliquid indiuiduum coloris in actu: et tamen 
             intel<lb ed="#V" n="78" break="no"/>lectus potest abstrahere colorem a qualibet coloris specie: et a 
@@ -588,12 +588,12 @@
             ¶ Ad 7m dicendum quod minior est falsa de rebus 
             <lb ed="#V" n="82"/>quae non sunt possibiles fieri nisi per potentiam creatoris: sicut enim 
             <lb ed="#V" n="83"/>secundum Ansel. in lib. de casu diaboli. c. 12. in mundo antequam esset 
-            <lb ed="#V" n="84"/>nulla erat potentia: ita dico quod in eo nulla erat propinguitas 
+            <lb ed="#V" n="84"/>nulla erat potentia: ita dico quod in eo nulla erat propinquitas 
             <lb ed="#V" n="85"/>ad esse.
           </p>
           <p xml:id="kzz7yh-a72648-d1e1065">
             ¶ Ad 8m dicendum quod no plus vult dicere illa 
-            auctori<lb ed="#V" n="86" break="no"/>tas nisi quod ille conmnexiones habent perpetuum exemplar in 
+            auctori<lb ed="#V" n="86" break="no"/>tas nisi quod ille connexiones habent perpetuum exemplar in 
             <lb ed="#V" n="87"/>deo: vt quod ab eterno fuerunt a deo intelligere et ex tempore 
             <lb ed="#V" n="88"/>per realem institutionem rerum que sunt realiter instituteo 
           </p>
@@ -638,24 +638,24 @@
           </p>
           <p xml:id="kzz7yh-a72648-d1e1142">
             ¶ Item sapien. vii. 
-            <lb ed="#V" n="112"/>omnium artisex instruit me sapientia: et loquitur de sapientia increata: 
+            <lb ed="#V" n="112"/>omnium artifex instruit me sapientia: et loquitur de sapientia increata: 
             <lb ed="#V" n="113"/>sapientia ergo dei est ars: sed secundum philosophum 6 ethi. c. 5. Ars spectat 
             <lb ed="#V" n="114"/>ad cognitionem practicam: ergo scientia dei est practica. 
           </p>
           <p xml:id="kzz7yh-a72648-d1e1151">
-            <lb ed="#V" n="115"/>Respondeo quod diuina scentia potest considerari per 
+            <lb ed="#V" n="115"/>Respondeo quod diuina scientia potest considerari per 
             com<lb ed="#V" n="116" break="no"/>parationem ad res scitas: et ad modum 
-            <lb ed="#V" n="117"/>sciendi: et ad voluntatem primo modo respectu aliorum a se pratica 
+            <lb ed="#V" n="117"/>sciendi: et ad voluntatem primo modo respectu aliorum a se practica 
             <lb ed="#V" n="118"/>est: quia sic est respectu operabilium per seipsum.
           </p>
           <p xml:id="kzz7yh-a72648-d1e1162">
             ¶ Secundo 
             mo<lb ed="#V" n="119" break="no"/>do est respectu aliorum a se. Practica est: et speculatiua: quia ea 
-            <lb ed="#V" n="120"/>scit modo speculatiuo. Sic enim eorum disiones in suas 
-            par<lb ed="#V" n="121" break="no"/>tes essentiales: et eorum distinctiones et eorum hitudines ad 
+            <lb ed="#V" n="120"/>scit modo speculatiuo. Sic enim eorum diuisiones in suas 
+            par<lb ed="#V" n="121" break="no"/>tes essentiales: et eorum distinctiones et eorum habitudines ad 
             <lb ed="#V" n="122"/>vniversalia praedicabilia de ipsis. hic autem modus sciendi operabilia 
             <lb ed="#V" n="123"/>est speculatiuus. Scit etiam ea modo practico: quia scit ea 
-            singu<lb ed="#V" n="124" break="no"/>lares conditiones eorum intuendo: et singulares hitudines earum 
+            singu<lb ed="#V" n="124" break="no"/>lares conditiones eorum intuendo: et singulares habitudines earum 
             <lb ed="#V" n="125"/>inter se: et ad suam productionem: et hic modus considerandi 
             opera<lb ed="#V" n="126" break="no"/>bilia: est practicus. Tercio modo scientia dei respectu aliorum a se 
             <lb ed="#V" n="127"/>non est plene practica: nec potest dici tantum speculatiua: 
@@ -671,11 +671,11 @@
             <!--00229.xml-->
             <pb ed="#V" n="108-r"/>
             <cb ed="#P" n="a"/>
-            <lb ed="#V" n="1"/>divinam voluntatem. Non enim quia dinus intellectus dixit rectum esse 
-            <lb ed="#V" n="2"/>creari: ideo voluntas imparauit vt mundus crearetur: sed quia voluntas 
-            <lb ed="#V" n="3"/>voluit creationem mundi futuram. ideo dinus intellectus 
+            <lb ed="#V" n="1"/>divinam voluntatem. Non enim quia diuinus intellectus dixit rectum esse 
+            <lb ed="#V" n="2"/>creari: ideo voluntas imperauit vt mundus crearetur: sed quia voluntas 
+            <lb ed="#V" n="3"/>voluit creationem mundi futuram. ideo diuinus intellectus 
             dicta<lb ed="#V" n="4" break="no"/>bat rectum esse vt mundus crearetur: ita quod dictam intellectus non 
-            <lb ed="#V" n="5"/>deterinauit voluntatem ad hoc volendum: sed voluntas hoc 
+            <lb ed="#V" n="5"/>determinavit voluntatem ad hoc volendum: sed voluntas hoc 
             vo<lb ed="#V" n="6" break="no"/>lendo deterinauit intellectum ad homo dictandum: quod sic patet. Dinus 
             <lb ed="#V" n="7"/>enim intelleetus dictauit esse vt mundus fieret quia rectum erat vt 
             fie<lb ed="#V" n="8" break="no"/>ret: nen ergo rectum erat vt fient mundus quia divinus intellectus 
@@ -688,9 +688,9 @@
             <lb ed="#V" n="15"/>non potuisset dictasse contrarium: ergo cum voluntas divina a dictani 
             <lb ed="#V" n="16"/>ne divini inteltectus discordare non possit de necessitate mundum 
             <lb ed="#V" n="17"/>creare voluisset quod falsum est: sic ergo prius secundum rationem 
-            intel<lb ed="#V" n="18" break="no"/>ligendi dinus intellectus proposuit et ostendit voluntati 
+            intel<lb ed="#V" n="18" break="no"/>ligendi diuinus intellectus proposuit et ostendit voluntati 
             factio<lb ed="#V" n="19" break="no"/>nem mundi non dictando hoc debere fieri vel debem non fieri. 
-            <lb ed="#V" n="20"/>Secundo diuina voluntas voluit mundum fieri. Tertio dinus 
+            <lb ed="#V" n="20"/>Secundo diuina voluntas voluit mundum fieri. Tertio diuinus 
             <lb ed="#V" n="21"/>intellectus dictauit esse rectum mundum fieri. sic ergo pte 
             <lb ed="#V" n="22"/>quod scientia dei respectu aliorum a se non est plene pratica per 
             compora<lb ed="#V" n="23" break="no"/>tionem ad voluntatem: nec tamen tam speculatiua: quia nisi 
@@ -704,8 +704,8 @@
             <lb ed="#V" n="31"/>ad voluntatem. Preterea quia scientia pure speculatiua nihil 
             di<lb ed="#V" n="32" break="no"/>ctat faciendum vel non faciendu: et divina scientia dictauit 
             cre<lb ed="#V" n="33" break="no"/>aturam esse faciendam quamuis secundum rationem intelligendi ad hoc 
-            di<lb ed="#V" n="34" break="no"/>ctandum determinaretur dinus intellectus per voluntatem ideo 
-            <lb ed="#V" n="35"/>per comparationem ad voluntatem non habet plenam rationem sacientie 
+            di<lb ed="#V" n="34" break="no"/>ctandum determinaretur diuinus intellectus per voluntatem ideo 
+            <lb ed="#V" n="35"/>per comparationem ad voluntatem non habet plenam rationem scientie 
             <lb ed="#V" n="36"/>speculatiue. Ex praedictis patere potest in parte quod dicendum ad 
             <lb ed="#V" n="37"/>argumenta ad vtranque partem.
           </p>
@@ -758,7 +758,7 @@
           </p>
           <p xml:id="kzz7yh-a72648-d1e1370">
             ¶ Item medium per quod hebetur certa. 
-            <lb ed="#V" n="65"/>cognitio de conclutione de necessitate infert illam conclusionem 
+            <lb ed="#V" n="65"/>cognitio de conclusione de necessitate infert illam conclusionem 
             <lb ed="#V" n="66"/>Sed divina essentia per quam deus cognoscit quicquid cognoscit 
             <lb ed="#V" n="67"/>non infert de necessitate alia ab ipsa: ergo deus non habet 
             cer<lb ed="#V" n="68" break="no"/>tam cognitionem de aliis a se.
@@ -788,11 +788,11 @@
             <lb ed="#V" n="81"/>probari per eandem rationem: per quam fuit probatum in 
             genera<lb ed="#V" n="82" break="no"/>li quod deus certitudinaliter intelligit: que ratio superius posita est 
             <lb ed="#V" n="83"/>in solutione prime quaestionis huius distinctionis. Quod autem liquido 
-            cogno<lb ed="#V" n="84" break="no"/>scat omnia bona praesentia alia a se speciealiter patet sic. cognoscere rem 
+            cogno<lb ed="#V" n="84" break="no"/>scat omnia bona praesentia alia a se specialiter patet sic. cognoscere rem 
             ali<lb ed="#V" n="85" break="no"/>quam cognoscendo liquido eius causam proximam et immediatam: et quod est 
             <lb ed="#V" n="86"/>illius rei causa est rem liquido cognoscere. Sed deus omnium bonorum 
             <lb ed="#V" n="87"/>praesentium que sunt alia a se: ita est causa prima: quod causa proxima et eorum 
-            <lb ed="#V" n="88"/>quorum est causa mediata et immediata non tantummo efficiens: sed etiam 
+            <lb ed="#V" n="88"/>quorum est causa mediata et immediata non tantummodo efficiens: sed etiam 
             <lb ed="#V" n="89"/>exemplaris. et finalis: sed deus certissime cognoscit se secundum 
             <lb ed="#V" n="90"/>id quod est: et sub ratione qua est causa aliorum a se ergo certissima habet 
             <lb ed="#V" n="91"/>cognitionem aliorum bonorum a se.
@@ -812,8 +812,8 @@
             ¶ Ad 
             <lb ed="#V" n="101"/>um dicitur quod medium per quod hebetur cognitio de conclusione de 
             ne<lb ed="#V" n="102" break="no"/>cessitate infert illam conclusionem etc. dico quod non est verum quando 
-            <lb ed="#V" n="103"/>hitudo illius conclusionis ad illum medium dependet ab agente 
-            per<lb ed="#V" n="104" break="no"/>voluntatem: hitudo autem bonorum creatorum ad divinam essentiam 
+            <lb ed="#V" n="103"/>habitudo illius conclusionis ad illum medium dependet ab agente 
+            per<lb ed="#V" n="104" break="no"/>voluntatem: habitudo autem bonorum creatorum ad divinam essentiam 
             rea<lb ed="#V" n="105" break="no"/>liter dependet a voluntate divina.
           </p>
           <p xml:id="kzz7yh-a72648-d1e1482">
@@ -858,7 +858,7 @@
           <p xml:id="kzz7yh-a72648-d1e1543">
             ¶ Item aut deus vnico actu intelligit omnia de quibus habet 
             <lb ed="#V" n="126"/>scientiam: aut pluribus non vno vt videtur quod intelligere divinum quo 
-            <lb ed="#V" n="127"/>se intelligit: causa est illius actus intelligendi: quo inteiligit 
+            <lb ed="#V" n="127"/>se intelligit: causa est illius actus intelligendi: quo intelligit 
             crea<lb ed="#V" n="128" break="no"/>turas. Creaturas enim intelligit per hoc quod se intelligit idem vero non est 
             <lb ed="#V" n="129"/>causa sui ipsius. Uidetur ergo quod pluribus actibus intelligendi intelligit 
             <lb ed="#V" n="130"/>ea de quibus hanc scientiam: sed nullum tale est semper in actu 
@@ -887,9 +887,9 @@
             in<lb ed="#V" n="10" break="no"/>telligere imperfectum: et tanto in imperfectius: quanto est magis 
             <lb ed="#V" n="11"/>potentia ab actu remota. Unde videmus quod in nobis 
             imper<lb ed="#V" n="12" break="no"/>fectus est intelligere quando est in sola potentia nuda: quam quando 
-            <lb ed="#V" n="13"/>est in potentia per hieitum principiorum perfecta: et adhuc minus 
+            <lb ed="#V" n="13"/>est in potentia per habitum principiorum perfecta: et adhuc minus 
             <lb ed="#V" n="14"/>imperfecta est in nobis quando est in potentia. non tantummodo 
-            perfe<lb ed="#V" n="15" break="no"/>cta per hietum principiorum: sed etiam per hitum conclusionum: 
+            perfe<lb ed="#V" n="15" break="no"/>cta per habitum principiorum: sed etiam per hitum conclusionum: 
             <lb ed="#V" n="16"/>sed nunquam est in nobis perfecte quousque actu intelligimus: nec 
             <lb ed="#V" n="17"/>adduxi hoc exemplum ad ostendendum quod deus intelligat per 
             <lb ed="#V" n="18"/>habitum: immo a me superius negatum est. Ex dictis sequitur 

--- a/kzz7yh-a72648/cod-ve07v1_kzz7yh-a72648.xml
+++ b/kzz7yh-a72648/cod-ve07v1_kzz7yh-a72648.xml
@@ -764,10 +764,9 @@
             cer<lb ed="#V" n="68" break="no"/>tam cognitionem de aliis a se.
           </p>
           <p xml:id="kzz7yh-a72648-d1e1381">
-            ¶ Item in Commen. super 8. ¬ 
+            ¶ Item in Commen. super 8.
             <!--00229.xml-->
-            <cb ed="#P" n="b"/>
-            propositio<lb ed="#V" n="69" break="no"/>nem de causis dicitur quod omnis intelligentia non apprehendit res nisi 
+            propositio<cb ed="#P" n="b"/><lb ed="#V" n="69" break="no"/>nem de causis dicitur quod omnis intelligentia non apprehendit res nisi 
             <lb ed="#V" n="70"/>per modum sue substantie. Sed modus substantiae intelligentie increate quae 
             <lb ed="#V" n="71"/>deus est alius est quam modus rerum aliarum: ergo non intelligit 
             <lb ed="#V" n="72"/>alia a se secundum modum eorum sed qui non intelligit modum rei: non 


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve07v1_kzz7yh-a72648.xml`.

## Applied changes

- p. 106v l. 67: perocedit → procedit: extra e
- p. 106v l. 92: propostione → propositione: missing i
- p. 106v l. 106: insttumentum → instrumentum: doubled t
- p. 107r l. 8: aliquomon → aliquomodo: missing do
- p. 107r l. 28: illu → illud: missing d
- p. 107r l. 29: deteminantur → determinantur: missing r
- p. 107r l. 45: hius → huius: missing u
- p. 107r l. 66: hitam → habitam: missing ab (hi→habi)
- p. 107r l. 67: nhil → nihil: transposition
- p. 107r l. 77: effe → esse: f/s long-s misread
- p. 107r l. 78: humerunt → habuerunt: h/hab misread
- p. 107r l. 79: hunissent → habuissent: garbled habuerunt form
- p. 107r l. 106: humisset → habuisset: h/hab misread
- p. 107r l. 119: humerunt → habuerunt: h/hab misread
- p. 107r l. 123: humerunt → habuerunt: h/hab misread
- p. 107r l. 128: humerunt → habuerunt: h/hab misread
- p. 107r l. 134: atgui → argui: t/r transposition
- p. 107r l. 135: humisset → habuisset: h/hab misread
- p. 107v l. 4: absolutsi → absoluti: si/i transposition
- p. 107v l. 5: nihillu → nihil: extra lu
- p. 107v l. 10: crcature → creature: extra rc
- p. 107v l. 75: differnt → differunt: missing u
- p. 107v l. 84: propinguitas → propinquitas: missing q
- p. 107v l. 86: conmnexiones → connexiones: extra mn
- p. 107v l. 112: artisex → artifex: s/f misread
- p. 107v l. 115: scentia → scientia: missing i
- p. 107v l. 117: pratica → practica: missing c
- p. 107v l. 120: disiones → diuisiones: missing ui
- p. 107v l. 121: hitudines → habitudines: missing ab (hi→habi)
- p. 107v l. 124: hitudines → habitudines: missing ab (hi→habi)
- p. 108r l. 1: dinus → diuinus: missing ui
- p. 108r l. 2: imparauit → imperauit: a/e misread
- p. 108r l. 3: dinus → diuinus: missing ui
- p. 108r l. 5: deterinauit → determinavit: missing m
- p. 108r l. 18: dinus → diuinus: missing ui
- p. 108r l. 20: dinus → diuinus: missing ui
- p. 108r l. 34: dinus → diuinus: missing ui
- p. 108r l. 35: sacientie → scientie: extra sa
- p. 108r l. 65: conclutione → conclusione: t/s misread
- p. 108r l. 84: speciealiter → specialiter: extra ea
- p. 108r l. 88: tantummo → tantummodo: missing do
- p. 108r l. 103: hitudo → habitudo: missing ab (hi→habi)
- p. 108r l. 104: hitudo → habitudo: missing ab (hi→habi)
- p. 108r l. 127: inteiligit → intelligit: extra ei
- p. 108v l. 13: hieitum → habitum: hi→habi + ei→i
- p. 108v l. 15: hietum → habitum: hi→habi + e dropped

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_