### PR TITLE
Transcription corrections: cod-ve07v1_kzz7yh-a74778.xml (9 changes)

### DIFF
--- a/kzz7yh-a74778/cod-ve07v1_kzz7yh-a74778.xml
+++ b/kzz7yh-a74778/cod-ve07v1_kzz7yh-a74778.xml
@@ -228,7 +228,7 @@
             su<lb ed="#V" n="123" break="no"/>per tertium de anima dicit. Quod si aliquis intellectus semper sit in 
             <lb ed="#V" n="124"/>actu non cognoscit priuationem: sed secundum beatum Aug. libro 83.q. 
             <lb ed="#V" n="125"/>quaestione 6 Totum nomen mali de speciei priuatione repertum est: ergo 
-            <lb ed="#V" n="126"/>cum dinus intellectus semper sit in actu non cognoscit malum. 
+            <lb ed="#V" n="126"/>cum diuinus intellectus semper sit in actu non cognoscit malum. 
           </p>
           <p xml:id="kzz7yh-a74778-d1e408">
             <lb ed="#V" n="127"/>¶ Item <ref xml:id="kzz7yh-a74778-Rd1e430">Matth. 7.</ref> dicitur quod deus dicet malis. Non 
@@ -240,7 +240,7 @@
           </p>
           <p xml:id="kzz7yh-a74778-d1e423">
             ¶ Item philosophus primo 
-            <lb ed="#V" n="131"/>de anima dicit sic. Sufficiens est altera pars conrietatis seipsum 
+            <lb ed="#V" n="131"/>de anima dicit sic. Sufficiens est altera pars contrarietatis seipsum 
             <lb ed="#V" n="132"/>iudicare et oppsium. recto enim et ipsum et obliquum cognoscimus sed 
             <lb ed="#V" n="133"/>malum est quaedam obliquatio a bono et bono oppositum: sicut priuatio: 
             <lb ed="#V" n="134"/>quia secundum Aug. xi. de ciui. dei. c. x. Mali nulla natura est: sed 
@@ -260,7 +260,7 @@
             <lb ed="#V" n="7"/>hanc allegatam: ideam in deo non habet: sed cognoscitur per ideam 
             <lb ed="#V" n="8"/>boni: sicut tenebra per cognitionem lucis. vt vult Diony. de 
             <lb ed="#V" n="9"/>diui. nomi. ca. 7. dicens lux secundum causam in se ipsa cognitionem 
-            <lb ed="#V" n="10"/>tenebrarum pseambiuit: non aliunde videns tenebras quam a luine.
+            <lb ed="#V" n="10"/>tenebrarum praeambiuit: non aliunde videns tenebras quam a luine.
           </p>
           <p xml:id="kzz7yh-a74778-d1e469">
             <lb ed="#V" n="11"/>Ad primum in oppositum dico quod quamuis mala non 
@@ -275,7 +275,7 @@
             <lb ed="#V" n="17"/>causa cognoscat cognoscendo bonitatem sibi appositam. 
           </p>
           <p xml:id="kzz7yh-a74778-d1e489">
-            <lb ed="#V" n="18"/>¶ Ad tertium cum arguitur per auctoriatem Commen. dico quod 
+            <lb ed="#V" n="18"/>¶ Ad tertium cum arguitur per auctoritatem Commen. dico quod 
             <lb ed="#V" n="19"/>auctoritas illa intelligenda est de primo cognito quod est 
             ro<lb ed="#V" n="20" break="no"/>alia cognoscendi. et bene verum est quod loquendo de illo cognitiuo 
             <lb ed="#V" n="21"/>non cognoscit nisi seipsum: et per feipsum bona creata: et 
@@ -301,7 +301,7 @@
           </p>
           <p xml:id="kzz7yh-a74778-d1e533">
             ¶ Item deus 
-            co<lb ed="#V" n="32" break="no"/>gnoscit creaturas que nusquam habent vitam sicut lapides et hius 
+            co<lb ed="#V" n="32" break="no"/>gnoscit creaturas que nusquam habent vitam sicut lapides et huius 
             <lb ed="#V" n="33"/>ergo nulla cognoscit que non sunt in ipso vita.
           </p>
           <p xml:id="kzz7yh-a74778-d1e540">
@@ -340,7 +340,7 @@
             <lb ed="#V" n="52"/>possunt dici esse in dei scientia: quia quamuis scientia significet 
             ean<lb ed="#V" n="53" break="no"/>dem rem cum divina essentia tamen significat sub ratione alia. per 
             <lb ed="#V" n="54"/>quam connotat quandam relationem rationis ipsius dei ad rem 
-            <lb ed="#V" n="55"/>scitam et ex conseqenti rei scite sub ratione qua scita est ad ipsum 
+            <lb ed="#V" n="55"/>scitam et ex consequenti rei scite sub ratione qua scita est ad ipsum 
             de<lb ed="#V" n="56" break="no"/>um sub ratione qua est sciens. Qua propter cum aliquid dicitur esse in 
             <lb ed="#V" n="57"/>scientia dei: hec praepositio in notat habitudinem similem illi 
             habi<lb ed="#V" n="58" break="no"/>tudini que est obiecti ad habitum. Quamuis enim scientie dei non 
@@ -353,7 +353,7 @@
             <lb ed="#V" n="65"/>non debet concedi quod sint in deo. Unde quamuis magister in 
             praesen<lb ed="#V" n="66" break="no"/>ti Dii non neget illa mala esse in dei scientia: negat tamen 
             il<lb ed="#V" n="67" break="no"/>la in deo esse: quia etiam quod nunquam erit: non respicit causam: 
-            ni<lb ed="#V" n="68" break="no"/>si sub ratione qua potest efficere: et sub ratione quarepraesentat nec cau¬ 
+            ni<lb ed="#V" n="68" break="no"/>si sub ratione qua potest efficere: et sub ratione qua repraesentat nec cau¬ 
             <!--00233.xml-->
             <cb ed="#P" n="b"/>
             <lb ed="#V" n="69"/>sam finalem nisi sub ratione qua in ipsam possibile est 
@@ -368,7 +368,7 @@
             <lb ed="#V" n="78"/>bona creata sint in dei scientia. Unde magr. i. c. huius 
             distinctio<lb ed="#V" n="79" break="no"/>nis dicit quod non omnia que sunt in eius presentia: vel in eius 
             <lb ed="#V" n="80"/>cognitionem in eius essentia dici debent: si enim hoc diceretur 
-            <lb ed="#V" n="81"/>intelligerentur cum eo esse eiusdem essentie. Ex predictis ptet 
+            <lb ed="#V" n="81"/>intelligerentur cum eo esse eiusdem essentie. Ex predictis patet 
             <lb ed="#V" n="82"/>quod non omnia que sunt in dei scientia sunt vita. nec 
             viuen<lb ed="#V" n="83" break="no"/>tia: quia multa non viuentia sunt obiectum divine scientie: nec 
             <lb ed="#V" n="84"/>omnia que possunt dici esse in deo sunt vita: vel viuentia: quia 
@@ -390,7 +390,7 @@
             <lb ed="#V" n="95"/>que allegate sunt ad partem aliam que videntur dicere quod 
             om<lb ed="#V" n="96" break="no"/>nia bona creata sunt in deo vita: sic intelligi debent non quod 
             <lb ed="#V" n="97"/>omnes creature sint in deo vita: sed quod idee ipsarum sunt in 
-            <lb ed="#V" n="98"/>ipso vita. Unde cum dicit beatus Ioanes: quod factum est in ipso 
+            <lb ed="#V" n="98"/>ipso vita. Unde cum dicit beatus Ioannes: quod factum est in ipso 
             <lb ed="#V" n="99"/>vita erat: intelligendum est quantum ad facti ideam: et modo 
             <lb ed="#V" n="100"/>simili alie auctoritates glosande sunt. 
           </p>

--- a/kzz7yh-a74778/cod-ve07v1_kzz7yh-a74778.xml
+++ b/kzz7yh-a74778/cod-ve07v1_kzz7yh-a74778.xml
@@ -203,12 +203,12 @@
           </p>
           <p xml:id="kzz7yh-a74778-d1e363">
             ¶ Ad quantum dico quod 
-            auctori<lb ed="#V" n="113" break="no"/>tas Agazel non recipitur in hac patte. 
+            auctori<lb ed="#V" n="113" break="no"/>tas Agazel non recipitur in hac <sic>patte</sic>. 
           </p>
         </div>
         <div xml:id="kzz7yh-a74778-Dd1e369">
-          <head xml:id="kzz7yh-a74778-Hd1e371">Quaestio 2</head>
-          <head xml:id="kzz7yh-a74778-Hd1e384" type="question-title">Utrum cognoscat mala</head>
+          Quaestio 2
+          Utrum cognoscat mala</head>
           <p xml:id="kzz7yh-a74778-d1e373">
             <lb ed="#V" n="114"/>¶ Questio. II. 
             <lb ed="#V" n="115"/>SEcundo queritur vtrum deus cognoscat 
@@ -235,7 +235,7 @@
             no<lb ed="#V" n="128" break="no"/>ui vos: ergo mala deus non cognoscit. 
           </p>
           <p xml:id="kzz7yh-a74778-d1e416">
-            <lb ed="#V" n="129"/>Contra. Sicut iustus iudex prasunit peccatores propter 
+            <lb ed="#V" n="129"/>Contra. Sicut iustus iudex posuit peccatores propter 
             <lb ed="#V" n="130"/>mala: ergo cognoscit ea.
           </p>
           <p xml:id="kzz7yh-a74778-d1e423">
@@ -265,7 +265,7 @@
           <p xml:id="kzz7yh-a74778-d1e469">
             <lb ed="#V" n="11"/>Ad primum in oppositum dico quod quamuis mala non 
             <lb ed="#V" n="12"/>sint in deo nec per essentiam nec per 
-            <lb ed="#V" n="13"/>similitudinem propostiam: tamen similitudo bonitatis sibi 
+            <lb ed="#V" n="13"/>similitudinem propriam: tamen similitudo bonitatis sibi 
             oppo<lb ed="#V" n="14" break="no"/>site per quam cognoscitur: in deo est.
           </p>
           <p xml:id="kzz7yh-a74778-d1e480">
@@ -336,7 +336,7 @@
           <p xml:id="kzz7yh-a74778-d1e586">
             <lb ed="#V" n="49"/>Respondeo quod eorum quae deus cognoscit quaedam sunt 
             ma<lb ed="#V" n="50" break="no"/>la: quaedam bona et eorum quadam praeterita: 
-            <lb ed="#V" n="51"/>quaedam praesentia: quaedam futura et quaedam poslbiatia<!--unsure of word-->: quae numquam erunt et omnia ista 
+            <lb ed="#V" n="51"/>quaedam praesentia: quaedam futura et quaedam possibilitas<!--unsure of word-->: quae numquam erunt et omnia ista 
             <lb ed="#V" n="52"/>possunt dici esse in dei scientia: quia quamuis scientia significet 
             ean<lb ed="#V" n="53" break="no"/>dem rem cum divina essentia tamen significat sub ratione alia. per 
             <lb ed="#V" n="54"/>quam connotat quandam relationem rationis ipsius dei ad rem 


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve07v1_kzz7yh-a74778.xml`.

## Applied changes

- p. 109v l. 126: dinus → diuinus: missing ui
- p. 109v l. 131: conrietatis → contrarietatis: missing ta
- p. 110r l. 10: pseambiuit → praeambiuit: garbled
- p. 110r l. 18: auctoriatem → auctoritatem: missing t
- p. 110r l. 32: hius → huius: missing u
- p. 110r l. 55: conseqenti → consequenti: missing u
- p. 110r l. 68: quarepraesentat → qua repraesentat: missing space
- p. 110r l. 81: ptet → patet: missing a
- p. 110r l. 98: Ioanes → Ioannes: missing n

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_