### PR TITLE
Transcription corrections: cod-ve07v1_kzz7yh-a75392.xml (37 changes)

### DIFF
--- a/kzz7yh-a75392/cod-ve07v1_kzz7yh-a75392.xml
+++ b/kzz7yh-a75392/cod-ve07v1_kzz7yh-a75392.xml
@@ -337,7 +337,7 @@
             Co<lb ed="#V" n="8" break="no"/>gnitio enim rationis secundum modum intelligendi presupponit 
             co<lb ed="#V" n="9" break="no"/>gnitionem vtriusque extremi. Cognoscit enim deus creaturam 
             <lb ed="#V" n="10"/>in idea sic accepta inquantum intuendo se exemplar 
-            crea<lb ed="#V" n="11" break="no"/>ture: videt eam refulgere in se. Non est autem idem dicentem 
+            crea<lb ed="#V" n="11" break="no"/>ture: videt eam refulgere in se. Non est autem idem dicere rem
             <lb ed="#V" n="12"/>cognoscere per aliquid et in aliquo. Sed quia secundum praedictam 
             <lb ed="#V" n="13"/>opinionem non tantum divina essentia esset immediatum obiectum 
             <lb ed="#V" n="14"/>diuini intellectus: sed etiam essentia creature. Ideo alii 
@@ -590,7 +590,7 @@
             <lb ed="#V" n="45"/>cognoscit eiusdem speciei per vnam ideam.
           </p>
           <p xml:id="kzz7yh-a75392-d1e1074">
-            ¶ Item in ea 
+            ¶ Item in
             ea<lb ed="#V" n="46" break="no"/>dem epistola. Quilibet homo vna ratione qua homo 
             intel<lb ed="#V" n="47" break="no"/>ligitur: factus est: ergo a simili vna ratione cognitus: ergo vna 
             <lb ed="#V" n="48"/>idea speciei sufficit ad cognitionem et factionem singularium 
@@ -916,8 +916,8 @@
             ¶ Illarum autem superexcellentiarum 
             <lb ed="#V" n="126"/>ille tamen sunt idee que sunt respectu bonorum factorum 
             <lb ed="#V" n="127"/>et faciendorum: quia communius accipiuntur idee secundum quod dicunt 
-            ratio<lb ed="#V" n="128" break="no"/>nes cognoscitiuas: et operatiuas simul. Omnia autem attribu 
-            <lb ed="#V" n="129"/>ta sunt perfectiones: sed non econuerso. Attributa enim sunt 
+            ratio<lb ed="#V" n="128" break="no"/>nes cognoscitiuas: et operatiuas simul. Omnia autem attribu
+            <lb ed="#V" n="129" break="no"/>ta sunt perfectiones: sed non econuerso. Attributa enim sunt 
             <lb ed="#V" n="130"/>superexcellentie perfectionum substantiam creature circumstantium: 
             <lb ed="#V" n="131"/>quarum quanlibet melius est simpliciter habere per modum 
             <lb ed="#V" n="132"/>rei intrinsece quam non habere in divina essentia existentes: sicut 

--- a/kzz7yh-a75392/cod-ve07v1_kzz7yh-a75392.xml
+++ b/kzz7yh-a75392/cod-ve07v1_kzz7yh-a75392.xml
@@ -237,7 +237,7 @@
             com<lb ed="#V" n="71" break="no"/>parationem ad divinum intellectum aliter non fuissent plures 
             <lb ed="#V" n="72"/>idee ab eterno cum non plurificentur secundum rem: sed per 
             intelle<lb ed="#V" n="73" break="no"/>ctum non possunt in deo plurificare nisi inquantum ipse 
-            intel<lb ed="#V" n="74" break="no"/>lectus dinus intuetur essentiam suam vt diuersimode imitabilem: 
+            intel<lb ed="#V" n="74" break="no"/>lectus diuinus intuetur essentiam suam vt diuersimode imitabilem: 
             <lb ed="#V" n="75"/>ergo diuina essentia non est idea nisi inquantum a divino 
             intel<lb ed="#V" n="76" break="no"/>lectu intellecta: et imitabilis a creatuta.
           </p>
@@ -247,7 +247,7 @@
             <lb ed="#V" n="78"/>eam vt imitabilem. Unde diuina essentia est a deo primum 
             <lb ed="#V" n="79"/>cognitum: sed divina essentia non est idea nisi inquantum est 
             <lb ed="#V" n="80"/>diuino intellectui ratio cognoscendi creaturam: et operandi: 
-            <lb ed="#V" n="81"/>ergo non est indea nisi inquantum est a diuino intellectu 
+            <lb ed="#V" n="81"/>ergo non est idea nisi inquantum est a diuino intellectu 
             <lb ed="#V" n="82"/>intellecta vt imitabilis. 
           </p>
           <p xml:id="kzz7yh-a75392-d1e447">
@@ -272,7 +272,7 @@
           </p>
           <p xml:id="kzz7yh-a75392-d1e485">
             ¶ Item intellectus noster cognoscit res per 
-            similitudi<lb ed="#V" n="98" break="no"/>nem non tamen intuendo eas in obiectum: ergo similiter dinus 
+            similitudi<lb ed="#V" n="98" break="no"/>nem non tamen intuendo eas in obiectum: ergo similiter diuinus 
             <lb ed="#V" n="99"/>intellectus non tantummodo cognoscit res per suam essentiam 
             <lb ed="#V" n="100"/>inquantum est obiectum sui intellectus etiam inquantum est 
             <lb ed="#V" n="101"/>forma in suo intellectu similis rebus: cum ergo divinam 
@@ -295,7 +295,7 @@
             ¶ Secundo 
             mo<lb ed="#V" n="114" break="no"/>do potest accipi idea secundum quod nominat essentiam creature 
             inquan<lb ed="#V" n="115" break="no"/>tum a diuino intellectu intellecta est: eo quod essentia crature 
-            <lb ed="#V" n="116"/>inquantum est a deo intellecta aliquomon est exemplar sui 
+            <lb ed="#V" n="116"/>inquantum est a deo intellecta aliquomodo est exemplar sui 
             <lb ed="#V" n="117"/>ipsius vt est in essentia realis et actualis existentie producta 
             <lb ed="#V" n="118"/>secundum quam significationem credunt aliqui platonem posuisse ideas 
             <lb ed="#V" n="119"/>quanuis secundum numerum specierum tantum: et sic esse ideam non 
@@ -305,13 +305,13 @@
             se<lb ed="#V" n="123" break="no"/>cundarium obiectum diuini intellectus.
           </p>
           <p xml:id="kzz7yh-a75392-d1e549">
-            ¶ Tertiomon 
+            ¶ Tertio modo 
             acci<lb ed="#V" n="124" break="no"/>pitur idea secundum quod dicit intrinsecus in deo rationem 
             cognosci<lb ed="#V" n="125" break="no"/>tiuam creaturarum et operatiuam: et sic videtur quibusdam quod 
             du<lb ed="#V" n="126" break="no"/>pliciter dicitur: vno modo dicitur divina essentia inquantum est 
             <lb ed="#V" n="127"/>imitabilis a creatura. Alio modo inquantum est intellecta 
             <lb ed="#V" n="128"/>vt imitabilis a creatura: et sic idea primo modo dicta prius 
-            <lb ed="#V" n="129"/>est secundum rationem intelligendi quam secundomon dicta: quia enim 
+            <lb ed="#V" n="129"/>est secundum rationem intelligendi quam secundo modo dicta: quia enim 
             di<lb ed="#V" n="130" break="no"/>uina essentia est imitabilis a creatura: ideo deus intelligit eam 
             <lb ed="#V" n="131"/>vt imitabilem a creatura non econuerso: et hoc modo idea 
             di<lb ed="#V" n="132" break="no"/>cit in deo respectum rationis: vt in potentia: ad creaturam et 
@@ -344,7 +344,7 @@
             vt<lb ed="#V" n="15" break="no"/>dentur communius dicere scilicet quod eo modo quo conuenit divina 
             <lb ed="#V" n="16"/>essentie esse ideam: non conuenit sibi nisi inquantum est 
             intelle<lb ed="#V" n="17" break="no"/>cta vt imitabilis a creatura: quia deus per essentiam suam non 
-            <lb ed="#V" n="18"/>cognoscit ereaturam nisi inquantum intelligit eam vt 
+            <lb ed="#V" n="18"/>cognoscit creaturam nisi inquantum intelligit eam vt 
             imi<lb ed="#V" n="19" break="no"/>tabilem a creatura. Unde vere per ideam et in idea deus 
             <lb ed="#V" n="20"/>cognoscit creaturam: quamuis enim divina essentia sub ratione 
             <lb ed="#V" n="21"/>idee non scit ratio cognitionis qua deus cognoscit 
@@ -376,10 +376,10 @@
             ar<lb ed="#V" n="40" break="no"/>gumenta contra eam.
           </p>
           <p xml:id="kzz7yh-a75392-d1e687">
-            <lb ed="#V" n="41"/>Ad primum cum dicitur quod duinia essentia est ratio 
+            <lb ed="#V" n="41"/>Ad primum cum dicitur quod diuina essentia est ratio 
             <lb ed="#V" n="42"/>cognoscendi et operandi 
             creatu<lb ed="#V" n="43" break="no"/>ram inquantum est forma in divino intellectu similis 
-            creatu<lb ed="#V" n="44" break="no"/>re etc. Potest dici quod falsum est. sed inquantum est cognitea 
+            creatu<lb ed="#V" n="44" break="no"/>re etc. Potest dici quod falsum est. sed inquantum est cognita 
             <lb ed="#V" n="45"/>vt imitabilis a creatura.
           </p>
           <p xml:id="kzz7yh-a75392-d1e700">
@@ -404,7 +404,7 @@
           </p>
           <p xml:id="kzz7yh-a75392-d1e733">
             ¶ Alii dicunt quod intellectus non 
-            <lb ed="#V" n="57"/>recipit aliam similitudinem quam intellectionem quodammode 
+            <lb ed="#V" n="57"/>recipit aliam similitudinem quam intellectionem quodammodo 
             <lb ed="#V" n="58"/>indistinctam respectu cuius intellectus possibilis est pure 
             <lb ed="#V" n="59"/>passiuus: et per quam aliquo modo in actu reductus venatur 
             <lb ed="#V" n="60"/>rei diffinitionem: vt habeat de re cognitionem distinctam 
@@ -415,7 +415,7 @@
           <head xml:id="kzz7yh-a75392-Hd1e749">Quaestio 3</head>
           <head xml:id="kzz7yh-a75392-Hd1e784" type="question-title">Utrum in deo sint plures ideae</head>
           <p xml:id="kzz7yh-a75392-d1e751">
-            Quaestido III. 
+            Quaestio III. 
             <lb ed="#V" n="62"/>Tertio queritur vtrum in deo sint plures 
             <lb ed="#V" n="63"/>idee. et videtur quod non. In deo non 
             <lb ed="#V" n="64"/>fuerunt plures idee ab eterno vt probabo. ergo nec 
@@ -454,7 +454,7 @@
             <lb ed="#V" n="85"/>rationes intelligit ideas: ergo in deo est pluralitas idearum 
             <lb ed="#V" n="86"/>Item cum deus producat creaturas distincte et cognoscat 
             <lb ed="#V" n="87"/>eas distincte: quod esse non posset nisi haberet distinctas 
-            ratio<lb ed="#V" n="88" break="no"/>nes cognoscendi et operandi et huismodi rationes sunt idee. 
+            ratio<lb ed="#V" n="88" break="no"/>nes cognoscendi et operandi et huiusmodi rationes sunt idee. 
             <lb ed="#V" n="89"/>sequitur quod in deo sunt plures idee. 
           </p>
           <p xml:id="kzz7yh-a75392-d1e830">
@@ -470,28 +470,28 @@
               <lb ed="#V" n="99"/>dicit li. 83. q. quaestione 46</ref> quod ipse idee eterne sunt. nec per 
             com<lb ed="#V" n="100" break="no"/>parationem ad diuersas conceptiones intellectus causati 
             <lb ed="#V" n="101"/>quia sic est sequeretur quod non fuissent plures idee ab eterno 
-            <lb ed="#V" n="102"/>cum nullus intellectus ereatus fuerit ab eterno. Nec e 
+            <lb ed="#V" n="102"/>cum nullus intellectus creatus fuerit ab eterno. Nec e 
             <lb ed="#V" n="103"/>comparationes ad diuersas conceptiones. in intellectui 
             increa<lb ed="#V" n="104" break="no"/>to: quia in divino intellectu non sunt diuerse conceptiones. 
             <lb ed="#V" n="105"/>Unico enim actu intelligendi intelligit omnia: et vnico 
             con<lb ed="#V" n="106" break="no"/>ceptu dicit omnia. Restat ergo quod pluralitas idearum in 
             <lb ed="#V" n="107"/>divino intellectu attenditur secundum diuersas relationes rationis 
             <lb ed="#V" n="108"/>divine existentie: que est forma diuini intellectus ad 
-            diuer<lb ed="#V" n="109" break="no"/>sas creaturas: et quia ralatio rationis non consequitur rem nisi 
+            diuer<lb ed="#V" n="109" break="no"/>sas creaturas: et quia relatio rationis non consequitur rem nisi 
             inquan<lb ed="#V" n="110" break="no"/>tum est intellecta. ideo dico quod pluralitas idearum est in deo 
             <lb ed="#V" n="111"/>per hoc quod dicimus intellectus intelligit essentiam suam: vt 
             <lb ed="#V" n="112"/>diuersarum creaturarum representatiuam: et vt ab eis 
             imi<lb ed="#V" n="113" break="no"/>tabilem: quamuis autem ab eterno non fuerit creatura in esse 
             <lb ed="#V" n="114"/>reali: neque vna: neque plures: tamen ab eterno fuerunt per 
             <lb ed="#V" n="115"/>diuinam essentiam a divino intellectu intellectam 
-            represen<lb ed="#V" n="116" break="no"/>tate creature divino intellectui. et ita ab etetno fuerunt in 
-            di<lb ed="#V" n="117" break="no"/>uina essentia plures relationes secndum rationem ad diuersas creaturas 
+            represen<lb ed="#V" n="116" break="no"/>tate creature divino intellectui. et ita ab aeterno fuerunt in 
+            di<lb ed="#V" n="117" break="no"/>uina essentia plures relationes secundum rationem ad diuersas creaturas 
             <lb ed="#V" n="118"/>non realiter existentes: sed divino intellectui representatas. Ex 
             <lb ed="#V" n="119"/>predictis patere potest responsio.
           </p>
           <p xml:id="kzz7yh-a75392-d1e898">
             <lb ed="#V" n="120"/>Ad primum argumentum in oppositum relatio enim 
-            ra<lb ed="#V" n="121" break="no"/>tionis non requrit sua 
+            ra<lb ed="#V" n="121" break="no"/>tionis non requirit sua 
             extrema<lb ed="#V" n="122" break="no"/>in esses reali. Sed per comparationem ad intellectum. Ab 
             eter<lb ed="#V" n="123" break="no"/>no autem fuit divina essentia a divino intellectu intellecta. et 3 
             <lb ed="#V" n="124"/>eam creature representate intellectui divino.
@@ -518,7 +518,7 @@
             <cb ed="#P" n="a"/>
             <lb ed="#V" n="1"/>in aliud tamen ducente vivel aliud representante: quamuis autem 
             <lb ed="#V" n="2"/>deus vno intelligat omnia: intelligit tamen illud vnum vt a 
-            <lb ed="#V" n="3"/>multis imitabile: et vt mltorum repraesentatiuum. Si autem dici non 
+            <lb ed="#V" n="3"/>multis imitabile: et vt multorum repraesentatiuum. Si autem dici non 
             <lb ed="#V" n="4"/>possunt multa exemplaria in deo: hoc forte est: quia illud 
             no<lb ed="#V" n="5" break="no"/>men imponitur ad significandum totam pluritatem idearum 
             <lb ed="#V" n="6"/>simul sicut sigillum. simul dicit congregationem omnium 
@@ -577,13 +577,13 @@
           </p>
           <p xml:id="kzz7yh-a75392-d1e1052">
             ¶ Item sicut genus est superius 
-            spe<lb ed="#V" n="38" break="no"/>cie: ita species indiduo: sed non inuenitur positum quod alia sit 
+            spe<lb ed="#V" n="38" break="no"/>cie: ita species indiuiduo: sed non inuenitur positum quod alia sit 
             <lb ed="#V" n="39"/>species generis: et speciei: ergo a simili non est alia idea 
             spe<lb ed="#V" n="40" break="no"/>ciei et indiuidui.
           </p>
           <p xml:id="kzz7yh-a75392-d1e1061">
-            ¶ Item Aug. 4. eplaad Nembridium 
-            <lb ed="#V" n="41"/>quae est. cv. in ordine epsturarum suarum sic ait. Quotiens 
+            ¶ Item Aug. 4. epistola ad Nembridium 
+            <lb ed="#V" n="41"/>quae est. cv. in ordine epistolarum suarum sic ait. Quotiens 
             de<lb ed="#V" n="42" break="no"/>monstrare angulum volo: non nisi vna ratio anguli mihi 
             <lb ed="#V" n="43"/>occurrit: ergo plures angulos cognoscere possumus per 
             <lb ed="#V" n="44"/>vnam rationem: ergo deus multo fortius omnia singularia 
@@ -634,10 +634,10 @@
             <lb ed="#V" n="71"/>ad species: neque quantum ad singularia est idea in deo 
             si<lb ed="#V" n="72" break="no"/>cut enim dicit <ref xml:id="kzz7yh-a75392-Rd1e1203">Diony. lib. de diuinis no. c. 4. parte 15</ref> 
             ma<lb ed="#V" n="73" break="no"/>lum in deo non habet ideas. Singularium autem bonorum que 
-            <lb ed="#V" n="74"/>dam sunt possibilia fieri que nunquam fient: et istorumnon est 
+            <lb ed="#V" n="74"/>dam sunt possibilia fieri que nunquam fient: et istorum non est 
             <lb ed="#V" n="75"/>idea in deo proprie loquendo. Idea enim in deo non 
             tantum<lb ed="#V" n="76" break="no"/>modo dicit rationem cognitionis: sed etiam rationem 
-            factio<lb ed="#V" n="77" break="no"/>nis rerum. Unde etiam Poato ideas posuit esse principium 
+            factio<lb ed="#V" n="77" break="no"/>nis rerum. Unde etiam Plato ideas posuit esse principium 
             <lb ed="#V" n="78"/>cognitionis et productionis rerum. Augu. etiam lib. 83.q. 
             <lb ed="#V" n="79"/>quaestione. 46 secundum eas formari dicit quicquid oritur et interit. 
           </p>
@@ -693,7 +693,7 @@
             <lb ed="#V" n="114"/>huius hominis: quia sicut rerum corruptibilium sunt in deo 
             incor<lb ed="#V" n="115" break="no"/>ruptibiles idee: et rerum inequalium equales idee in 
             nobi<lb ed="#V" n="116" break="no"/>litate: ita dico quod rerum per ordinem prioris et posterioris se 
-            <lb ed="#V" n="117"/>habentium in deo simul sunt idee sine ordine praeoritatis et 
+            <lb ed="#V" n="117"/>habentium in deo simul sunt idee sine ordine prioritatis et 
             po<lb ed="#V" n="118" break="no"/>sterioritatis.
           </p>
           <p xml:id="kzz7yh-a75392-d1e1269">
@@ -714,8 +714,8 @@
           </p>
           <p xml:id="kzz7yh-a75392-d1e1300">
             ¶ Ad 6m quasi modo soluendum est: deus enim 
-            ha<lb ed="#V" n="132" break="no"/>bet: et ideas generum: et specierum: et magis differunt secundum ratio 
-            <lb ed="#V" n="133"/>nem idee duarum specierum quam idee generis et speciei contente 
+            ha<lb ed="#V" n="132" break="no"/>bet: et ideas generum: et specierum: et magis differunt secundum 
+            ratio<lb ed="#V" n="133" break="no"/>nem idee duarum specierum quam idee generis et speciei contente 
             <lb ed="#V" n="134"/>sub illo genere.
           </p>
           <p xml:id="kzz7yh-a75392-d1e1309">
@@ -777,7 +777,7 @@
             <lb ed="#V" n="28"/>Respondeo quod in deo sunt ide insitorum 
             exten<lb ed="#V" n="29" break="no"/>dendo nomen idee ad rationes 
             cogno<lb ed="#V" n="30" break="no"/>scitiuas: quia vt inferius ostendetur diuina essentia infinita est 
-            <lb ed="#V" n="31"/>infinitate: que dicit persectionem et includit positionem. Talis 
+            <lb ed="#V" n="31"/>infinitate: que dicit perfectionem et includit positionem. Talis 
             <lb ed="#V" n="32"/>ergo infinitas ponit perfectionem infinitam: perfecto autem 
             infini<lb ed="#V" n="33" break="no"/>ta modis infinitis est imitabilis: ergo diuina essentia est 
             <lb ed="#V" n="34"/>imitabilis modis infinitis. Intelligit ergo se vt modis 
@@ -817,7 +817,7 @@
             ¶ Ex his sic arguunt. autem in deo sunt idee 
             <lb ed="#V" n="54"/>finite in aliquo numero determinato: aut finite non tamen 
             in<lb ed="#V" n="55" break="no"/>aliquo numero determinato: aut infinite in actu 
-            permixto<lb ed="#V" n="56" break="no"/>potentie: aut infinita in actu puro non primomo: quia tunc 
+            permixto<lb ed="#V" n="56" break="no"/>potentie: aut infinita in actu puro non primo modo: quia tunc 
             <lb ed="#V" n="57"/>esset aliquid futurum cuius non est idea in deo: quia ex quo 
             sin<lb ed="#V" n="58" break="no"/>gularia producentur sine fine excedent communem numerum 
             fini<lb ed="#V" n="59" break="no"/>tum determinatum: et tamen per primam suppositionem in deo 
@@ -873,11 +873,11 @@
             ¶ Ad 3m cum 
             di<lb ed="#V" n="97" break="no"/>citur quod deus non fecit infinita nec facturus est etc. dico quod 
             <lb ed="#V" n="98"/>verum est in actu puro: faciet tamen infinita in actu 
-            per<lb ed="#V" n="99" break="no"/>mixto potentie mediantibus causis secundis: quia omens 
+            per<lb ed="#V" n="99" break="no"/>mixto potentie mediantibus causis secundis: quia omnes 
             mo<lb ed="#V" n="100" break="no"/>tus cognitionum futurarum inquantum motus sunt ab ipso 
             <lb ed="#V" n="101"/>deo sunt mediante causa secunda: cuius etiam effectus immediate 
             <lb ed="#V" n="102"/>producit. Tales autem motus erunt infiniti in actu 
-            permixto<lb ed="#V" n="103" break="no"/>potentie: et infinitorum in actu permxto potentie. Deus 
+            permixto<lb ed="#V" n="103" break="no"/>potentie: et infinitorum in actu permixto potentie. Deus 
             <lb ed="#V" n="104"/>iam habet ideas in puro actu.
           </p>
         </div>
@@ -886,14 +886,14 @@
           <head xml:id="kzz7yh-a75392-Hd1e1675" type="question-title">Utrum in deo sit aliqua differentia secundum rationem idearum et attributorum</head>
           <p xml:id="kzz7yh-a75392-d1e1606">
             ¶ Quaestio VI 
-            <lb ed="#V" n="105"/>SExto queritur sine arguntis vtrum 
+            <lb ed="#V" n="105"/>SExto queritur sine argumentis vtrum 
             <lb ed="#V" n="106"/>in deo sit aliqua 
             dif<lb ed="#V" n="107" break="no"/>ferentia secundum rationem idearum et attributorum. 
           </p>
           <p xml:id="kzz7yh-a75392-d1e1615">
-            <lb ed="#V" n="108"/>Respondeo quod sic ad cuis pleniorem intelligentiam 
-            <lb ed="#V" n="109"/>sciendum quod superexcellentie perfectio 
-            <lb ed="#V" n="110"/>num entium creatorum et creandorum et creari possibilium in 
+            <lb ed="#V" n="108"/>Respondeo quod sic ad cuius pleniorem intelligentiam 
+            <lb ed="#V" n="109"/>sciendum quod superexcellentie 
+            perfectio<lb ed="#V" n="110" break="no"/>num entium creatorum et creandorum et creari possibilium in 
             <lb ed="#V" n="111"/>deo sunt: et omnes ille superexcellentie in deo existentes: 
             perfe<lb ed="#V" n="112" break="no"/>ctiones dicuntur: et rationes cognoscitiue: et prime mensure 
             en<lb ed="#V" n="113" break="no"/>tium predictorum: et quedam sunt idee: et quedam attributa 
@@ -928,7 +928,7 @@
             <!--00238.xml-->
             <pb ed="#V" n="112-v"/>
             <cb ed="#P" n="a"/>
-            <lb ed="#V" n="1"/>am dicantur de cretaore et creatura non inquamtum 
+            <lb ed="#V" n="1"/>am dicantur de cretaore et creatura non inquantum 
             ac<lb ed="#V" n="2" break="no"/>cipiuntur tantum cum modo quo determinantur ad 
             crea<lb ed="#V" n="3" break="no"/>turam et ita pte quod superexcellentie perfectionum asinitatis et 
             <lb ed="#V" n="4"/>leonitatis et sic de aliis in divina essentia existentes ita sunt 
@@ -943,8 +943,8 @@
             <lb ed="#V" n="13"/>c. 4. Cum dixit si bonum et si iustum et si sapiens et si quodcumque 
             dixe<lb ed="#V" n="14" break="no"/>ris non naturam dices dei: sed ea que sunt circa naturam 
             <lb ed="#V" n="15"/>Sciendum etiam quod ille perfectiones quae sunt attributa sub alia 
-            <lb ed="#V" n="16"/>ratione dicuntur persectiones: et sub alia ratione dicuntur 
-            at<lb ed="#V" n="17" break="no"/>tributa. Dicuntur enim perfectiones sub ratione qua nihit 
+            <lb ed="#V" n="16"/>ratione dicuntur perfectiones: et sub alia ratione dicuntur 
+            at<lb ed="#V" n="17" break="no"/>tributa. Dicuntur enim perfectiones sub ratione qua nihil 
             <lb ed="#V" n="18"/>eis deest de nobilitate essendi simpliciter.
           </p>
           <p xml:id="kzz7yh-a75392-d1e1733">
@@ -956,10 +956,10 @@
             ¶ Ex dictis patet quod 
             attribu<lb ed="#V" n="21" break="no"/>ta et idee differunt in hoc quod quedam superexcellentie per 
             <lb ed="#V" n="22"/>sectionum sunt idee que non sunt attributa: sicut 
-            superex<lb ed="#V" n="23" break="no"/>cellentia petfectionis asinine et leonine sunt idee: et non 
+            superex<lb ed="#V" n="23" break="no"/>cellentia perfectionis asinine et leonine sunt idee: et non 
             <lb ed="#V" n="24"/>attributa. Ille est superexcellentie perfectionum quae sunt 
             attribu<lb ed="#V" n="25" break="no"/>ta sub alia ratione sunt idee: et sub alia ratione scut attributa. Sunt 
-            <lb ed="#V" n="26"/>enm idee inquantum sunt deo rationes cogoscendi et operandi. 
+            <lb ed="#V" n="26"/>enm idee inquantum sunt deo rationes cognoscendi et operandi. 
             <lb ed="#V" n="27"/>Sunt autem attributa inquantum attribuuntur diuine 
             substan<lb ed="#V" n="28" break="no"/>tie tanquam de ipsa predicabilia.
           </p>

--- a/kzz7yh-a75392/cod-ve07v1_kzz7yh-a75392.xml
+++ b/kzz7yh-a75392/cod-ve07v1_kzz7yh-a75392.xml
@@ -239,7 +239,7 @@
             intelle<lb ed="#V" n="73" break="no"/>ctum non possunt in deo plurificare nisi inquantum ipse 
             intel<lb ed="#V" n="74" break="no"/>lectus diuinus intuetur essentiam suam vt diuersimode imitabilem: 
             <lb ed="#V" n="75"/>ergo diuina essentia non est idea nisi inquantum a divino 
-            intel<lb ed="#V" n="76" break="no"/>lectu intellecta: et imitabilis a creatuta.
+            intel<lb ed="#V" n="76" break="no"/>lectu intellecta: et imitabilis a <sic>creatuta</sic>.
           </p>
           <p xml:id="kzz7yh-a75392-d1e431">
             ¶ Item deus non 
@@ -263,7 +263,7 @@
             pre<lb ed="#V" n="89" break="no"/>supposita illius rei alia cognitione. Unde intuendo 
             ima<lb ed="#V" n="90" break="no"/>ginem Pauli nunquam per ipsum. Paulum cognoscerem nisi 
             <lb ed="#V" n="91"/>presupposita aliqua alia cognitione de Paulo. Unde 
-            sal<lb ed="#V" n="92" break="no"/>tem hoc opetet quod scientia illam imaginem esse Pauli quod 
+            sal<lb ed="#V" n="92" break="no"/>tem hoc oportet quod scientia illam imaginem esse Pauli quod 
             <lb ed="#V" n="93"/>includit me habere aliam cognitionem de Paulo quam per illam 
             <lb ed="#V" n="94"/>imaginem. Sed deus cognoscit creaturam per ideam non 
             pre<lb ed="#V" n="95" break="no"/>supposita alia cognitionem de creatura: ergo sue essentie: non 
@@ -284,7 +284,7 @@
             <lb ed="#V" n="105"/>Respondeo quod idea potest accipi tribus modis. Uno 
             <lb ed="#V" n="106"/>modo secundum quod nominat quiditates istorum 
             <lb ed="#V" n="107"/>sensibilium ab istis sensibilibus realiter separatas: et per se in actu 
-            <lb ed="#V" n="108"/>reali existentes et realem differeutiam inter se habentes: quas secundum 
+            <lb ed="#V" n="108"/>reali existentes et realem <sic>differeutiam</sic> inter se habentes: quas secundum 
             <lb ed="#V" n="109"/>numerum specierum existentes Aristotiles imponit platoni 
             <lb ed="#V" n="110"/>posuisse tanquam exemplaria istorum sensibilium necessaria ad 
             <lb ed="#V" n="111"/>istorum sensibilium cognitionem et productionem: et hoc modo esse 
@@ -294,7 +294,7 @@
           <p xml:id="kzz7yh-a75392-d1e525">
             ¶ Secundo 
             mo<lb ed="#V" n="114" break="no"/>do potest accipi idea secundum quod nominat essentiam creature 
-            inquan<lb ed="#V" n="115" break="no"/>tum a diuino intellectu intellecta est: eo quod essentia crature 
+            inquan<lb ed="#V" n="115" break="no"/>tum a diuino intellectu intellecta est: eo quod essentia <sic>crature</sic> 
             <lb ed="#V" n="116"/>inquantum est a deo intellecta aliquomodo est exemplar sui 
             <lb ed="#V" n="117"/>ipsius vt est in essentia realis et actualis existentie producta 
             <lb ed="#V" n="118"/>secundum quam significationem credunt aliqui platonem posuisse ideas 
@@ -337,7 +337,7 @@
             Co<lb ed="#V" n="8" break="no"/>gnitio enim rationis secundum modum intelligendi presupponit 
             co<lb ed="#V" n="9" break="no"/>gnitionem vtriusque extremi. Cognoscit enim deus creaturam 
             <lb ed="#V" n="10"/>in idea sic accepta inquantum intuendo se exemplar 
-            crea<lb ed="#V" n="11" break="no"/>ture: videt eam refulgere in se. Non est autem idem dicenrem 
+            crea<lb ed="#V" n="11" break="no"/>ture: videt eam refulgere in se. Non est autem idem dicentem 
             <lb ed="#V" n="12"/>cognoscere per aliquid et in aliquo. Sed quia secundum praedictam 
             <lb ed="#V" n="13"/>opinionem non tantum divina essentia esset immediatum obiectum 
             <lb ed="#V" n="14"/>diuini intellectus: sed etiam essentia creature. Ideo alii 
@@ -516,7 +516,7 @@
             <!--00236.xml-->
             <pb ed="#V" n="111-v"/>
             <cb ed="#P" n="a"/>
-            <lb ed="#V" n="1"/>in aliud tamen ducente vivel aliud representante: quamuis autem 
+            <lb ed="#V" n="1"/>in aliud tamen ducente vel aliud representante: quamuis autem 
             <lb ed="#V" n="2"/>deus vno intelligat omnia: intelligit tamen illud vnum vt a 
             <lb ed="#V" n="3"/>multis imitabile: et vt multorum repraesentatiuum. Si autem dici non 
             <lb ed="#V" n="4"/>possunt multa exemplaria in deo: hoc forte est: quia illud 
@@ -528,7 +528,7 @@
             crea<lb ed="#V" n="10" break="no"/>tura habere in deo proprium exemplar: et sic plurium 
             crea<lb ed="#V" n="11" break="no"/>turarum exemplaria plura. vnde Diony. lib. de diui. nomi. 
             <lb ed="#V" n="12"/>c. 5 ipsas ideas vocat paradygmata: pro quo ponit 
-            trans<lb ed="#V" n="13" break="no"/>latio albictis exemplaria.
+            trans<lb ed="#V" n="13" break="no"/>latio <unclear>albis</unclear> exemplaria.
           </p>
           <p xml:id="kzz7yh-a75392-d1e977">
             ¶ Ad 4m cum dicitur quod 
@@ -591,7 +591,7 @@
           </p>
           <p xml:id="kzz7yh-a75392-d1e1074">
             ¶ Item in ea 
-            <lb ed="#V" n="46"/>dem epistola. Quilibet homo vna ratione qua homo 
+            ea<lb ed="#V" n="46" break="no"/>dem epistola. Quilibet homo vna ratione qua homo 
             intel<lb ed="#V" n="47" break="no"/>ligitur: factus est: ergo a simili vna ratione cognitus: ergo vna 
             <lb ed="#V" n="48"/>idea speciei sufficit ad cognitionem et factionem singularium 
             <lb ed="#V" n="49"/>sub vna specie contentorum. 
@@ -757,7 +757,7 @@
           <p xml:id="kzz7yh-a75392-d1e1369">
             ¶ Item idee non 
             <lb ed="#V" n="16"/>sunt nisi respectu entium creatorum et creandorum: sed 
-            ta<lb ed="#V" n="17" break="no"/>lia non sunt infinita. deus enim nec creauit iufinita: nec 
+            ta<lb ed="#V" n="17" break="no"/>lia non sunt infinita. deus enim nec creauit <sic>iufinita:</sic> nec 
             <lb ed="#V" n="18"/>facturus est: ergo in deo non sunt idee infinitorum. 
           </p>
           <p xml:id="kzz7yh-a75392-d1e1378">
@@ -789,11 +789,11 @@
             <!--TODO: insert para break here-->
             <lb ed="#V" n="40"/>Quanuis et aliqui magis estiment non esse in deo 
             <lb ed="#V" n="41"/>ideas infinitorum: sed quod dicit rationes 
-            co<lb ed="#V" n="42" break="no"/>gnoscitiuas: et operatiuas simul eo quod deus nunquam producert 
+            co<lb ed="#V" n="42" break="no"/>gnoscitiuas: et operatiuas simul eo quod deus nunquam producet 
             <lb ed="#V" n="43"/>infinita.
           </p>
           <p xml:id="kzz7yh-a75392-d1e1440">
-            ¶ Uidetur tamen aliis probabiliter contrarium quod ex triplicitur 
+            ¶ Uidetur tamen aliis probabiliter contrarium quod ex <sic>triplicius</sic> 
             <lb ed="#V" n="44"/>suppositione quarum vna iam probata est: et due alie satis 
             ma<lb ed="#V" n="45" break="no"/>nifeste probant. 
           </p>
@@ -846,8 +846,8 @@
           <p xml:id="kzz7yh-a75392-d1e1534">
             ¶ Et in hoc soluta est illa questio qua 
             que<lb ed="#V" n="79" break="no"/>ritur vtrum deus cognoscat infinita bona. Et ex hoc vel 
-            <lb ed="#V" n="80"/>terius patere potest quid respondendum est ad quaestionem qua 
-            queri<lb ed="#V" n="81" break="no"/>tur: et vtrum deus cognoscat infinita mala: et ideo non opetet 
+            <lb ed="#V" n="80"/><sic>terius</sic> patere potest quid respondendum est ad quaestionem qua 
+            queri<lb ed="#V" n="81" break="no"/>tur: et vtrum deus cognoscat infinita mala: et ideo non oportet 
             <lb ed="#V" n="82"/>de hoc vlterius facere questionem.
           </p>
           <p xml:id="kzz7yh-a75392-d1e1545">
@@ -897,7 +897,7 @@
             <lb ed="#V" n="111"/>deo sunt: et omnes ille superexcellentie in deo existentes: 
             perfe<lb ed="#V" n="112" break="no"/>ctiones dicuntur: et rationes cognoscitiue: et prime mensure 
             en<lb ed="#V" n="113" break="no"/>tium predictorum: et quedam sunt idee: et quedam attributa 
-            <lb ed="#V" n="114"/>sed sub alia et alia ratione. dicminter enim perfectiones inquantum 
+            <lb ed="#V" n="114"/>sed sub alia et alia ratione. dicuuntur enim perfectiones inquantum 
             <lb ed="#V" n="115"/>eis nihil deest de notabilitate essendi. Sicut enim 
             perfectio<lb ed="#V" n="116" break="no"/>in genere dicitur cui nihil deesse de notabilitate spectante 
             <lb ed="#V" n="117"/>ad ea que debentur perfectioni in illo genere: ita 
@@ -915,8 +915,8 @@
           <p xml:id="kzz7yh-a75392-d1e1660">
             ¶ Illarum autem superexcellentiarum 
             <lb ed="#V" n="126"/>ille tamen sunt idee que sunt respectu bonorum factorum 
-            <lb ed="#V" n="127"/>et faciendorum: quia conius accipiuntur idee secundum quod dicunt 
-            ratio<lb ed="#V" n="128" break="no"/>nes cognoscitiuas: et operatiuas simul. Omnima autem attribum 
+            <lb ed="#V" n="127"/>et faciendorum: quia communius accipiuntur idee secundum quod dicunt 
+            ratio<lb ed="#V" n="128" break="no"/>nes cognoscitiuas: et operatiuas simul. Omnia autem attribu 
             <lb ed="#V" n="129"/>ta sunt perfectiones: sed non econuerso. Attributa enim sunt 
             <lb ed="#V" n="130"/>superexcellentie perfectionum substantiam creature circumstantium: 
             <lb ed="#V" n="131"/>quarum quanlibet melius est simpliciter habere per modum 
@@ -958,7 +958,7 @@
             <lb ed="#V" n="22"/>sectionum sunt idee que non sunt attributa: sicut 
             superex<lb ed="#V" n="23" break="no"/>cellentia perfectionis asinine et leonine sunt idee: et non 
             <lb ed="#V" n="24"/>attributa. Ille est superexcellentie perfectionum quae sunt 
-            attribu<lb ed="#V" n="25" break="no"/>ta sub alia ratione sunt idee: et sub alia ratione scut attributa. Sunt 
+            attribu<lb ed="#V" n="25" break="no"/>ta sub alia ratione sunt idee: et sub alia ratione sunt attributa. Sunt 
             <lb ed="#V" n="26"/>enm idee inquantum sunt deo rationes cognoscendi et operandi. 
             <lb ed="#V" n="27"/>Sunt autem attributa inquantum attribuuntur diuine 
             substan<lb ed="#V" n="28" break="no"/>tie tanquam de ipsa predicabilia.


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve07v1_kzz7yh-a75392.xml`.

## Applied changes

- p. 110v l. 74: dinus → diuinus: missing ui
- p. 110v l. 81: indea → idea: extra in (or line-start fragment of "in idea")
- p. 110v l. 98: dinus → diuinus: missing ui
- p. 110v l. 116: aliquomon → aliquomodo: missing do
- p. 110v l. 123: Tertiomon → Tertio modo: garbled abbreviation + missing space
- p. 110v l. 129: secundomon → secundo modo: garbled abbreviation + missing space
- p. 111r l. 18: ereaturam → creaturam: e/c misread
- p. 111r l. 41: duinia → diuina: ui transposition
- p. 111r l. 44: cognitea → cognita: extra e
- p. 111r l. 57: quodammode → quodammodo: e/o misread
- p. 111r l. 61: Quaestido → Quaestio: extra d
- p. 111r l. 88: huismodi → huiusmodi: missing u
- p. 111r l. 102: ereatus → creatus: e/c misread
- p. 111r l. 109: ralatio → relatio: a/e misread
- p. 111r l. 116: etetno → aeterno: garbled
- p. 111r l. 117: secndum → secundum: missing u
- p. 111r l. 121: requrit → requirit: missing i
- p. 111v l. 3: mltorum → multorum: missing u
- p. 111v l. 38: indiduo → indiuiduo: missing ui
- p. 111v l. 40: eplaad → epistola ad: epla = abbreviated epistola, missing space
- p. 111v l. 41: epsturarum → epistolarum: garbled
- p. 111v l. 74: istorumnon → istorum non: missing space
- p. 111v l. 77: Poato → Plato: o/l misread
- p. 111v l. 117: praeoritatis → prioritatis: ae/i misread
- p. 111v l. 133: 'ratio' + 'nem' split across line break without break="no" on lb n=133
- p. 112r l. 31: persectionem → perfectionem: s/f misread
- p. 112r l. 56: primomo → primo modo: missing space + garbled
- p. 112r l. 99: omens → omnes: missing n
- p. 112r l. 103: permxto → permixto: missing i
- p. 112r l. 105: arguntis → argumentis: missing me
- p. 112r l. 108: cuis → cuius: missing u
- p. 112r l. 110: 'perfectio' + 'num' split across line break without break="no" on lb n=110
- p. 112v l. 1: inquamtum → inquantum: m/n misread
- p. 112v l. 16: persectiones → perfectiones: s/f misread
- p. 112v l. 17: nihit → nihil: t/l misread
- p. 112v l. 23: petfectionis → perfectionis: t/r transposition
- p. 112v l. 26: cogoscendi → cognoscendi: missing n

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_