### PR TITLE
Transcription corrections: cod-ve07v1_kzz7yh-a77062.xml (2 changes)

### DIFF
--- a/kzz7yh-a77062/cod-ve07v1_kzz7yh-a77062.xml
+++ b/kzz7yh-a77062/cod-ve07v1_kzz7yh-a77062.xml
@@ -74,12 +74,12 @@
           <lb ed="#V" n="47"/>vim etc). Uerum est quantum ad rem: quam significant 
           <lb ed="#V" n="48"/>ex ipso dicit principium primum per ipsum principium 
           suffi<lb ed="#V" n="49" break="no"/>cientissimum: in ipso dicit principium infinitissimum: et hec 
-          <lb ed="#V" n="50"/>in deo vnde sunt: et secundum hoc loqutur Ambro. Sed si 
+          <lb ed="#V" n="50"/>in deo vnde sunt: et secundum hoc loquitur Ambro. Sed si 
           loqua<lb ed="#V" n="51" break="no"/>mur quantum ad ordinem quem connotant propositiones secundum 
           diuer<lb ed="#V" n="52" break="no"/>sas habitudines sic sunt appropriata tribus personis: ex ipso 
           <lb ed="#V" n="53"/>dicit rationem principii primi: vnde primi appropriatur per ipsum dicit 
-          <lb ed="#V" n="54"/>rationem medii: vnde filio appropriatur per ipsum dicit ratio 
-          <lb ed="#V" n="55"/>nem vltimi: ideo spiritui sancto appropriatur. (In ipso 
+          <lb ed="#V" n="54"/>nem medii: vnde filio appropriatur per ipsum dicit ratio 
+          ratio<lb ed="#V" n="55" break="no"/>nem vltimi: ideo spiritui sancto appropriatur. (In ipso 
           <lb ed="#V" n="56"/>viuimus mouemur et sumus) scilicet sicut in causa efficienter 
           <lb ed="#V" n="57"/>et conseruante et exemplari et finali: et quia divina immensitas 
           om<lb ed="#V" n="58" break="no"/>nem creaturam intra se concludit loquendo per quandam 


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve07v1_kzz7yh-a77062.xml`.

## Applied changes

- p. 112v l. 50: loqutur → loquitur: missing i
- p. 112v l. 55: 'ratio' + 'nem' split across line break without break="no" on lb n=55

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_