### PR TITLE
Transcription corrections: cod-ve07v1_kzz7yh-a77141.xml (2 changes)

### DIFF
--- a/kzz7yh-a77141/cod-ve07v1_kzz7yh-a77141.xml
+++ b/kzz7yh-a77141/cod-ve07v1_kzz7yh-a77141.xml
@@ -593,7 +593,7 @@
           <lb ed="#V" n="54"/>Quidam tamen.
         </p>
         <p xml:id="kzz7yh-a77141-d1e1190">
-          ¶ Tertio mouet et solouit dubitationem 
+          ¶ Tertio mouet et <sic>solouit</sic> dubitationem 
           <lb ed="#V" n="55"/>super hoc incidentem: ibi. Solet etiam. Tunc sequitur illa 
           <lb ed="#V" n="56"/>pars que ibi incipit. Continet divina natura: in qua 
           remo<lb ed="#V" n="57" break="no"/>uet modos quibus deus non est in rebus et diditur in partes 

--- a/kzz7yh-a77141/cod-ve07v1_kzz7yh-a77141.xml
+++ b/kzz7yh-a77141/cod-ve07v1_kzz7yh-a77141.xml
@@ -605,10 +605,10 @@
         </p>
         <p xml:id="kzz7yh-a77141-d1e1206">
           ¶ 2o 
-          <lb ed="#V" n="60"/>huius veritatis ponit repetitionem: et confirmationem. ibi. Fatea <!--this should go with the "-mur" in the following line--> 
+          <lb ed="#V" n="60"/>huius veritatis ponit repetitionem: et confirmationem. ibi. Fatea
           <!--00242.xml-->
           <cb ed="#P" n="b"/>
-          <lb ed="#V" n="61"/>mur itaque.
+          <lb ed="#V" n="61" break="no"/>mur itaque.
         </p>
         <p xml:id="kzz7yh-a77141-d1e1217">
           ¶ Primus in tres.

--- a/kzz7yh-a77141/cod-ve07v1_kzz7yh-a77141.xml
+++ b/kzz7yh-a77141/cod-ve07v1_kzz7yh-a77141.xml
@@ -575,8 +575,8 @@
           Scien<lb ed="#V" n="47" break="no"/>dum est etiam.
         </p>
         <p xml:id="kzz7yh-a77141-d1e1163">
-          ¶ Quarto ostendit quod non tantum hitat in 
-          san<lb ed="#V" n="48" break="no"/>ctis adultis: sed etiam in peruulis regeneratis: et illud quoque 
+          ¶ Quarto ostendit quod non tantum habitat in 
+          san<lb ed="#V" n="48" break="no"/>ctis adultis: sed etiam in paruulis regeneratis: et illud quoque 
           <lb ed="#V" n="49"/>mirabile est.
         </p>
         <p xml:id="kzz7yh-a77141-d1e1170">


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve07v1_kzz7yh-a77141.xml`.

## Applied changes

- p. 114v l. 47: hitat → habitat: missing ab (hi→habi pattern)
- p. 114v l. 48: peruulis → paruulis: e/a misread

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_