### PR TITLE
Transcription corrections: cod-ve07v1_kzz7yh-a78315.xml (9 changes)

### DIFF
--- a/kzz7yh-a78315/cod-ve07v1_kzz7yh-a78315.xml
+++ b/kzz7yh-a78315/cod-ve07v1_kzz7yh-a78315.xml
@@ -123,7 +123,7 @@
             positi<lb ed="#V" n="104" break="no"/>ua: vt inferius ostendetur: et quia in infinitate est summa simplicitas in 
             <lb ed="#V" n="105"/>ea: ideo ita est divina essentia in omnibus rebus quod in qualet earum est tota: hoc 
             <lb ed="#V" n="106"/>est concludit omnium creaturarum emanatio imediate a deo quamuis 
-            <lb ed="#V" n="107"/>quedam emanent ab ipso immediate tantum. Quedam autem immed iate 
+            <lb ed="#V" n="107"/>quedam emanent ab ipso immediate tantum. Quedam autem immediate 
             <lb ed="#V" n="108"/>et cum hoc mediante causa secunda. Cum enim in deo idem sit essentia et potentia 
             <lb ed="#V" n="109"/>nihil attingit eius potentia quod non attingat eius essentia. 
           </p>
@@ -136,14 +136,14 @@
           </p>
           <p xml:id="kzz7yh-a78315-d1e232">
             <lb ed="#V" n="115"/>¶ Quod etiam sit in omnibus rebus per potentiam patet ex eius 
-            omnipo<lb ed="#V" n="116" break="no"/>tentia. Inferius enim ostendetur quod deus est omnipotens. Hhoc 
+            omnipo<lb ed="#V" n="116" break="no"/>tentia. Inferius enim ostendetur quod deus est omnipotens. Hoc 
             <lb ed="#V" n="117"/>etiam ostendit creaturarum debilitas in essendo que semper eget 
             <lb ed="#V" n="118"/>manuteneri per divinam potentiam quamdiu est: vnde Augustinus. 4uod 
             <lb ed="#V" n="119"/>super genesim longe ante medium loquens de dei virtute 
             di<lb ed="#V" n="120" break="no"/>cit. Que virtus ab eis que creata sunt regendis: si 
             aliquan<lb ed="#V" n="121" break="no"/>do cessaret simul et illorum cessaret species: omnisque 
             creatu<lb ed="#V" n="122" break="no"/>ra concideret. Dicit enim Aui. 6. Metaphy. sue. c. i. Quod 
-            crea<lb ed="#V" n="123" break="no"/>tum eget datore sui esse semper et incessanter quamdiu humerit 
+            crea<lb ed="#V" n="123" break="no"/>tum eget datore sui esse semper et incessanter quamdiu habuerit 
             <lb ed="#V" n="124"/>esfe. Sic ergo patet quod deus est in ominibus rebus per essentiam 
             <lb ed="#V" n="125"/>in quo excluditur error illorum qui dicebant divinam essentiam 
             <lb ed="#V" n="126"/>limitatam: nec omnibus creaturis immediatam essendi causam esse. 
@@ -180,7 +180,7 @@
             il<lb ed="#V" n="16" break="no"/>lam manutenentiam qui creature manutenentur a deo. Ex praedictis 
             <lb ed="#V" n="17"/>patet quod deus est in omni loco per essentiam: praesentiam et potentiam: sicut et 
             <lb ed="#V" n="18"/>in aliis rebus: et quod a nullo loco circunscribitur nec diffinitur: et quod 
-            <lb ed="#V" n="19"/>non debet dici localis: et ideo de istis non opetet facem quaestines.
+            <lb ed="#V" n="19"/>non debet dici localis: et ideo de istis non oportet facem quaestines.
           </p>
         </div>
         <div xml:id="kzz7yh-a78315-Dd1e325">
@@ -192,7 +192,7 @@
             equa<lb ed="#V" n="21" break="no"/>liter: et videtur quod sic. Dicitur enim. <ref xml:id="kzz7yh-a78315-Rd1e358">24 
               <lb ed="#V" n="22"/>propositione de causis</ref> quod causa prima existit in rebus 
             om<lb ed="#V" n="23" break="no"/>nibus secundum dispositionem vnam. Sed omnes res non existunt 
-            <lb ed="#V" n="24"/>in causa prima secundum dispositionem vnamm: ergo non obstante quod 
+            <lb ed="#V" n="24"/>in causa prima secundum dispositionem vnam: ergo non obstante quod 
             <lb ed="#V" n="25"/>creature se habent ad deum inequaliter: videtur quod deus sit in 
             omni<lb ed="#V" n="26" break="no"/>bus creaturis equaliter.
           </p>
@@ -303,7 +303,7 @@
             fa<lb ed="#V" n="85" break="no"/>cta aliqua positione de loci peruitate: et sic anima esset vbique si non 
             <lb ed="#V" n="86"/>esset aliud corpus: nisi illud corpus cnius ipsa est perfectio. ex 
             consen<lb ed="#V" n="87" break="no"/>ti autem vbique est: quod est vbique ratione suarum pertium: et sic vniversale 
-            <lb ed="#V" n="88"/>est vbique ratione suorum singituiarium: et materia rone suarum partium 
+            <lb ed="#V" n="88"/>est vbique ratione suorum singularium: et materia ratione suarum partium 
             <lb ed="#V" n="89"/>Et similiter dico de ente creato sub quo etiam comprehenditur materia 
             <lb ed="#V" n="90"/>ipsa et enim creata est.
           </p>
@@ -318,7 +318,7 @@
             <lb ed="#V" n="94"/>fuit ab eterno vt supra visum est: quia deum esse dominum connotat 
             <lb ed="#V" n="95"/>seruitutem in creatura: ita dico quod deus non fuit vbique ab 
             eter<lb ed="#V" n="96" break="no"/>no: quia quanuis deum esse vbique imponat in deo aliquam 
-            relatio<lb ed="#V" n="97" break="no"/>nem realem ad loca: tamen connotat realem ralationem et actualem 
+            relatio<lb ed="#V" n="97" break="no"/>nem realem ad loca: tamen connotat realem relationem et actualem 
             <lb ed="#V" n="98"/>omnium locorum ad deum. Ab eterno autem nullus fuit locnus. 
             Ar<lb ed="#V" n="99" break="no"/>autem ad partem aliam concludunt conuenire soli deo esse vbique per 
             se<lb ed="#V" n="100" break="no"/>et primo: et hoc est verum.
@@ -332,7 +332,7 @@
             <lb ed="#V" n="101"/>QUarto queritur vtrum deus sit extra omnem 
             lo<lb ed="#V" n="102" break="no"/>cum et videtur quod sic: quia ille est extra 
             <lb ed="#V" n="103"/>omnem locum: quem omnia loca non capiunt. Sed ad 
-            ho<lb ed="#V" n="104" break="no"/>norem beate virginis dicit ecclestia: Uirgo dei 
+            ho<lb ed="#V" n="104" break="no"/>norem beate virginis dicit ecclesia: Uirgo dei 
             ge<lb ed="#V" n="105" break="no"/>nitrix quem totus non capit orbis in tua se clausit viscera 
             fa<lb ed="#V" n="106" break="no"/>ctus homo: ergo deus est extra omnem locum.
           </p>
@@ -371,7 +371,7 @@
             <lb ed="#V" n="127"/>loco: et <ref xml:id="kzz7yh-a78315-Rd1e692">Greg. x. libro moralium longe ante finem</ref> dicit. Quia 
             <lb ed="#V" n="128"/>agnita est omnis creatura creatori: et hoc patet: quia si de nouo 
             cre<lb ed="#V" n="129" break="no"/>aretur alius mundus: et deus esset in illo mundo: sic in isto: 
-            <lb ed="#V" n="130"/>et constat quod non esset per sui transtationem de isto mundo ad alium 
+            <lb ed="#V" n="130"/>et constat quod non esset per sui translationem de isto mundo ad alium 
             mun<lb ed="#V" n="131" break="no"/>dum cum penitus sit immutabilis: sed hoc esset ratione sue immensitatis 
             <lb ed="#V" n="132"/>que in infinitum capacitatem mundi huius excedit.
           </p>

--- a/kzz7yh-a78315/cod-ve07v1_kzz7yh-a78315.xml
+++ b/kzz7yh-a78315/cod-ve07v1_kzz7yh-a78315.xml
@@ -156,7 +156,7 @@
             <lb ed="#V" n="2"/>ostenditur esse in omnibus rebus per potentiam excluditur error 
             <lb ed="#V" n="3"/>manicheorum qui spiritualia et incorporalia tantum dicunt esse subiecta 
             <lb ed="#V" n="4"/>diuine potestati. visibilia vero et corruptibilia non: sed 
-            pote<lb ed="#V" n="5" break="no"/>stati principii conttarii.
+            pote<lb ed="#V" n="5" break="no"/>stati principii <sic>conttarii.</sic>
           </p>
           <p xml:id="kzz7yh-a78315-d1e283">
             <lb ed="#V" n="6"/>Ad primum in oppositum quod arguebatur per auctorem <ref xml:id="kzz7yh-a78315-Rd1e303">Ansel.</ref> 
@@ -242,7 +242,7 @@
             <lb ed="#V" n="55"/>per essentiam: praesentiam et potentiam.
           </p>
           <p xml:id="kzz7yh-a78315-d1e426">
-            ¶ Argumentad partem aliam procedunt secundum 
+            ¶ Argumenta partem aliam procedunt secundum 
             <lb ed="#V" n="56"/>iltum modum quo dicitur esse in rebus per influentiam.
           </p>
         </div>
@@ -298,11 +298,11 @@
             <lb ed="#V" n="80"/>quia ergo solus deus facta quacumque positione de magnitudine 
             <lb ed="#V" n="81"/>spatii est si poneretur spatium infinitum esset vbique secundum se totum 
             <lb ed="#V" n="82"/>ideo proprium est solius dei esse vbique per se: et primo. Per accidens 
-            <lb ed="#V" n="83"/>autem et ex conseqenti esse vbique competem posset creature. Per 
+            <lb ed="#V" n="83"/>autem et ex conseqenti esse vbique competere posset creature. Per 
             acci<lb ed="#V" n="84" break="no"/>dens enim esset vbique illud cui hoc competere non potest nisi 
             fa<lb ed="#V" n="85" break="no"/>cta aliqua positione de loci peruitate: et sic anima esset vbique si non 
             <lb ed="#V" n="86"/>esset aliud corpus: nisi illud corpus cnius ipsa est perfectio. ex 
-            consen<lb ed="#V" n="87" break="no"/>ti autem vbique est: quod est vbique ratione suarum pertium: et sic vniversale 
+            consen<lb ed="#V" n="87" break="no"/>ti autem vbique est: quod est vbique ratione suarum partium: et sic vniversale 
             <lb ed="#V" n="88"/>est vbique ratione suorum singularium: et materia ratione suarum partium 
             <lb ed="#V" n="89"/>Et similiter dico de ente creato sub quo etiam comprehenditur materia 
             <lb ed="#V" n="90"/>ipsa et enim creata est.
@@ -376,11 +376,11 @@
             <lb ed="#V" n="132"/>que in infinitum capacitatem mundi huius excedit.
           </p>
           <p xml:id="kzz7yh-a78315-d1e654">
-            ¶ Aalioo potest 
+            ¶ Aalio potest 
             <lb ed="#V" n="133"/>intelligi deum esse extra mundum: ita quod sit dare spatium extra mundum: 
             <lb ed="#V" n="134"/>in quod sit deus et sic suum est. hoc enim ponere esset confirmare opinionem 
             <lb ed="#V" n="135"/>illorum quae opiniabantur vltra vltium caelum esse spatium infinitum quae opinio 
-            <lb ed="#V" n="136"/>ffa est. Ex dicinis patet pro maiori parte rastenus ad argumentad vtramque partem. 
+            <lb ed="#V" n="136"/>ffa est. Ex dictis patet pro maiori parte rastenus ad argumentad vtramque partem. 
             <!--00244.xml-->
             <pb ed="#V" n="115-v"/>
             <cb ed="#P" n="a"/>

--- a/kzz7yh-a78315/cod-ve07v1_kzz7yh-a78315.xml
+++ b/kzz7yh-a78315/cod-ve07v1_kzz7yh-a78315.xml
@@ -242,7 +242,7 @@
             <lb ed="#V" n="55"/>per essentiam: praesentiam et potentiam.
           </p>
           <p xml:id="kzz7yh-a78315-d1e426">
-            ¶ Argumenta partem aliam procedunt secundum 
+            ¶ Argumenta ad partem aliam procedunt secundum 
             <lb ed="#V" n="56"/>iltum modum quo dicitur esse in rebus per influentiam.
           </p>
         </div>
@@ -376,7 +376,7 @@
             <lb ed="#V" n="132"/>que in infinitum capacitatem mundi huius excedit.
           </p>
           <p xml:id="kzz7yh-a78315-d1e654">
-            ¶ Aalio potest 
+            ¶ Alio modo potest 
             <lb ed="#V" n="133"/>intelligi deum esse extra mundum: ita quod sit dare spatium extra mundum: 
             <lb ed="#V" n="134"/>in quod sit deus et sic suum est. hoc enim ponere esset confirmare opinionem 
             <lb ed="#V" n="135"/>illorum quae opiniabantur vltra vltium caelum esse spatium infinitum quae opinio 


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve07v1_kzz7yh-a78315.xml`.

## Applied changes

- p. 115r l. 19: opetet → oportet: missing or
- p. 114v l. 107: immed iate → immediate: spurious space within word
- p. 114v l. 116: Hhoc → Hoc: doubled capital H — transcription error
- p. 114v l. 123: humerit → habuerit: hu- misread for hab-
- p. 115r l. 24: vnamm → vnam: doubled final m — transcription error
- p. 115r l. 88: singituiarium → singularium: garbled interior — transcription error; rone → ratione: missing letters — transcription error
- p. 115r l. 97: ralationem → relationem: a/e misread — transcription error
- p. 115r l. 104: ecclestia → ecclesia: spurious t insertion — transcription error
- p. 115r l. 130: transtationem → translationem: t/l transposition — transcription error

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_