### PR TITLE
Transcription corrections: cod-ve07v1_kzz7yh-a78920.xml (34 changes)

### DIFF
--- a/kzz7yh-a78920/cod-ve07v1_kzz7yh-a78920.xml
+++ b/kzz7yh-a78920/cod-ve07v1_kzz7yh-a78920.xml
@@ -175,20 +175,20 @@
             <lb ed="#V" n="69"/>fuit: quia omne quod est in loco applicatur ad locum aut per 
             commensuratio<lb ed="#V" n="70" break="no"/>nem et sic corpus est in loco aut per informationem corporis 
             existen<lb ed="#V" n="71" break="no"/>tis in loco: et sic anima est in loco dum actu informat corpus 
-            <lb ed="#V" n="72"/>aut per hoc quod est termius rei habentis positionem in loco: et sic 
-            <lb ed="#V" n="73"/>punctus est loco. Angitulus autem non commensuratur corpori nec 
-            <lb ed="#V" n="74"/>est forma corporis: nec termius corporis: ergo nulla est ratio 
+            <lb ed="#V" n="72"/>aut per hoc quod est terminus rei habentis positionem in loco: et sic 
+            <lb ed="#V" n="73"/>punctus est loco. Angelus autem non commensuratur corpori nec 
+            <lb ed="#V" n="74"/>est forma corporis: nec terminus corporis: ergo nulla est ratio 
             <lb ed="#V" n="75"/>sue applicationis ad locum nisi operatio. 
           </p>
           <p xml:id="kzz7yh-a78920-d1e307">
-            <lb ed="#V" n="76"/>Sed contra hanc opionem est auctoritas: et ratio 
+            <lb ed="#V" n="76"/>Sed contra hanc opinionem est auctoritas: et ratio 
             <lb ed="#V" n="77"/>dicit enim <ref xml:id="kzz7yh-a78920-Rd1e339">Strabus in glosa genese primo</ref> 
             <lb ed="#V" n="78"/>Quia caelum empyreum statim angeli repletum esti. et constat quod 
             <lb ed="#V" n="79"/>non intelligit hoc fuisse per aliquam operationem illorum: quam 
             sta<lb ed="#V" n="80" break="no"/>tim haberet circa locum illum.
           </p>
           <p xml:id="kzz7yh-a78920-d1e320">
-            ¶ Item <ref xml:id="kzz7yh-a78920-Rd1e351">Hugo. i. de sacramenis parte 
+            ¶ Item <ref xml:id="kzz7yh-a78920-Rd1e351">Hugo. i. de sacramentis parte 
               <lb ed="#V" n="81"/>3. c. 13.</ref> illam opinionem expresse videtur redarguere dicens 
             <lb ed="#V" n="82"/>sic: non ignoro quosdam ab omni spiritu locum vniversaiter remouere 
             vo<lb ed="#V" n="83" break="no"/>luisse: quoniam secundum dimensionem solum: et citcunscriptionem 
@@ -215,17 +215,17 @@
             <lb ed="#V" n="96"/>prius ordine nature angelus applicatur ad corpus quam 
             ali<lb ed="#V" n="97" break="no"/>quam operationem corporalem faciat in corpore. Si autem illa 
             <lb ed="#V" n="98"/>virtus non est in angelo: vt in radice: sed in ipso corpore 
-            <lb ed="#V" n="99"/>opoertet eam esse creatam a virtute que est in angelo: vt in 
+            <lb ed="#V" n="99"/>oportet eam esse creatam a virtute que est in angelo: vt in 
             ra<lb ed="#V" n="100" break="no"/>dice: et sic cum ratio illius virtutis sit aliqua operatio prius 
             <lb ed="#V" n="101"/>ordine nature virtus: que est in angelo vt in radice 
             appli<lb ed="#V" n="102" break="no"/>catur illi corpori quam causet illam aliam virtutem in ipso 
-            cor<lb ed="#V" n="103" break="no"/>pore: cumergo angelus praesenus sit vbi est praesens virtus existens 
+            cor<lb ed="#V" n="103" break="no"/>pore: cum ergo angelus praesenus sit vbi est praesens virtus existens 
             <lb ed="#V" n="104"/>in ipso: sequitur quod prius ordine nature angelus praesens est 
             cor<lb ed="#V" n="105" break="no"/>pus quam aliquam operationem causet in corpore. 
             <!--insert para break here-->
-            <lb ed="#V" n="106"/>Ideo mihi viletur dicendum quod angelus praeter
+            <lb ed="#V" n="106"/>Ideo mihi videtur dicendum quod angelus praeter
             om<lb ed="#V" n="107" break="no"/>nem operationem quam hebeat circa locum est 
-            <lb ed="#V" n="108"/>in loco non circumsriptiue cum non sit res corporalis: sed 
+            <lb ed="#V" n="108"/>in loco non circumscriptiue cum non sit res corporalis: sed 
             diffini<lb ed="#V" n="109" break="no"/>tiue est praesens alicui loco determinato: et si queratur ratio sue 
             <lb ed="#V" n="110"/>applicationis ad locum: dico quod ratio applicationem efficiens est 
             vo<lb ed="#V" n="111" break="no"/>luntas angeli imperans: et sua potentia exequens: vel potentia 
@@ -233,15 +233,15 @@
             <lb ed="#V" n="113"/>maior vniuersi vnitas. Uel quia quandoque aliquid angelus 
             inten<lb ed="#V" n="114" break="no"/>dit operari circa locum. Ratio autem formalis illius 
             applicatio<lb ed="#V" n="115" break="no"/>nis non est circunscriptio a loco: quia nihil potest loco 
-            circunscribi<lb ed="#V" n="116" break="no"/>nisi quod est dimensionatum: nec inforatio corporis existentis in 
+            circunscribi<lb ed="#V" n="116" break="no"/>nisi quod est dimensionatum: nec informatio corporis existentis in 
             loco<lb ed="#V" n="117" break="no"/>quia angelus nullius est corporis forma: nec terminatio 
-            magni<lb ed="#V" n="118" break="no"/>tudinis existentis in loco: quia angelus nullius magnitudis 
+            magni<lb ed="#V" n="118" break="no"/>tudinis existentis in loco: quia angelus nullius magnitudinis 
             ter<lb ed="#V" n="119" break="no"/>minus est: nec operatio circa locum potest esse praecisa ratio huius 
             ap<lb ed="#V" n="120" break="no"/>plicationis: vt superius probatum est: nec ordo vniuersi: quia si 
             <lb ed="#V" n="121"/>ordo vniuersi sit ratio huius applicationis non est ratio formalis 
-            <lb ed="#V" n="122"/>huius applicationis: sed finalis: dico ergo quod foralis ratio 
+            <lb ed="#V" n="122"/>huius applicationis: sed finalis: dico ergo quod formalis ratio 
             applica<lb ed="#V" n="123" break="no"/>tionis angeli ad locum est sua simultas cum loco vel cum re in 
-            <lb ed="#V" n="124"/>loco existente. Unde sicut fornalis ratio applicationis corporis ad 
+            <lb ed="#V" n="124"/>loco existente. Unde sicut formalis ratio applicationis corporis ad 
             lo<lb ed="#V" n="125" break="no"/>cum est circunscriptio: sic foralis applicatio angeli ad locumem 
             <lb ed="#V" n="126"/>similtas sua cum loco lecum re existente in loco.
           </p>
@@ -272,7 +272,7 @@
             <cb ed="#P" n="a"/>
             <lb ed="#V" n="1"/>Dicunt enim quod eo ipso quod angelus et ista corporalis 
             machina<lb ed="#V" n="2" break="no"/>sunt ab vno printia scilicet a deo oportet angelum esse applicatum alicui 
-            <lb ed="#V" n="3"/>perti huius machine: non tamen alicui determinate.
+            <lb ed="#V" n="3"/>parti huius machine: non tamen alicui determinate.
           </p>
           <p xml:id="kzz7yh-a78920-d1e480">
             ¶ Alii autem 
@@ -304,7 +304,7 @@
             ¶ Argumenta 
             <lb ed="#V" n="22"/>ad partem secundam gratia conclusionis concedenda sunt: vltimum 
             <lb ed="#V" n="23"/>tamen non cognoscit ratione forme: sicut nec istud prius est esse moueri 
-            <lb ed="#V" n="24"/>ergo primo est esse in tempore quam mouere intempore: quae consena nulla est: quia res per suum 
+            <lb ed="#V" n="24"/>ergo primo est esse in tempore quam mouere in tempore: quae consena nulla est: quia res per suum 
             <lb ed="#V" n="25"/>moueri est in tempore secundum philosophum. 40. physi.
           </p>
         </div>
@@ -313,7 +313,7 @@
           <head xml:id="kzz7yh-a78920-Hd1e579" type="question-title">Utrum angelus sit in spatio</head>
           <p xml:id="kzz7yh-a78920-d1e544">
             ¶ Quaestio II. 
-            <lb ed="#V" n="26"/>SEcundo queritur vtrum angustolus sit in spatio: vel in 
+            <lb ed="#V" n="26"/>SEcundo queritur vtrum angelus sit in spatio: vel in 
             <lb ed="#V" n="27"/>aliquo impertibili ipsius spatii sicut in 
             <lb ed="#V" n="28"/>puncto: et ostendo quod non sit in spatio. <ref xml:id="kzz7yh-a78920-Rd1e590">Philosophus i. de anima</ref> 
             <lb ed="#V" n="29"/>Quorum locus est indibilis: et ipsa sunt indiuisibilia 
@@ -327,7 +327,7 @@
             <lb ed="#V" n="34"/>diuisibili.
           </p>
           <p xml:id="kzz7yh-a78920-d1e569">
-            ¶ Item cum angtuolnus sit indiuisibilis probabilius videtur quod sit in 
+            ¶ Item cum angelus sit indiuisibilis probabilius videtur quod sit in 
             <lb ed="#V" n="35"/>puncto quod est indisibile: quam in spatio. Sed non potest esse in 
             prun<lb ed="#V" n="36" break="no"/>cto: quia nec anima in puncto corporis est: ergo multominus potest esse 
             <lb ed="#V" n="37"/>in spatio.
@@ -355,13 +355,13 @@
             <lb ed="#V" n="49"/>ita tamen quod illius spatii cuius cuilibet parti 
             <lb ed="#V" n="50"/>simul potest esse proesens: est dare terminum in maius: non tamen in 
             <lb ed="#V" n="51"/>minus: et cum angelus non sit dimensionatus non est ita proaesens 
-            <lb ed="#V" n="52"/>spatio quod vna pars angelilsit praesens et vni pearti spatii: et alia 
+            <lb ed="#V" n="52"/>spatio quod vna pars angeli sit praesens et vni parti spatii: et alia 
             <lb ed="#V" n="53"/>pars angeli sit praesenus alii parti spatii. Unde nec 
             commensura<lb ed="#V" n="54" break="no"/>tur spatio: nec conscribitur spatio: sed ita proaesenus est spatio toti quod 
             <lb ed="#V" n="55"/>totus praesenus est cuilibet parti ipsius spatii. 
           </p>
           <p xml:id="kzz7yh-a78920-d1e628">
-            <lb ed="#V" n="56"/>Ad cuius intelligentam debes scire quod est considerare 
+            <lb ed="#V" n="56"/>Ad cuius intelligentiam debes scire quod est considerare 
             <lb ed="#V" n="57"/>quadruplicem simplicitatem scilicet simplicitatem 
             <lb ed="#V" n="58"/>negatiuam magnitudinis: sicut est simplicitas puncti: qui nec 
             <lb ed="#V" n="59"/>est extensus: nec natus extendi. Et simplicitatem 
@@ -381,7 +381,7 @@
             <cb ed="#P" n="b"/>
             <lb ed="#V" n="69"/>nite tamen: quam dicere possumus aliquam longinquam. d 
             <lb ed="#V" n="70"/>debilem diuine immensitatis imitationem. Ideo ratio 
-            <lb ed="#V" n="71"/>ne huius positiue spiritualis magnititudinis ita potest esse proesens 
+            <lb ed="#V" n="71"/>ne huius positiue spiritualis magnitudinis ita potest esse proesens 
             <lb ed="#V" n="72"/>alicui spatio toti simul: quod tamen propter simplicitatem erit in 
             <lb ed="#V" n="73"/>qualibet parte totius
           </p>
@@ -396,7 +396,7 @@
           </p>
           <p xml:id="kzz7yh-a78920-d1e696">
             ¶ Ad 3m dicendum quod argumentum 
-            transcen<lb ed="#V" n="81" break="no"/>dens est: si enim valeret argumentum iequeretur angelum nusquam 
+            transcen<lb ed="#V" n="81" break="no"/>dens est: si enim valeret argumentum sequeretur angelum nusquam 
             <lb ed="#V" n="82"/>esse: quia si est alicubi: oportet quod sit in diuisibili: vel in 
             indisibi<lb ed="#V" n="83" break="no"/>libro Dicunt ergo aliqui quod non est in indiuisibili: quia indiuisibile 
             <lb ed="#V" n="84"/>non est locus. Unde cum dicitur quod probabilius videtur quod indisi 
@@ -409,7 +409,7 @@
             obstan<lb ed="#V" n="88" break="no"/>te quod punctus non sit locus: angelus potest esse in puncto propter 
             <lb ed="#V" n="89"/>simplicitatem eius: quanuis enim non sit nusquam: non tamen 
             <lb ed="#V" n="90"/>oportet quod sequatur legem loci: nec potest dici quod ad existendum in puncto 
-            <lb ed="#V" n="91"/>requiratur summa simplicitas: quia nec puctus summe simplex est Quod 
+            <lb ed="#V" n="91"/>requiratur summa simplicitas: quia nec punctus summe simplex est Quod 
             <lb ed="#V" n="92"/>aut dicebas animam non esse in corporis puncto: dico quod non est 
             simi<lb ed="#V" n="93" break="no"/>le: quia anima est in corpore: sicut est forma: sed punctus non 
             <lb ed="#V" n="94"/>est corpus: nec corporis pars: et ideo non sic potest dici esse in 
@@ -418,7 +418,7 @@
           </p>
           <p xml:id="kzz7yh-a78920-d1e736">
             ¶ Ad 4m 
-            <lb ed="#V" n="97"/>dicendum quod Dama. dicit angelulium esse in loco intelligibiliter ad 
+            <lb ed="#V" n="97"/>dicendum quod Dama. dicit angelum esse in loco intelligibiliter ad 
             osten<lb ed="#V" n="98" break="no"/>dendum quod non est in loco circunscriptibiliter. Et quia quamuis 
             spa<lb ed="#V" n="99" break="no"/>tium in quo est angelus sit imaginabile: ipsum tamen angelum essei eo 
             <lb ed="#V" n="100"/>et modus quo existit in eo non apprehenditur imagine: sed ratione.
@@ -450,9 +450,9 @@
           <p xml:id="kzz7yh-a78920-d1e788">
             ¶ Item <ref xml:id="kzz7yh-a78920-Rd1e843">Augu. 18 libo de ciui. dei. c. 19.</ref> vult quod 
             ho<lb ed="#V" n="114" break="no"/>mine dorminiente: et viuo remanente phantasticum eius 
-            ve<lb ed="#V" n="115" break="no"/>luti communicatum in alicuius animalis effigie quandoque apporet sensibus alienis 
+            ve<lb ed="#V" n="115" break="no"/>luti communicatum in alicuius animalis effigie quandoque apparet sensibus alienis 
             <lb ed="#V" n="116"/>quod esse non posset nisi illud phantasticum simul esset in corpore 
-            dormi<lb ed="#V" n="117" break="no"/>entis: et praesens sensibus alicuius: cum ergo angtilus minus sit limitatus 
+            dormi<lb ed="#V" n="117" break="no"/>entis: et praesens sensibus alicuius: cum ergo angelus minus sit limitatus 
             <lb ed="#V" n="118"/>quam phantasticum hominis simul esse potest in pluribus locis.
           </p>
           <p xml:id="kzz7yh-a78920-d1e802">
@@ -470,7 +470,7 @@
           </p>
           <p xml:id="kzz7yh-a78920-d1e824">
             ¶ Item <ref xml:id="kzz7yh-a78920-Rd1e886">Dama. li. i. c. 2.</ref> dicit quod angis non pot 
-            <lb ed="#V" n="127"/>secundum idem in diuersis locis operari: sed vbicumque est angltuolus ibi secundum 
+            <lb ed="#V" n="127"/>secundum idem in diuersis locis operari: sed vbicumque est angelus ibi secundum 
             <lb ed="#V" n="128"/>idem operari potest: ergo non potest simul esse in diuersis locis. 
           </p>
           <p xml:id="kzz7yh-a78920-d1e831">
@@ -520,7 +520,7 @@
             ¶ Ad 4m dicendum quod illud quod dicit 
             Au<lb ed="#V" n="23" break="no"/>gu. de phantastico hominis non est intelligendum ita quod 
             reali<lb ed="#V" n="24" break="no"/>ter exeat homine dormiente: sed quia aliquando contingit quod 
-            ho<lb ed="#V" n="25" break="no"/>mo sommniat se esse praesentem alieno conspectui: et dum hoc 
+            ho<lb ed="#V" n="25" break="no"/>mo somniat se esse praesentem alieno conspectui: et dum hoc 
             som<lb ed="#V" n="26" break="no"/>niat aliquis spiritus in specie illius hominis apparet illi: 
             <lb ed="#V" n="27"/>in cuius conspectus ille homo dormiens se somniat esse 
             <lb ed="#V" n="28"/>praesentem.
@@ -570,7 +570,7 @@
             <lb ed="#V" n="50"/>videtur fuisse possibile nisi plures fuissent in eodem loco. 
           </p>
           <p xml:id="kzz7yh-a78920-d1e998">
-            <lb ed="#V" n="51"/>¶ Item duo pruncta manentia distincta possunt simul esse quod 
+            <lb ed="#V" n="51"/>¶ Item duo puncta manentia distincta possunt simul esse quod 
             <lb ed="#V" n="52"/>patet: si aliquid corpus summe sphericum tangeret aliquod 
             cor<lb ed="#V" n="53" break="no"/>pus summe planum: in puncto enim tangeret: et punctus 
             <lb ed="#V" n="54"/>signatus in corpore spherico simul esset cum puncto 
@@ -609,7 +609,7 @@
             an<lb ed="#V" n="75" break="no"/>geli virtute creata in eodem loco proprio non possunt simul esse.
           </p>
           <p xml:id="kzz7yh-a78920-d1e1070">
-            <lb ed="#V" n="76"/>Ad primum in oppostum dicendum secundum aliquos quod 
+            <lb ed="#V" n="76"/>Ad primum in oppositum dicendum secundum aliquos quod 
             cor<lb ed="#V" n="77" break="no"/>pus glorificatum non potest esse cum 
             cor<lb ed="#V" n="78" break="no"/>pore non glorificato virtute creata: sed virtute increata: 
             <lb ed="#V" n="79"/>qua etiam virtute posset spiritus bonus simul esse cum spiritu 
@@ -643,7 +643,7 @@
             <lb ed="#V" n="96"/>malus spiritus aliquando subintret corpus non tamen simul est 
             <lb ed="#V" n="97"/>cum anima: quia malus angelus cum subiectintrat hominem non 
             <lb ed="#V" n="98"/>est presens per substantiam aliquam in parte corporis humani: sed 
-            <lb ed="#V" n="99"/>vel in humoribus: vesl in vacuis ipsius coporis: qui humores 
+            <lb ed="#V" n="99"/>vel in humoribus: vel in vacuis ipsius corporis: qui humores 
             <lb ed="#V" n="100"/>vel que vacuitates ab essentia anime non perficiuntur: et 
             vo<lb ed="#V" n="101" break="no"/>co hic vacuitatem concauittatem non infra quam nihll est: quia 
             <lb ed="#V" n="102"/>non est ponere vacuum: sed infra quam non est nisi aer vel 
@@ -672,15 +672,15 @@
             <lb ed="#V" n="118"/>duo puncta ponantur simul in aliquo tertio puncto. 
           </p>
           <p xml:id="kzz7yh-a78920-d1e1184">
-            <lb ed="#V" n="119"/>¶ Sed quia videtur aliquibus hoc esse talsum eo quod 
+            <lb ed="#V" n="119"/>¶ Sed quia videtur aliquibus hoc esse falsum eo quod 
             si<lb ed="#V" n="120" break="no"/>due linee applicentur super aliquid planum puncta 
             termi<lb ed="#V" n="121" break="no"/>nantia illas lineas concurrent in eodem puncto quem 
-            <lb ed="#V" n="122"/>signabunt in ipso plano. non enim signabunt duo pruncta 
+            <lb ed="#V" n="122"/>signabunt in ipso plano. non enim signabunt duo puncta 
             <lb ed="#V" n="123"/>in plano: vt aliqui imaginati sunt: quia secundum quod probat philosophus. 6 
             <lb ed="#V" n="124"/>physi. In eodem continuo inter duo puncta semper est line 
             <lb ed="#V" n="125"/>ea media. Ideo videtur eis dicendum quod quamuis duo 
-            prun<lb ed="#V" n="126" break="no"/>cta possint esse simul: non tamen ex hoc sequiturquod duo 
-            an<lb ed="#V" n="127" break="no"/>geli possint esse simul: quia purctus est simplex 
+            prun<lb ed="#V" n="126" break="no"/>cta possint esse simul: non tamen ex hoc sequitur quod duo 
+            an<lb ed="#V" n="127" break="no"/>geli possint esse simul: quia punctus est simplex 
             simplicita<lb ed="#V" n="128" break="no"/>te negatiua. Angelus autem simplex est simplicitate spiritualis 
             <lb ed="#V" n="129"/>magnitudinis positiua.
           </p>

--- a/kzz7yh-a78920/cod-ve07v1_kzz7yh-a78920.xml
+++ b/kzz7yh-a78920/cod-ve07v1_kzz7yh-a78920.xml
@@ -191,7 +191,7 @@
             ¶ Item <ref xml:id="kzz7yh-a78920-Rd1e351">Hugo. i. de sacramentis parte 
               <lb ed="#V" n="81"/>3. c. 13.</ref> illam opinionem expresse videtur redarguere dicens 
             <lb ed="#V" n="82"/>sic: non ignoro quosdam ab omni spiritu locum vniversaiter remouere 
-            vo<lb ed="#V" n="83" break="no"/>luisse: quoniam secundum dimensionem solum: et citcunscriptionem 
+            vo<lb ed="#V" n="83" break="no"/>luisse: quoniam secundum dimensionem solum: et <sic>citcunscriptionem</sic> 
             corpora<lb ed="#V" n="84" break="no"/>lem locum constare comprobauerunt. Sed horum: vt 
             supradi<lb ed="#V" n="85" break="no"/>ximus: consideratio minus a communi estimatione et possibilitate 
             <lb ed="#V" n="86"/>recessit.
@@ -242,8 +242,8 @@
             <lb ed="#V" n="122"/>huius applicationis: sed finalis: dico ergo quod formalis ratio 
             applica<lb ed="#V" n="123" break="no"/>tionis angeli ad locum est sua simultas cum loco vel cum re in 
             <lb ed="#V" n="124"/>loco existente. Unde sicut formalis ratio applicationis corporis ad 
-            lo<lb ed="#V" n="125" break="no"/>cum est circunscriptio: sic foralis applicatio angeli ad locumem 
-            <lb ed="#V" n="126"/>similtas sua cum loco lecum re existente in loco.
+            lo<lb ed="#V" n="125" break="no"/>cum est circunscriptio: sic formalis applicatio angeli ad locum 
+            <lb ed="#V" n="126"/>simulitas sua cum loco locum re existente in loco.
           </p>
           <p xml:id="kzz7yh-a78920-d1e431">
             ¶ Et sic patet responsio 
@@ -255,7 +255,7 @@
           <p xml:id="kzz7yh-a78920-d1e442">
             ¶ Ad 
             <lb ed="#V" n="129"/>principium quod arguitur per auctoritatem boetii dicendum quod non intendit negare 
-            incor<lb ed="#V" n="130" break="no"/>poralia esse in locoper sui similtate cum loco: vel cum re existente in loco 
+            incor<lb ed="#V" n="130" break="no"/>poralia esse in loco per sui simulitate cum loco: vel cum re existente in loco 
             <lb ed="#V" n="131"/>sed intendit negare quod non sunt in loco circunscriptiue. Simili 
             <lb ed="#V" n="132"/>modo solui potest ad alia tria quae sequuntur.
           </p>
@@ -376,7 +376,7 @@
           </p>
           <p xml:id="kzz7yh-a78920-d1e657">
             ¶ Quia 
-            er<lb ed="#V" n="68" break="no"/>go simplicitas angeli est positiua spiritualis magnitudis fi¬ 
+            er<lb ed="#V" n="68" break="no"/>go simplicitas angeli est positiua spiritualis magnitudinis fi¬ 
             <!--00245.xml-->
             <cb ed="#P" n="b"/>
             <lb ed="#V" n="69"/>nite tamen: quam dicere possumus aliquam longinquam. d 
@@ -449,7 +449,7 @@
           </p>
           <p xml:id="kzz7yh-a78920-d1e788">
             ¶ Item <ref xml:id="kzz7yh-a78920-Rd1e843">Augu. 18 libo de ciui. dei. c. 19.</ref> vult quod 
-            ho<lb ed="#V" n="114" break="no"/>mine dorminiente: et viuo remanente phantasticum eius 
+            ho<lb ed="#V" n="114" break="no"/>mine <sic>dorminiente:</sic> et viuo remanente phantasticum eius 
             ve<lb ed="#V" n="115" break="no"/>luti communicatum in alicuius animalis effigie quandoque apparet sensibus alienis 
             <lb ed="#V" n="116"/>quod esse non posset nisi illud phantasticum simul esset in corpore 
             dormi<lb ed="#V" n="117" break="no"/>entis: et praesens sensibus alicuius: cum ergo angelus minus sit limitatus 
@@ -476,8 +476,8 @@
           <p xml:id="kzz7yh-a78920-d1e831">
             <lb ed="#V" n="129"/>¶ Respondeo quod vnus angelus non potest simil esse in diuersis locis 
             <lb ed="#V" n="130"/>saltem per operationem cuiuscumque virtutis create. In 
-            <lb ed="#V" n="131"/>praecedenti enim quaestione habitum est quod spatii cui toti simul potest angtolus se 
-            facin<lb ed="#V" n="132" break="no"/>praesentem est dare termium in maius: quod verum non esset: si angelus 
+            <lb ed="#V" n="131"/>praecedenti enim quaestione habitum est quod spatii cui toti simul potest angelus se 
+            facere<lb ed="#V" n="132" break="no"/>praesentem est dare termium in maius: quod verum non esset: si angelus 
             <lb ed="#V" n="133"/>posset virtute propria simul esse in diuersis locis: quia qua 
             ratio<lb ed="#V" n="134" break="no"/>ne posset esse in pluribus per vnam leucasa distantibus a se 
             inui<lb ed="#V" n="135" break="no"/>cem: pari ratione posset esse in quibuscumque distantibus. Sed 
@@ -628,7 +628,7 @@
             <lb ed="#V" n="90"/>quia non decet
           </p>
           <p xml:id="kzz7yh-a78920-d1e1107">
-            ¶ Ad 2m dicendum quod ratio quare angeli sitl 
+            ¶ Ad 2m dicendum quod ratio quare angeli simul 
             <lb ed="#V" n="91"/>sunt cum deo: est quia deus eis illabitur. Unus autem angelus 
             <lb ed="#V" n="92"/>alii illabi non potest
           </p>
@@ -641,11 +641,11 @@
           <p xml:id="kzz7yh-a78920-d1e1123">
             ¶ Ad 4m dicendum quod quamuis 
             <lb ed="#V" n="96"/>malus spiritus aliquando subintret corpus non tamen simul est 
-            <lb ed="#V" n="97"/>cum anima: quia malus angelus cum subiectintrat hominem non 
+            <lb ed="#V" n="97"/>cum anima: quia malus angelus cum subiect intrat hominem non 
             <lb ed="#V" n="98"/>est presens per substantiam aliquam in parte corporis humani: sed 
             <lb ed="#V" n="99"/>vel in humoribus: vel in vacuis ipsius corporis: qui humores 
             <lb ed="#V" n="100"/>vel que vacuitates ab essentia anime non perficiuntur: et 
-            vo<lb ed="#V" n="101" break="no"/>co hic vacuitatem concauittatem non infra quam nihll est: quia 
+            vo<lb ed="#V" n="101" break="no"/>co hic vacuitatem <sic>concauittatem</sic> non infra quam nihil est: quia 
             <lb ed="#V" n="102"/>non est ponere vacuum: sed infra quam non est nisi aer vel 
             <lb ed="#V" n="103"/>vapor subtilis secundum vulgarem modum loquendi: quo dicitur quod 
             <lb ed="#V" n="104"/>vas est vacuum in quo nihil est nisi aer vel vapor subtilis. 

--- a/kzz7yh-a78920/cod-ve07v1_kzz7yh-a78920.xml
+++ b/kzz7yh-a78920/cod-ve07v1_kzz7yh-a78920.xml
@@ -242,7 +242,7 @@
             <lb ed="#V" n="122"/>huius applicationis: sed finalis: dico ergo quod formalis ratio 
             applica<lb ed="#V" n="123" break="no"/>tionis angeli ad locum est sua simultas cum loco vel cum re in 
             <lb ed="#V" n="124"/>loco existente. Unde sicut formalis ratio applicationis corporis ad 
-            lo<lb ed="#V" n="125" break="no"/>cum est circunscriptio: sic formalis applicatio angeli ad locum 
+            lo<lb ed="#V" n="125" break="no"/>cum est circunscriptio: sic formalis applicatio angeli ad locum est
             <lb ed="#V" n="126"/>simulitas sua cum loco locum re existente in loco.
           </p>
           <p xml:id="kzz7yh-a78920-d1e431">
@@ -376,10 +376,10 @@
           </p>
           <p xml:id="kzz7yh-a78920-d1e657">
             ¶ Quia 
-            er<lb ed="#V" n="68" break="no"/>go simplicitas angeli est positiua spiritualis magnitudinis fi¬ 
+            er<lb ed="#V" n="68" break="no"/>go simplicitas angeli est positiua spiritualis magnitudinis fi¬
             <!--00245.xml-->
             <cb ed="#P" n="b"/>
-            <lb ed="#V" n="69"/>nite tamen: quam dicere possumus aliquam longinquam. d 
+            <lb ed="#V" n="69" break="no"/>nite tamen: quam dicere possumus aliquam longinquam. d 
             <lb ed="#V" n="70"/>debilem diuine immensitatis imitationem. Ideo ratio 
             <lb ed="#V" n="71"/>ne huius positiue spiritualis magnitudinis ita potest esse proesens 
             <lb ed="#V" n="72"/>alicui spatio toti simul: quod tamen propter simplicitatem erit in 
@@ -641,7 +641,7 @@
           <p xml:id="kzz7yh-a78920-d1e1123">
             ¶ Ad 4m dicendum quod quamuis 
             <lb ed="#V" n="96"/>malus spiritus aliquando subintret corpus non tamen simul est 
-            <lb ed="#V" n="97"/>cum anima: quia malus angelus cum subiect intrat hominem non 
+            <lb ed="#V" n="97"/>cum anima: quia malus angelus cum subintrat hominem non 
             <lb ed="#V" n="98"/>est presens per substantiam aliquam in parte corporis humani: sed 
             <lb ed="#V" n="99"/>vel in humoribus: vel in vacuis ipsius corporis: qui humores 
             <lb ed="#V" n="100"/>vel que vacuitates ab essentia anime non perficiuntur: et 


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve07v1_kzz7yh-a78920.xml`.

## Applied changes

- p. 115v l. 72: termius → terminus: missing n — transcription error
- p. 115v l. 73: Angitulus → Angelus: garbled — transcription error
- p. 115v l. 74: termius → terminus: missing n — transcription error
- p. 115v l. 76: opionem → opinionem: missing letters ni — transcription error
- p. 115v l. 80: sacramenis → sacramentis: missing t — transcription error
- p. 115v l. 99: opoertet → oportet: extra o — transcription error
- p. 115v l. 103: cumergo → cum ergo: missing space — transcription error
- p. 115v l. 106: viletur → videtur: l/d misread — transcription error
- p. 115v l. 108: circumsriptiue → circumscriptiue: missing c — transcription error
- p. 115v l. 116: inforatio → informatio: missing m — transcription error
- p. 115v l. 118: magnitudis → magnitudinis: missing syllable ni — transcription error
- p. 115v l. 122: foralis → formalis: missing m — transcription error
- p. 115v l. 124: fornalis → formalis: n/m misread — transcription error
- p. 116r l. 3: perti → parti: e/a misread — transcription error
- p. 116r l. 24: intempore → in tempore: missing space — transcription error
- p. 116r l. 26: angustolus → angelus: garbled — transcription error
- p. 116r l. 34: angtuolnus → angelus: garbled — transcription error
- p. 116r l. 52: angelilsit → angeli sit: missing space — transcription error; pearti → parti: spurious ea — transcription error
- p. 116r l. 56: intelligentam → intelligentiam: missing i — transcription error
- p. 116r l. 71: magnititudinis → magnitudinis: doubled ti — transcription error
- p. 116r l. 81: iequeretur → sequeretur: i/s misread at word start — transcription error
- p. 116r l. 91: puctus → punctus: missing n — transcription error
- p. 116r l. 97: angelulium → angelum: garbled — transcription error
- p. 116r l. 115: apporet → apparet: o/a misread — transcription error
- p. 116r l. 117: angtilus → angelus: garbled — transcription error
- p. 116r l. 127: angltuolus → angelus: garbled — transcription error
- p. 116v l. 25: sommniat → somniat: doubled m — transcription error
- p. 116v l. 51: pruncta → puncta: r/u transposition — transcription error
- p. 116v l. 76: oppostum → oppositum: missing i — transcription error
- p. 116v l. 99: vesl → vel: spurious s — transcription error; coporis → corporis: missing r — transcription error
- p. 116v l. 119: talsum → falsum: t/f misread — transcription error
- p. 116v l. 122: pruncta → puncta: r/u transposition — transcription error
- p. 116v l. 126: sequiturquod → sequitur quod: missing space — transcription error
- p. 116v l. 127: purctus → punctus: r/n transposition — transcription error

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_