### PR TITLE
Transcription corrections: cod-ve07v1_kzz7yh-a80049.xml (22 changes)

### DIFF
--- a/kzz7yh-a80049/cod-ve07v1_kzz7yh-a80049.xml
+++ b/kzz7yh-a80049/cod-ve07v1_kzz7yh-a80049.xml
@@ -98,12 +98,12 @@
             se<lb ed="#V" n="18" break="no"/>mouens: et aliud per se motum. Sed angelus non est 
             resolubi<lb ed="#V" n="19" break="no"/>lis in talia duo: quia et si in angelo sit natura actualis: et 
             po<lb ed="#V" n="20" break="no"/>tentialis: tamen natura eius potentialis non habet rationem per se 
-            mobi<lb ed="#V" n="21" break="no"/>lis: ergo angtuolus non potest se mouere de loco ad locum.
+            mobi<lb ed="#V" n="21" break="no"/>lis: ergo angelus non potest se mouere de loco ad locum.
           </p>
           <p xml:id="kzz7yh-a80049-d1e179">
             ¶ Item 
             <lb ed="#V" n="22"/>quod mouet se localiter prius pertransit spatium minus vel 
-            equale<lb ed="#V" n="23" break="no"/>sibi quam spatium maius secundum philosophum 6 phy. Sed angtolus non potest 
+            equale<lb ed="#V" n="23" break="no"/>sibi quam spatium maius secundum philosophum 6 phy. Sed angelus non potest 
             <lb ed="#V" n="24"/>pertransire spatium minus se: quia nihil est minus indisibile: neque 
             <lb ed="#V" n="25"/>equale sibi: quia tunc primo pertransiret vnum indisibile: et pari 
             <lb ed="#V" n="26"/>ratione secundo aliud indisibile: et sic deinceps: et ita sequaretur 
@@ -112,7 +112,7 @@
           </p>
           <p xml:id="kzz7yh-a80049-d1e197">
             <lb ed="#V" n="29"/>¶ Item accidens diuisibile non potest esse in subiecto indiuisibili: sed 
-            mo<lb ed="#V" n="30" break="no"/>tus est accidens disibile: ergo angtuolus non potest moueri.
+            mo<lb ed="#V" n="30" break="no"/>tus est accidens disibile: ergo angelus non potest moueri.
           </p>
           <p xml:id="kzz7yh-a80049-d1e205">
             ¶ Item 
@@ -141,7 +141,7 @@
           <p xml:id="kzz7yh-a80049-d1e246">
             ¶ Item cum homo 
             mori<lb ed="#V" n="45" break="no"/>tur: anima eius sine assumpto corpore pertransit autem ad infernum 
-            <lb ed="#V" n="46"/>aut ad purgatorium: aut ad caelum empyreum: ergo simliter 
+            <lb ed="#V" n="46"/>aut ad purgatorium: aut ad caelum empyreum: ergo similiter 
             an<lb ed="#V" n="47" break="no"/>gelus sine assumpto corpore potest transire de loco ad locum. 
           </p>
           <p xml:id="kzz7yh-a80049-d1e255">
@@ -158,8 +158,8 @@
             po<lb ed="#V" n="58" break="no"/>test esse in alio: quamuis vnus sit magis sibi congruus quam alius: 
             <lb ed="#V" n="59"/>ergo mutabilis est de loco ad locum. eo modo quo sibi 
             conue<lb ed="#V" n="60" break="no"/>nit esse in loco. Quod autem ipsemet se possit mutare patet sic: quia 
-            <lb ed="#V" n="61"/>vt inferius ostendetur scilicet lib. 2. angitilus compositus est ex natura 
-            actu<lb ed="#V" n="62" break="no"/>ali et potentiali: ergo qua ratione ipse angelilus potest mutari 
+            <lb ed="#V" n="61"/>vt inferius ostendetur scilicet lib. 2. angelus compositus est ex natura 
+            actu<lb ed="#V" n="62" break="no"/>ali et potentiali: ergo qua ratione ipse angelus potest mutari 
             in<lb ed="#V" n="63" break="no"/>quantum est aliquid possibile: videtur quod etiam possit se 
             muta<lb ed="#V" n="64" break="no"/>re ratione sui actualis: quod est proportionatum suo possibili: vel 
             <lb ed="#V" n="65"/>prepotens ei: ita vt totius sit mutabilis de loco ad locum 
@@ -183,7 +183,7 @@
             Auemn<lb ed="#V" n="79" break="no"/>peche illam partibilitatem intelligi secundum quod refert 
             Com<lb ed="#V" n="80" break="no"/>mentator super locum predictum: cuius opinionis 
             di<lb ed="#V" n="81" break="no"/>cit se aliquando fuisse quamuis postea dimisit eam. Angelus autem 
-            <lb ed="#V" n="82"/>quamuis sit simplex: tamen bene est in loco peartibili: et ideo bene 
+            <lb ed="#V" n="82"/>quamuis sit simplex: tamen bene est in loco partibili: et ideo bene 
             <lb ed="#V" n="83"/>potest habere partem de terio a quo et partem de terio ad quem. 
           </p>
           <p xml:id="kzz7yh-a80049-d1e344">
@@ -230,7 +230,7 @@
         </div>
         <div xml:id="kzz7yh-a80049-Dd1e416">
           <head xml:id="kzz7yh-a80049-Hd1e418">Quaestio 2</head>
-          <head xml:id="kzz7yh-a80049-Hd1e440" type="question-title">Utrumangelum mouentem se de loco ad locum oporteat pertransire medium</head>
+          <head xml:id="kzz7yh-a80049-Hd1e440" type="question-title">Utrum angelum mouentem se de loco ad locum oporteat pertransire medium</head>
           <p xml:id="kzz7yh-a80049-d1e420">
             <lb ed="#V" n="111"/>¶ Questio. II. 
             <lb ed="#V" n="112"/>SEcundo queritur vtrum 
@@ -249,7 +249,7 @@
             <lb ed="#V" n="122"/>nisi pertranseundo in infinita. quod falsum est.
           </p>
           <p xml:id="kzz7yh-a80049-d1e451">
-            ¶ Item animna 
+            ¶ Item anima 
             <lb ed="#V" n="123"/>nostra sua cogitatione potest transire de vno termino ad 
             ter<lb ed="#V" n="124" break="no"/>minum alium non per medium. possum enim cogitare de 
             Pa<lb ed="#V" n="125" break="no"/>risius et postea de ambianis non cogitando de locis mediis. 
@@ -289,12 +289,12 @@
             di<lb ed="#V" n="10" break="no"/>cunt quod transire de loco ad locum pertranseundo medium 
             <lb ed="#V" n="11"/>vel non pertranseundo si placet ei. 
             <!--TODO: insert para break here-->
-            <lb ed="#V" n="12"/>Sed contra hanc opionem est communor doctorum 
+            <lb ed="#V" n="12"/>Sed contra hanc opinionem est communor doctorum 
             opi<lb ed="#V" n="13" break="no"/>nio.
           </p>
           <p xml:id="kzz7yh-a80049-d1e531">
             ¶ Dico ergo quod dum mouetur 
-            <lb ed="#V" n="14"/>angelus de loco ad locum opetet ipsum transire per medium: 
+            <lb ed="#V" n="14"/>angelus de loco ad locum oportet ipsum transire per medium: 
             <lb ed="#V" n="15"/>non tamen eo modo quo res corporales: quia non commensuratur 
             <lb ed="#V" n="16"/>medio neque actu: neque potentia.
           </p>
@@ -312,7 +312,7 @@
             <lb ed="#V" n="24"/>motus: sed tantum in potentia. Unde angelus dum 
             moue<lb ed="#V" n="25" break="no"/>tur non diffinit aliquod spatium in actu: sed in potentia: 
             quam<lb ed="#V" n="26" break="no"/>uis autem sit impossibile pertransire infinita in actu: non est 
-            ta<lb ed="#V" n="27" break="no"/>men possibile pertransire infintia in potentia.
+            ta<lb ed="#V" n="27" break="no"/>men possibile pertransire infinita in potentia.
           </p>
           <p xml:id="kzz7yh-a80049-d1e569">
             ¶ Ad 3m 
@@ -341,7 +341,7 @@
             ¶ Item secundum <ref xml:id="kzz7yh-a80049-Rd1e649">philosophum 
               <lb ed="#V" n="41"/>4. physicorum. c. de vacuo.</ref> Si esset vacuum non esset 
             loca<lb ed="#V" n="42" break="no"/>lis mutatio successiua. Sed angelo non plus resistit 
-            plan<lb ed="#V" n="43" break="no"/>num quam vacuum: ergo non mouet se angitilus per medium 
+            plan<lb ed="#V" n="43" break="no"/>num quam vacuum: ergo non mouet se angelus per medium 
             succes<lb ed="#V" n="44" break="no"/>siue: sed in instanti.
           </p>
           <p xml:id="kzz7yh-a80049-d1e618">
@@ -370,7 +370,7 @@
           </p>
           <p xml:id="kzz7yh-a80049-d1e659">
             ¶ Item <ref xml:id="kzz7yh-a80049-Rd1e707">Damas. libro 2. c. 3.</ref> Angeli confestim 
-            inueniun<lb ed="#V" n="60" break="no"/>tur vbicunque dinus iusserit nutus velocitate nature sed 
+            inueniun<lb ed="#V" n="60" break="no"/>tur vbicunque divinus iusserit nutus velocitate nature sed 
             <lb ed="#V" n="61"/>confestim et in instanti idem esse videntur: ergo videtur quod 
             ange<lb ed="#V" n="62" break="no"/>lus transeat medium inter duo loca in instanti. 
           </p>
@@ -403,12 +403,12 @@
             <lb ed="#V" n="80"/>se ad spatium medium inter duo loca in instanti. 
           </p>
           <p xml:id="kzz7yh-a80049-d1e720">
-            <lb ed="#V" n="81"/>Ad istam quaestionem voluerunt aliqui dicere quod angustolus 
+            <lb ed="#V" n="81"/>Ad istam quaestionem voluerunt aliqui dicere quod angelus 
             <lb ed="#V" n="82"/>potest pertransire medium inter duo loca in 
             in<lb ed="#V" n="83" break="no"/>stanti: quia quanuis virtus angeli non sit infinita secundum se: tamen 
             <lb ed="#V" n="84"/>in infinitum excedit quodcumque spatium finitum inquantum spatium 
             <lb ed="#V" n="85"/>nullo modo sibi resistit: sicut videmus quod linea finita secundum se 
-            <lb ed="#V" n="86"/>est in infinitum tamen excedit punctum inquantum pum ctus 
+            <lb ed="#V" n="86"/>est in infinitum tamen excedit punctum inquantum punctus 
             <lb ed="#V" n="87"/>quotienscunque replicatus non equatur ei. 
             <!--TODO: insert para break here-->
             <lb ed="#V" n="88"/>Sed hec ratio non est sufficiens quia quamuis spatium 
@@ -426,7 +426,7 @@
             <lb ed="#V" n="98"/>medium non est dare locum signatum in medio in quo non 
             <lb ed="#V" n="99"/>possit esse in actu: quia vt probatum est supra potest esse in loco 
             <lb ed="#V" n="100"/>diffinitiue: sed in omnibus locis: quibus potest esse in actu est in 
-            <lb ed="#V" n="101"/>potentia permixta actui: sed cum aliquid tranfertur de loco ad 
+            <lb ed="#V" n="101"/>potentia permixta actui: sed cum aliquid transfertur de loco ad 
             <lb ed="#V" n="102"/>locum exstendo in omnibus locis intermedii in potentia: et non 
             <lb ed="#V" n="103"/>in actu puro transfertur de loco ad locum successiue et talis 
             <lb ed="#V" n="104"/>translatio non est in instanti.
@@ -447,8 +447,8 @@
             dimen<lb ed="#V" n="114" break="no"/>siones etiam separate: quia tunc inter duo loca: nullum 
             pe<lb ed="#V" n="115" break="no"/>nitus esset medium in actu: et ideo sic loquendo de vacuo 
             <lb ed="#V" n="116"/>auctoritas nihitur facit ad propositum: et quod auctoritas 
-            philosophi<lb ed="#V" n="117" break="no"/>de tali vacuo ita sic intelligenda: videtur ex hoc quod in eo 
-            <lb ed="#V" n="118"/>dem. c. vult quod in vacuo vbi essent dimensiones separate: nullum 
+            philosophi<lb ed="#V" n="117" break="no"/>de tali vacuo ita sic intelligenda: videtur ex hoc quod in 
+            eo<lb ed="#V" n="118" break="no"/>dem. c. vult quod in vacuo vbi essent dimensiones separate: nullum 
             <lb ed="#V" n="119"/>corpus posset poni. Ex quo sequitur quod per tale vacuum nullum 
             <lb ed="#V" n="120"/>corpus naturaliter posset moueri nec mutari
           </p>
@@ -476,7 +476,7 @@
             <!--00249.xml-->
             <pb ed="#V" n="118-r"/>
             <cb ed="#P" n="a"/>
-            <lb ed="#V" n="1"/>sationem successionis. Hoc enimm est in proposito finitas 
+            <lb ed="#V" n="1"/>sationem successionis. Hoc enim est in proposito finitas 
             <lb ed="#V" n="2"/>virtutis angelice cum diuisibilitate spatii.
           </p>
           <p xml:id="kzz7yh-a80049-d1e869">
@@ -487,7 +487,7 @@
             expendit<lb ed="#V" n="6" break="no"/>motu ratione resistentie tantum: et non de tempore quod expenderetur in 
             mo<lb ed="#V" n="7" break="no"/>tu ratione dimensionis si circunscriberetur resistentia medii: 
             <lb ed="#V" n="8"/>et sic etiam potest exponi verbum philosophi dicentis. 4. physico. quod 
-            <lb ed="#V" n="9"/>secundum proportionem resistentie que est in vnomedio ad 
+            <lb ed="#V" n="9"/>secundum proportionem resistentie que est in vno medio ad 
             resiste<lb ed="#V" n="10" break="no"/>tiam que est in alio medio est proportio temporis mensurantis 
             <lb ed="#V" n="11"/>motum per vnum medium ad tempus mensurans motum 
             per<lb ed="#V" n="12" break="no"/>alium medium.
@@ -549,7 +549,7 @@
             pri<lb ed="#V" n="46" break="no"/>mo acquirat nec diuisibile: quia pars diuisibilis prius acquiritur quam 
             <lb ed="#V" n="47"/>totum nec indiuisibile: quia in continuo indisibile 
             indiuisibi<lb ed="#V" n="48" break="no"/>li non continuatur: nec contiguatur: ex parte autem finis motus est 
-            <lb ed="#V" n="49"/>dare aliquid indisibile ad quod primomodo determinatur: sed non 
+            <lb ed="#V" n="49"/>dare aliquid indisibile ad quod primo modo determinatur: sed non 
             <lb ed="#V" n="50"/>est dare instantia a quo mutatum est: neque indisibile: quia 
             po<lb ed="#V" n="51" break="no"/>sterius est mutatum esse a parte secunda quam a prima: nec 
             indiuisibi<lb ed="#V" n="52"/>le: quia in continuo indisibile indiuisibili non continuatur: nec 
@@ -566,7 +566,7 @@
             in<lb ed="#V" n="63" break="no"/>telliguntur rationes philosophi per quas probat 6 physi quod non est 
             prin<lb ed="#V" n="64" break="no"/>cipium in quo mutatum est a patte principii motus. 
             <!--TODO: insert para break here-->
-            <lb ed="#V" n="65"/>Argumenta ad partem aliam procaedunt de 
+            <lb ed="#V" n="65"/>Argumenta ad partem aliam procedunt de 
             muta<lb ed="#V" n="66" break="no"/>tione inquantum est ab aliquo: 
             quam<lb ed="#V" n="67" break="no"/>uis non sit simile de puncto respectu linee: et mutatione 
             <lb ed="#V" n="68"/>respectu motus: quia non est contra naturam linee quod punctus 

--- a/kzz7yh-a80049/cod-ve07v1_kzz7yh-a80049.xml
+++ b/kzz7yh-a80049/cod-ve07v1_kzz7yh-a80049.xml
@@ -174,17 +174,17 @@
           <p xml:id="kzz7yh-a80049-d1e313">
             <lb ed="#V" n="71"/>Ad primum in oppositum cum dicitur quo omne 
             <lb ed="#V" n="72"/>quod mouetur partim est in termino a quo 
-            <lb ed="#V" n="73"/>et pertim in terio ad quem etc. dico quod sic debet exponi idest 
-            <lb ed="#V" n="74"/>partem habet de termino a quo et partem habet de terio ad quem 
+            <lb ed="#V" n="73"/>et partim in termino ad quem etc. dico quod sic debet exponi idest 
+            <lb ed="#V" n="74"/>partem habet de termino a quo et partem habet de termino ad quem 
             <lb ed="#V" n="75"/>Unde non oportet quod ista partibilitas ponatur in mobili 
             ab<lb ed="#V" n="76" break="no"/>solute secundum sui vltima: sed sufficit quod sit ibi per comparationem 
-            <lb ed="#V" n="77"/>ad termnium a quo et ad terminum ad quem: hoc est secundum 
+            <lb ed="#V" n="77"/>ad <sic>termnium</sic> a quo et ad terminum ad quem: hoc est secundum 
             <lb ed="#V" n="78"/>habere partem vnius: et partem alterius et sic vult 
             Auemn<lb ed="#V" n="79" break="no"/>peche illam partibilitatem intelligi secundum quod refert 
             Com<lb ed="#V" n="80" break="no"/>mentator super locum predictum: cuius opinionis 
             di<lb ed="#V" n="81" break="no"/>cit se aliquando fuisse quamuis postea dimisit eam. Angelus autem 
             <lb ed="#V" n="82"/>quamuis sit simplex: tamen bene est in loco partibili: et ideo bene 
-            <lb ed="#V" n="83"/>potest habere partem de terio a quo et partem de terio ad quem. 
+            <lb ed="#V" n="83"/>potest habere partem de termino a quo et partem de terio ad quem. 
           </p>
           <p xml:id="kzz7yh-a80049-d1e344">
             <lb ed="#V" n="84"/>¶ Ad 2m cum dicitur quod omne quod monet se resolubile est in 
@@ -268,7 +268,7 @@
             prece<lb ed="#V" n="133" break="no"/>dit moueri: sed motum esse est in termino ad quem. ergo 
             mo<lb ed="#V" n="134" break="no"/>ueri est ante terminum ad quem. sed non in termino a quo 
             <lb ed="#V" n="135"/>ergo in medio. nihil ergo mouetur de loco ad locum quan 
-            <lb ed="#V" n="136"/>perttanseat medium. 
+            <lb ed="#V" n="136"/>(pertranseat medium. 
           </p>
           <p xml:id="kzz7yh-a80049-d1e489">
             <lb ed="#V" n="137"/>Ad hanc questionem dixerunt aliqui quod angelus potest 
@@ -446,7 +446,7 @@
             va<lb ed="#V" n="113" break="no"/>cuo: vbi nec essent dimensiones in substantia corporea: nec 
             dimen<lb ed="#V" n="114" break="no"/>siones etiam separate: quia tunc inter duo loca: nullum 
             pe<lb ed="#V" n="115" break="no"/>nitus esset medium in actu: et ideo sic loquendo de vacuo 
-            <lb ed="#V" n="116"/>auctoritas nihitur facit ad propositum: et quod auctoritas 
+            <lb ed="#V" n="116"/>auctoritas nihil facit ad propositum: et quod auctoritas 
             philosophi<lb ed="#V" n="117" break="no"/>de tali vacuo ita sic intelligenda: videtur ex hoc quod in 
             eo<lb ed="#V" n="118" break="no"/>dem. c. vult quod in vacuo vbi essent dimensiones separate: nullum 
             <lb ed="#V" n="119"/>corpus posset poni. Ex quo sequitur quod per tale vacuum nullum 
@@ -461,7 +461,7 @@
             <lb ed="#V" n="125"/>ad solutionem argumenti spectat: dico quod si concedatur quod 
             il<lb ed="#V" n="126" break="no"/>luminatio medii est in instanti adhuc non valet 
             argumen<lb ed="#V" n="127" break="no"/>tum: quia illuminatione medii non est aliquid vnum et idem 
-            <lb ed="#V" n="128"/>quod transeat medium. Sed lumnare illuminat vnam partem 
+            <lb ed="#V" n="128"/>quod transeat medium. Sed <sic>lumnare</sic> illuminat vnam partem 
             <lb ed="#V" n="129"/>et illa aliam: et sic vsque ad terram: et ideo non requirit ibi 
             tem<lb ed="#V" n="130" break="no"/>pus propter spatium: sicut in motu angeli: et sic diceretur quod 
             il<lb ed="#V" n="131" break="no"/>luminatio medii est simplicior quam mutatio angeli per 
@@ -516,7 +516,7 @@
           <p xml:id="kzz7yh-a80049-d1e928">
             <lb ed="#V" n="24"/>¶ Item Commentator super locum praedictum dicit: 
             mani<lb ed="#V" n="25" break="no"/>festum est quod transmutatio non habet principium: nisi 
-            tramsmu<lb ed="#V" n="26" break="no"/>tatio esset composita ex indiuisibilibus et tempus simliter: sed temp. 
+            tramsmu<lb ed="#V" n="26" break="no"/>tatio esset composita ex indiuisibilibus et tempus similiter: sed tempus 
             <lb ed="#V" n="27"/>non est compositum ex indiuisibilibus: vt probat philosophus 6 physi 
             <lb ed="#V" n="28"/>ergo transmutatio non habet principium quod non esset verum: si in ¬ 
             <lb ed="#V" n="29"/>motu angeli esset aliqua mutatio prima.
@@ -557,14 +557,14 @@
             transfe<lb ed="#V" n="54" break="no"/>rat se ad aliud spatium illi non continuum: sed contiguum: adhuc 
             <lb ed="#V" n="55"/>non poterit dici quod primo acquirat aliquid indiuisibile spatii 
             <lb ed="#V" n="56"/>contigui in actu: quia impossibile est mobile aliquid acquirere in 
-            <lb ed="#V" n="57"/>actu siue disibile siue indisibile quir quiescat alias adeent et ab 
+            <lb ed="#V" n="57"/>actu siue disibile siue indisibile quir quiescat alias adesset et ab 
             <lb ed="#V" n="58"/>esset in actu eidem signo in eodem instanti. Unde 
             Com<lb ed="#V" n="59" break="no"/>mentator super 6 physi. dicit quod intentio phlosophi. est declarare 
             <lb ed="#V" n="60"/>quod initium transmutationis non est in actu sed in potentia 
             <lb ed="#V" n="61"/>sed finis transmutationis est in actu: et hoc intelligi debet 
             <lb ed="#V" n="62"/>de initio transmutationis inquantum est in aliquid: et sic 
             in<lb ed="#V" n="63" break="no"/>telliguntur rationes philosophi per quas probat 6 physi quod non est 
-            prin<lb ed="#V" n="64" break="no"/>cipium in quo mutatum est a patte principii motus. 
+            prin<lb ed="#V" n="64" break="no"/>cipium in quo mutatum est a <sic>patte</sic> principii motus. 
             <!--TODO: insert para break here-->
             <lb ed="#V" n="65"/>Argumenta ad partem aliam procedunt de 
             muta<lb ed="#V" n="66" break="no"/>tione inquantum est ab aliquo: 


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve07v1_kzz7yh-a80049.xml`.

## Applied changes

- p. 117v l. 14: opetet → oportet: missing or
- p. 117v l. 118: 'eo' + 'dem' split across line break without break="no" on lb n=118
- p. 117r l. 21: angtuolus → angelus: garbled — transcription error
- p. 117r l. 23: angtolus → angelus: garbled — transcription error
- p. 117r l. 30: angtuolus → angelus: garbled — transcription error
- p. 117r l. 46: simliter → similiter: missing i — transcription error
- p. 117r l. 61: angitilus → angelus: garbled — transcription error
- p. 117r l. 62: angelilus → angelus: garbled — transcription error
- p. 117r l. 82: peartibili → partibili: spurious ea — transcription error
- p. 117r l. 110: Utrumangelum → Utrum angelum: missing space — transcription error
- p. 117r l. 122: animna → anima: extra n — transcription error
- p. 117v l. 12: opionem → opinionem: missing ni — transcription error
- p. 117v l. 27: infintia → infinita: missing a — transcription error
- p. 117v l. 43: angitilus → angelus: garbled — transcription error
- p. 117v l. 60: dinus → divinus: missing vi — transcription error
- p. 117v l. 81: angustolus → angelus: garbled — transcription error
- p. 117v l. 86: pum ctus → punctus: spurious space — transcription error
- p. 117v l. 101: tranfertur → transfertur: missing s — transcription error
- p. 118r l. 1: enimm → enim: doubled m — transcription error
- p. 118r l. 9: vnomedio → vno medio: missing space — transcription error
- p. 118r l. 49: primomodo → primo modo: missing space — transcription error
- p. 118r l. 65: procaedunt → procedunt: ae/e — transcription error

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_