### PR TITLE
Transcription corrections: cod-ve07v1_kzz7yh-a81516.xml (21 changes)

### DIFF
--- a/kzz7yh-a81516/cod-ve07v1_kzz7yh-a81516.xml
+++ b/kzz7yh-a81516/cod-ve07v1_kzz7yh-a81516.xml
@@ -94,7 +94,7 @@
           <p xml:id="kzz7yh-a81516-d1e160">
             ¶ Item <ref xml:id="kzz7yh-a81516-Rd1e170">philosophus. 2. 
               Meta<lb ed="#V" n="51" break="no"/>physi.</ref> Unumquodque sicut se habet vt sit: ita ad veritatem: ergo 
-            <lb ed="#V" n="52"/>cum futura non sint non habent aliquam veritatem: sed nihitur 
+            <lb ed="#V" n="52"/>cum futura non sint non habent aliquam veritatem: sed nihil 
             <lb ed="#V" n="53"/>potest fieri nisi verum: quia secundum Aug. 15 de tri. c. x. falsum non est 
             <lb ed="#V" n="54"/>scire: ergo deus non habet scientiam futurorum.
           </p>
@@ -167,7 +167,7 @@
           <p xml:id="kzz7yh-a81516-d1e291">
             ¶ Item prescientia dei respectu futurorum est quasi 
             pre<lb ed="#V" n="96" break="no"/>scientia artificis respectu artificiandorum: sed prescientia 
-            artifi<lb ed="#V" n="97" break="no"/>cis est causa vt artificienda siant: ergo prescientia dei est causa: vt 
+            artifi<lb ed="#V" n="97" break="no"/>cis est causa vt artificienda fiant: ergo prescientia dei est causa: vt 
             <lb ed="#V" n="98"/>futura eueniant.
           </p>
           <p xml:id="kzz7yh-a81516-d1e300">
@@ -242,7 +242,7 @@
             <lb ed="#V" n="11"/>Tertio queritur vtrum futura sint 
             <lb ed="#V" n="12"/>causa prescientie dei et 
             <lb ed="#V" n="13"/>videtur quod sic. Sequitur deus prescit hoc futurum: ergo 
-            <lb ed="#V" n="14"/>hoc erit: ergo ibi est aliqua hitudo localis: non 
+            <lb ed="#V" n="14"/>hoc erit: ergo ibi est aliqua habitudo localis: non 
             cau<lb ed="#V" n="15" break="no"/>se ad effectum: vt habitum est in quaestione praecedenti: ergo ibi est 
             <lb ed="#V" n="16"/>habitudo effectus ad causam.
           </p>
@@ -589,7 +589,7 @@
             <lb ed="#V" n="109"/>necessitate euenient.
           </p>
           <p xml:id="kzz7yh-a81516-d1e1064">
-            ¶ Item ista propotio est per se: omnia futura 
+            ¶ Item ista propositio est per se: omnia futura 
             <lb ed="#V" n="110"/>euenient. Sed secundum philosophum id s posterio. necesse est que sunt per 
             <lb ed="#V" n="111"/>se inesse: ergo necesse est quod omnia futura eueniant.
           </p>
@@ -627,7 +627,7 @@
           </p>
           <p xml:id="kzz7yh-a81516-d1e1126">
             ¶ Item si omnia futura de necessitate eueniret: tunc 
-            su<lb ed="#V" n="133" break="no"/>perfluum esset consiliari: et mouere homines ad baefaciendum: quia 
+            su<lb ed="#V" n="133" break="no"/>perfluum esset consiliari: et mouere homines ad benefaciendum: quod 
             <lb ed="#V" n="134"/>absurdum est: quia sicut dicit Aug. 3 de libero arbitrio parum post 
             prin<lb ed="#V" n="135" break="no"/>cipium. Quisquis existimat non esse monendum hominem bene 
             <lb ed="#V" n="136"/>viuere de hominum numero existimandus non est.
@@ -657,7 +657,7 @@
             condi<lb ed="#V" n="16" break="no"/>tionem divinae notionis. Per se vero considerata: non debent 
             <lb ed="#V" n="17"/>omnia de necessitate euenire. Cui opinioni videtur consentire 
             <lb ed="#V" n="18"/>Boe. 5 de consola. non multum ante finem libr.o vbi dicit sic. 
-            <lb ed="#V" n="19"/>Deus ea futura que ex arbitii libertate proueniunt 
+            <lb ed="#V" n="19"/>Deus ea futura que ex <sic>arbitii</sic> libertate proueniunt 
             presen<lb ed="#V" n="20" break="no"/>tia contuetur. hec igitur ad intuitum relata divinum necessaria 
             <lb ed="#V" n="21"/>fiunt per conditionem divinae notionis. Per se vero considerata 
             <lb ed="#V" n="22"/>absoluta nature sue libertate non desinunt. et aliquibus 
@@ -678,7 +678,7 @@
             <lb ed="#V" n="35"/>esse: loquendo de prima necessitate non est verum quod omnia 
             fu<lb ed="#V" n="36" break="no"/>tura de necessitate euenient. Sed loquendo de necessitateus 
             <lb ed="#V" n="37"/>secunda omnia futura de necessitate euenient: quia illa necessitas 
-            <lb ed="#V" n="38"/>non plus dicit nisi necessariam conetam euentus rei ad suam 
+            <lb ed="#V" n="38"/>non plus dicit nisi necessariam consequentiam euentus rei ad suam 
             <lb ed="#V" n="39"/>futurationem: et dei prescientiam: et certum tamen est quod ista coneqea est 
             <lb ed="#V" n="40"/>necessaria: hoc est futurum: ergo eueniet: et hoc est necessarium 
             <lb ed="#V" n="41"/>deus prescit quod hoc eueniat: ergo eueniet: sed quia 

--- a/kzz7yh-a81516/cod-ve07v1_kzz7yh-a81516.xml
+++ b/kzz7yh-a81516/cod-ve07v1_kzz7yh-a81516.xml
@@ -205,7 +205,7 @@
           <p xml:id="kzz7yh-a81516-d1e361">
             <lb ed="#V" n="122"/>Ad primum in oppositum quod arguebatur per 
             aucto<lb ed="#V" n="123" break="no"/>ritate Augu. dico quod intelligenda 
-            <lb ed="#V" n="124"/>est de notitia approbatiua: que includit dinum beneplacitum 
+            <lb ed="#V" n="124"/>est de notitia approbatiua: que includit divinum beneplacitum 
           </p>
           <p xml:id="kzz7yh-a81516-d1e370">
             <lb ed="#V" n="125"/>¶ Ad 2m cum dicitur quod prescientia dei respectu futurorum est 
@@ -243,7 +243,7 @@
             <lb ed="#V" n="12"/>causa prescientie dei et 
             <lb ed="#V" n="13"/>videtur quod sic. Sequitur deus prescit hoc futurum: ergo 
             <lb ed="#V" n="14"/>hoc erit: ergo ibi est aliqua hitudo localis: non 
-            cau<lb ed="#V" n="15" break="no"/>se ad effectum: vt hitum est in quaestione praecedenti: ergo ibi est 
+            cau<lb ed="#V" n="15" break="no"/>se ad effectum: vt habitum est in quaestione praecedenti: ergo ibi est 
             <lb ed="#V" n="16"/>habitudo effectus ad causam.
           </p>
           <p xml:id="kzz7yh-a81516-d1e442">
@@ -255,7 +255,7 @@
             <lb ed="#V" n="19"/>¶ Item quando vnum sequitur ad aliud: aut vnum est causa 
             alte<lb ed="#V" n="20" break="no"/>rius: aut ambo causantur a tertio: sed non potest dici quod prescientia 
             <lb ed="#V" n="21"/>dei et ipsa futura ab aliquo tertio causata sint nec prescientia dei 
-            <lb ed="#V" n="22"/>causa est futurorum: vt in quaestione praecedenti hitum est: ergo 
+            <lb ed="#V" n="22"/>causa est futurorum: vt in quaestione praecedenti habitum est: ergo 
             re<lb ed="#V" n="23" break="no"/>stat tertium scilicet quod futura sint cause prescientie dei. 
           </p>
           <p xml:id="kzz7yh-a81516-d1e462">
@@ -272,7 +272,7 @@
             cau<lb ed="#V" n="31" break="no"/>sa prescientie dei. 
           </p>
           <p xml:id="kzz7yh-a81516-d1e485">
-            <lb ed="#V" n="32"/>Ad istam quaestionem potest dici quod prescientia viltra scientiam 
+            <lb ed="#V" n="32"/>Ad istam quaestionem potest dici quod prescientia vltra scientiam 
             <lb ed="#V" n="33"/>significat quandam rationem rationis scilicet 
             prio<lb ed="#V" n="34" break="no"/>ritatatem in duratione respectu rei future: et futurum vltra 
             ip<lb ed="#V" n="35" break="no"/>sam rem importat posterioritatem in duratione respectu 
@@ -282,8 +282,8 @@
             <lb ed="#V" n="39"/>dicit prescientia vltra scientiam non videtur esse causa relatio quam 
             <lb ed="#V" n="40"/>futurum dicit vltra rem: nec econuerso: quia sicut dicit Ansel 
             <lb ed="#V" n="41"/>monoluis 3 c. ipse relationes quibus reseruntur ea que referuntur ad 
-            <lb ed="#V" n="42"/>inuicem non ominio sunt per se inuicem: quia hec desunt per subita. 
-            <lb ed="#V" n="43"/>vnde dico quod ralationis quam dicit prescientia vltra scientiam: et 
+            <lb ed="#V" n="42"/>inuicem non omnino sunt per se inuicem: quia hec desunt per subita. 
+            <lb ed="#V" n="43"/>vnde dico quod relationis quam dicit prescientia vltra scientiam: et 
             rela<lb ed="#V" n="44" break="no"/>tionis quam dicit prescitum vltra ipsam rem prescitam ipsa 
             <lb ed="#V" n="45"/>scientia dei et res scite sunt causa: sicut extrema sunt causa 
             <lb ed="#V" n="46"/>relationum inter ipsa: illa tamen relatio rationis per quam scientia habet 
@@ -301,7 +301,7 @@
           </p>
           <p xml:id="kzz7yh-a81516-d1e543">
             ¶ Ad 2m cum arguebatur per auctoritatem magistri 
-            <lb ed="#V" n="56"/>dico quod intelligebat quod res futura et dina scientia sit quedam 
+            <lb ed="#V" n="56"/>dico quod intelligebat quod res futura et divina scientia sit quedam 
             <lb ed="#V" n="57"/>relatio secundum rationem per quam dei scientia dicitur prescientia: et verum 
             <lb ed="#V" n="58"/>est quod scientia dei et res futura causa sunt illius relationis secundum 
             <lb ed="#V" n="59"/>quod extrema possunt dici causa relationum que sunt in ea.
@@ -310,7 +310,7 @@
             ¶ Ad 
             <lb ed="#V" n="60"/>3m dicendum quod ipsa scientia dei approbatiua causa est sit res sit 
             <lb ed="#V" n="61"/>futura relationis aut secundum rationem: quam dicit prescientia super scientiam: et 
-            <lb ed="#V" n="62"/>illius ralationis quam dicit prescitum vltra rem prescitam. ipsa 
+            <lb ed="#V" n="62"/>illius relationis quam dicit prescitum vltra rem prescitam. ipsa 
             <lb ed="#V" n="63"/>diuina scientia et ipse res causa sunt eo modo quo 
             extrema<lb ed="#V" n="64" break="no"/>sunt relationum inter se causa. Ex dictis patet quomodo solui 
             de<lb ed="#V" n="65" break="no"/>beat ad argumenta ad aliam partem. bene enim probant quod 
@@ -362,10 +362,10 @@
           <p xml:id="kzz7yh-a81516-d1e645">
             ¶ Item 
             intel<lb ed="#V" n="90" break="no"/>ligere componendo vel didendo est dicere hoc est hoc: vel 
-            <lb ed="#V" n="91"/>hoc non est hoc: sed dinus intellectus dicit quod iustitia est 
+            <lb ed="#V" n="91"/>hoc non est hoc: sed divinus intellectus dicit quod iustitia est 
             <lb ed="#V" n="92"/>bona: et quod iniustitia non est bona: ergo intelligit 
             componen<lb ed="#V" n="93"/>do vel diuidendo: sed qui sic intelligit: ita potest intelligere 
-            com<lb ed="#V" n="94" break="no"/>positionem et disionem sicut rem: ergo dinus intellectus ita 
+            com<lb ed="#V" n="94" break="no"/>positionem et disionem sicut rem: ergo divinus intellectus ita 
             <lb ed="#V" n="95"/>scit et prescit enunciabilia: sicut res ipsas. 
           </p>
           <p xml:id="kzz7yh-a81516-d1e661">
@@ -402,7 +402,7 @@
           <p xml:id="kzz7yh-a81516-d1e720">
             ¶ Ad 3m cum dicitur 
             <lb ed="#V" n="120"/>quod res scite sunt in sciente etc. dico quod verum est obiectiue: sied 
-            <lb ed="#V" n="121"/>non opetet quod sint in sciente per modum rei intrinsece nisi 
+            <lb ed="#V" n="121"/>non oportet quod sint in sciente per modum rei intrinsece nisi 
             ra<lb ed="#V" n="122" break="no"/>tione suarum idearum
           </p>
           <p xml:id="kzz7yh-a81516-d1e730">
@@ -418,7 +418,7 @@
             <lb ed="#V" n="130"/>quod concludunt quod deus intelligit componendo vel 
             diuiden<lb ed="#V" n="131" break="no"/>do: hoc enim falsum est. 
             <lb ed="#V" n="132"/>Dico ergo ad primum quod illud verbum phlosophilicet quod 
-            <lb ed="#V" n="133"/>veritas et fassitas sunt circa compositionem 
+            <lb ed="#V" n="133"/>veritas et falsitas sunt circa compositionem 
             <lb ed="#V" n="134"/>et diuisionem secundum <ref xml:id="kzz7yh-a81516-Rd1e807">Boe. intelligendum est per comparationem ad 
               no<lb ed="#V" n="135" break="no"/>strum intellectum.</ref>
           </p>
@@ -429,7 +429,7 @@
             <pb ed="#V" n="120-r"/>
             <cb ed="#P" n="a"/>
             <lb ed="#V" n="1"/>Dico quod verum est in vnam redigendo seorsum intellecta: 
-            quam<lb ed="#V" n="2" break="no"/>uis autem dinus intellectus dicat quod iustitia est bona: et quod 
+            quam<lb ed="#V" n="2" break="no"/>uis autem divinus intellectus dicat quod iustitia est bona: et quod 
             iniu<lb ed="#V" n="3" break="no"/>stitia non est bona: hoc tamen non est in vnum redigendo 
             <lb ed="#V" n="4"/>seorsum intellecta cum omnia per suam essentiam que est 
             simpli<lb ed="#V" n="5" break="no"/>cissima. et per vnum actum simplicissimum intelligat vnde 
@@ -453,7 +453,7 @@
             ¶ Item 
             <lb ed="#V" n="15"/>scire non est nisi non contingentium aliter se habere secundum philosophum 
             <lb ed="#V" n="16"/>i. posteriorum: et 6 ethi. c. x. sed futura contingentia contingit 
-            ali<lb ed="#V" n="17" break="no"/>ter sehabere: ergo cum prescire sit scire prescientia dei non est 
+            ali<lb ed="#V" n="17" break="no"/>ter se habere: ergo cum prescire sit scire prescientia dei non est 
             <lb ed="#V" n="18"/>respectu omnium futurorum.
           </p>
           <p xml:id="kzz7yh-a81516-d1e821">
@@ -479,7 +479,7 @@
             <lb ed="#V" n="30"/>enim inferius declarabitur: omnia futura eternitati realiter 
             prossen<lb ed="#V" n="31" break="no"/>tia sunt inquantum eternitas ratione immensitatis transcendit 
             <lb ed="#V" n="32"/>nostrum praesens. Unde Ansel. in libro de concordia prescientie. et lir. 
-            <lb ed="#V" n="33"/>arbitrio longe post principsium dicit de deo quod omnia sunt illi simul praesentia. 
+            <lb ed="#V" n="33"/>arbitrio longe post principium dicit de deo quod omnia sunt illi simul praesentia. 
             <lb ed="#V" n="34"/>Contingens autem dum videtur vt praesenus perspicue videtur: et 
             <lb ed="#V" n="35"/>ideo quia deus videt omnia futura: vt sibi realiter praesentia de illis 
             <lb ed="#V" n="36"/>habet certam cognitionem: nec tantum illorum est scientia sed 
@@ -585,7 +585,7 @@
             ¶ Item secundum philosophum ids 
             prio<lb ed="#V" n="106" break="no"/>rum. Ex maiori de necessario et miniori de inesse sequitur 
             con<lb ed="#V" n="107" break="no"/>clusio de necessario: sed omnia prescita de necessitate 
-            eue<lb ed="#V" n="108" break="no"/>nient: et omnia futura sunt a deo praescita: ergo ominia futura de 
+            eue<lb ed="#V" n="108" break="no"/>nient: et omnia futura sunt a deo praescita: ergo omnia futura de 
             <lb ed="#V" n="109"/>necessitate euenient.
           </p>
           <p xml:id="kzz7yh-a81516-d1e1064">
@@ -610,7 +610,7 @@
             abso<lb ed="#V" n="121" break="no"/>lute est necessarium. 
           </p>
           <p xml:id="kzz7yh-a81516-d1e1097">
-            <lb ed="#V" n="122"/>Contra. <ref xml:id="kzz7yh-a81516-Rd1e1171">Aug. 3 de libro arbitrio</ref> longe potest prineipium 
+            <lb ed="#V" n="122"/>Contra. <ref xml:id="kzz7yh-a81516-Rd1e1171">Aug. 3 de libro arbitrio</ref> longe potest principium 
             <lb ed="#V" n="123"/>Sicut memoria tua non cognoscit facta esse 
             <lb ed="#V" n="124"/>que preterierunt: sic deus praescientia sua non cogit faciendo 
             <lb ed="#V" n="125"/>que futura sunt: sed propter nihil aliud quam propter diuinam 
@@ -641,7 +641,7 @@
             <lb ed="#V" n="2"/>futura sunt: nec possit suturum verum conuerti in falsum: fati 
             ne<lb ed="#V" n="3" break="no"/>cessitatem confirmant. et cito post subdit. hi enim hominem 
             vo<lb ed="#V" n="4" break="no"/>luntate libera spoliant: necessitate sati deuincunt: et cum 
-            <lb ed="#V" n="5"/>recitauit Tul. inconueneiens ad quod illi ducunt nisi ita esset: quia 
+            <lb ed="#V" n="5"/>recitauit Tul. inconueniens ad quod illi ducunt nisi ita esset: quia 
             <lb ed="#V" n="6"/>vt ipsi dicunt: non omnis enunciatio esset vera aut falsa 
             <lb ed="#V" n="7"/>nisi esset. Postea subdit: hic primum si mihi libeat assentire 
             <lb ed="#V" n="8"/>episcopo et negare communem enunciacionem aut veram esse aut 
@@ -672,7 +672,7 @@
             <lb ed="#V" n="29"/>et relata ad divinam prescientiam sunt de necessitate ventura: videtur 
             <lb ed="#V" n="30"/>quod omnibus computatis omnia futura de necessitate euenient. 
             <lb ed="#V" n="31"/>Ideo videtur alis dicendum quod secundum <ref xml:id="kzz7yh-a81516-Rd1e1292">Ansel in 
-              <lb ed="#V" n="32"/>lib. de concor.</ref> praescientie: et libero arbrtio 
+              <lb ed="#V" n="32"/>lib. de concor.</ref> praescientie: et libero arbitrio 
             <lb ed="#V" n="33"/>non vltra post principium. Duplex est necessitas vna 
             praece<lb ed="#V" n="34" break="no"/>dens que facit rem esse: et vna sequens: que nihil cogit 
             <lb ed="#V" n="35"/>esse: loquendo de prima necessitate non est verum quod omnia 
@@ -714,7 +714,7 @@
             <lb ed="#V" n="64"/>¶ Ad 3m cum dicitur quod pariter necesse est fuisse omne quod fuit 
             <lb ed="#V" n="65"/>et omne quod est et futurum esse quod erit etc. dico quod hoc sic 
             intel<lb ed="#V" n="66" break="no"/>ligendum est: quod sicut illud quod fuit non potest non fuisse: ita non 
-            <lb ed="#V" n="67"/>est possibile: vt aliquid sit futurum: et non euemat 
+            <lb ed="#V" n="67"/>est possibile: vt aliquid sit futurum: et non eueniat 
             coniunctim<lb ed="#V" n="68" break="no"/>accipiendo. Ista enim duo sunt incompossibilia: hoc est fu¬ 
             <!--00254.xml-->
             <cb ed="#P" n="b"/>
@@ -724,7 +724,7 @@
           </p>
           <p xml:id="kzz7yh-a81516-d1e1319">
             ¶ Ad 4m cum 
-            <lb ed="#V" n="72"/>dicitur quod ex minori de necessario et miniori de inees sequitur 
+            <lb ed="#V" n="72"/>dicitur quod ex minori de necessario et miniori de inesse sequitur 
             con<lb ed="#V" n="73" break="no"/>clusio de necessario etc. dico quod hoc intelligendum est quando 
             <lb ed="#V" n="74"/>minor est de inesse simpliciter: sed ista que fuit minor in 
             argu<lb ed="#V" n="75" break="no"/>mento scilicet quod omnia futura sunt a deo prescita non est de inesse 


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve07v1_kzz7yh-a81516.xml`.

## Applied changes

- p. 119v l. 121: opetet → oportet: missing or
- p. 119r l. 124: dinum → divinum: missing vi — transcription error
- p. 119v l. 15: hitum → habitum: ha- lost at line start — transcription error
- p. 119v l. 22: hitum → habitum: ha- lost at line start — transcription error
- p. 119v l. 32: viltra → vltra: extra i — transcription error
- p. 119v l. 42: ominio → omnino: missing n — transcription error
- p. 119v l. 43: ralationis → relationis: a/e misread — transcription error
- p. 119v l. 56: dina → divina: missing vi — transcription error
- p. 119v l. 62: ralationis → relationis: a/e misread — transcription error
- p. 119v l. 91: dinus → divinus: missing vi — transcription error
- p. 119v l. 94: dinus → divinus: missing vi — transcription error
- p. 119v l. 133: fassitas → falsitas: ss/ls misread — transcription error
- p. 120r l. 2: dinus → divinus: missing vi — transcription error
- p. 120r l. 17: sehabere → se habere: missing space — transcription error
- p. 120r l. 33: principsium → principium: spurious s — transcription error
- p. 120r l. 108: ominia → omnia: spurious i — transcription error
- p. 120r l. 122: prineipium → principium: e/c misread — transcription error
- p. 120v l. 5: inconueneiens → inconueniens: doubled ei — transcription error
- p. 120v l. 32: arbrtio → arbitrio: missing i — transcription error
- p. 120v l. 67: euemat → eueniat: missing ni — transcription error
- p. 120v l. 72: inees → inesse: missing letters — transcription error

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_