### PR TITLE
Transcription corrections: cod-ve07v1_kzz7yh-a82814.xml (2 changes)

### DIFF
--- a/kzz7yh-a82814/cod-ve07v1_kzz7yh-a82814.xml
+++ b/kzz7yh-a82814/cod-ve07v1_kzz7yh-a82814.xml
@@ -56,7 +56,7 @@
         <head xml:id="kzz7yh-a82814-Hd1e101">Circa litteram</head>
         <p xml:id="kzz7yh-a82814-d1e103">
           <lb ed="#V" n="102"/>3 CIrca litteram. (Nec aliter sciuit creata noscilicet quo 
-          <lb ed="#V" n="103"/>ad modum cognitonis exparte 
+          <lb ed="#V" n="103"/>ad modum cognitionis exparte 
           cognoscen<lb ed="#V" n="104" break="no"/>tis: sed aliter quantum ad modum ex parte 
           cognoscibi<lb ed="#V" n="105" break="no"/>lis: quia creanda cognoscit esse futura per 
           comperatio<lb ed="#V" n="106" break="no"/>nem ad praesens creatum et creata cognoscit esse: et praesentia: et 
@@ -70,7 +70,7 @@
           <lb ed="#V" n="114"/>nulli reuelat casum suum ne de desperet. Respondeo casum 
           <lb ed="#V" n="115"/>irreparabilem creature: deus illi creature non reuelat sub 
           cer<lb ed="#V" n="116" break="no"/>titudine et absolute: ne illa creatura desperare cogeretur: 
-          ta<lb ed="#V" n="117" break="no"/>men casum creature reperabilem aliquando illi reuelat. et quandoque 
+          ta<lb ed="#V" n="117" break="no"/>men casum creature reparabilem aliquando illi reuelat. et quandoque 
           <lb ed="#V" n="118"/>reuelat illi casum suum irreparabilem conditionaliter: tamen et 
           commi<lb ed="#V" n="119" break="no"/>natorie: quia quando sit illa reuelatio: sit salua liberi ar. libertate 
           <lb ed="#V" n="120"/>(Illorum peccata praesciuit non sua). q. d. si sua praescientia eos ad 

--- a/kzz7yh-a82814/cod-ve07v1_kzz7yh-a82814.xml
+++ b/kzz7yh-a82814/cod-ve07v1_kzz7yh-a82814.xml
@@ -55,7 +55,7 @@
       <div xml:id="kzz7yh-a82814"><!-- l1d38cl -->
         <head xml:id="kzz7yh-a82814-Hd1e101">Circa litteram</head>
         <p xml:id="kzz7yh-a82814-d1e103">
-          <lb ed="#V" n="102"/>3 CIrca litteram. (Nec aliter sciuit creata noscilicet quo 
+          <lb ed="#V" n="102"/>3 CIrca litteram. (Nec aliter sciuit creata) non scilicet quo 
           <lb ed="#V" n="103"/>ad modum cognitionis exparte 
           cognoscen<lb ed="#V" n="104" break="no"/>tis: sed aliter quantum ad modum ex parte 
           cognoscibi<lb ed="#V" n="105" break="no"/>lis: quia creanda cognoscit esse futura per 


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve07v1_kzz7yh-a82814.xml`.

## Applied changes

- p. 120v l. 103: cognitonis → cognitionis: missing i — transcription error
- p. 120v l. 117: reperabilem → reparabilem: spurious e — transcription error

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_