### PR TITLE
Transcription corrections: cod-ve07v1_kzz7yh-a83276.xml (9 changes)

### DIFF
--- a/kzz7yh-a83276/cod-ve07v1_kzz7yh-a83276.xml
+++ b/kzz7yh-a83276/cod-ve07v1_kzz7yh-a83276.xml
@@ -151,7 +151,7 @@
           </p>
           <p xml:id="kzz7yh-a83276-d1e255">
             ¶ Contra quam opinionem dicunt 
-            <lb ed="#V" enim="87"/>aliqui esse plures auctoritates. Dicit n Anselmus in de concordia 
+            <lb ed="#V" n="87"/>aliqui esse plures auctoritates. Dicit enim Anselmus in de concordia 
             pre<lb ed="#V" n="88" break="no"/>scientie: et libero arbitrio longe post poeniteoa quod quamuis ibi nihil sit nisi poenientus: 
             <lb ed="#V" n="89"/>non est tamen illud temporale: sicut nostrm: sed eternu: in quo cuncta 
             <lb ed="#V" n="90"/>tempora continentur: siudem quemadmodum praesens tempus continet omnem 

--- a/kzz7yh-a83276/cod-ve07v1_kzz7yh-a83276.xml
+++ b/kzz7yh-a83276/cod-ve07v1_kzz7yh-a83276.xml
@@ -153,7 +153,7 @@
             ¶ Contra quam opinionem dicunt 
             <lb ed="#V" n="87"/>aliqui ese prloes auctoritates. Dicit. n Aqnlelin in de concor 
             pare<lb ed="#V" n="88" break="no"/>scientie: et libero arbitrio longe post poeniteoa quod quamuis ibi nihil sit nisi poenientus: 
-            <lb ed="#V" n="89"/>non est tamen illud temporale: sicut nostrm: sed eternu: in quo cucta 
+            <lb ed="#V" n="89"/>non est tamen illud temporale: sicut nostrm: sed eternu: in quo cuncta 
             <lb ed="#V" n="90"/>tempora continentur: siudem quemadmodum prenenus chmpsous continet omnem 
             locun<lb ed="#V" n="91" break="no"/>et que in quolibet loco sunt: ita eterno praesti simui clauditur 
             <lb ed="#V" n="92"/>omne tempus et que sunt in quolibet tempore. Pretuo Ansel. in eodem 
@@ -195,7 +195,7 @@
             su<lb ed="#V" n="128" break="no"/>stinere hanc opinionem secundam possunt respondem ad arius quae sunt contra eam.
           </p>
           <p xml:id="kzz7yh-a83276-d1e349">
-            <lb ed="#V" n="129"/>Ad primum cum dicitur quod illa non coexistut que non 
+            <lb ed="#V" n="129"/>Ad primum cum dicitur quod illa non coexistunt que non 
             <lb ed="#V" n="130"/>existunt etc. dico quod verum est quod non 
             <lb ed="#V" n="131"/>coexistunt rei limitate non transcendenti nrm proesenus: nec etiam 
             <!--00257.xml-->
@@ -236,7 +236,7 @@
             <lb ed="#V" n="24"/>deus iudicat illa esse praesentia: sed iudicat quod illa aliquando erunt. 
           </p>
           <p xml:id="kzz7yh-a83276-d1e424">
-            <lb ed="#V" n="25"/>¶ Ad 5m dicendum quod sic divina essentia compeohendit omina loca: ita 
+            <lb ed="#V" n="25"/>¶ Ad 5m dicendum quod sic divina essentia comprehendit omina loca: ita 
             <lb ed="#V" n="26"/>eternitas omnia tempora. vnde quamuis ea quae non sunt non coesistant divine 
             <lb ed="#V" n="27"/>essentie in loco: ex hoc non poterit inferri quod ea que non sunt 
             <lb ed="#V" n="28"/>non coesistant eternitati: sed debes inferre quod ea que nec 
@@ -246,13 +246,13 @@
             <lb ed="#V" n="30"/>¶ Ad 6m quod arguebatur per illam glosam ad Ro. X. dicendum quod 
             eli<lb ed="#V" n="31" break="no"/>gendos apod se habunit non in natura sui ipeius: quia non erant in deo 
             <lb ed="#V" n="32"/>per modum rei intrinsece: nec etiam in natura electorum 
-            inquan<lb ed="#V" n="33" break="no"/>tum sua eternitas est ante ominia: sed inquantum sua eternitas 
+            inquan<lb ed="#V" n="33" break="no"/>tum sua eternitas est ante omnia: sed inquantum sua eternitas 
             <lb ed="#V" n="34"/>complectebatur omnia futura: et quanuis uatura 
             electo<lb ed="#V" n="35" break="no"/>rum ab eterno non fuerit: tamen ab eterno omnino futura 
             <lb ed="#V" n="36"/>fuit.
           </p>
           <p xml:id="kzz7yh-a83276-d1e455">
-            ¶ Qui voluerit sustiuere primam opinionem potest 
+            ¶ Qui voluerit sustinere primam opinionem potest 
             <lb ed="#V" n="37"/>dicere ad rationem in oppositum quod quamuis eternitas sit 
             immen<lb ed="#V" n="38" break="no"/>sa: tamen futura non ei realiter existunt non propter defectum ex parte 
             immen<lb ed="#V" n="39" break="no"/>sitatis: que quantum ex parte sua potest simul comprehendere omnia 
@@ -324,11 +324,11 @@
             ¶ Iterum ipsum futurum 
             <lb ed="#V" n="76"/>et si sit in se contingens relatum tamen ad divinam scientiam est necessarium 
             <!--TODO: insert paragraph break here-->
-            <lb ed="#V" n="77"/>Sed contra hoc potest argui sic. Oppositum necestrii est impossibile: ergo si omne futurum est 
-            <lb ed="#V" n="78"/>necesarium percomperationem ad divinam scientiam. Opositum cuiusset 
+            <lb ed="#V" n="77"/>Sed contra hoc potest argui sic. Oppositum necessarii est impossibile: ergo si omne futurum est 
+            <lb ed="#V" n="78"/>necesarium percomperationem ad divinam scientiam. Oppositum cuiusset 
             fu<lb ed="#V" n="79" break="no"/>turi est impossibile: et ita nulla res quae est futura: potest non esse futura 
             <lb ed="#V" n="80"/>sed quia dicit: etiam quod sicut esse futurum relatum ad divinam 
-            scien<lb ed="#V" n="81" break="no"/>tiam necessarium est: ita oppsium cuilibet futuri relati ad divinam 
+            scien<lb ed="#V" n="81" break="no"/>tiam necessarium est: ita oppositum cuilibet futuri relati ad divinam 
             scie<lb ed="#V" n="82" break="no"/>tiam est impossibile quia sicut animam anticprsi esse futuram necessarium 
             <lb ed="#V" n="83"/>est per comperationem ad divinam scientiam: quanuis non sit necessarium 
             <lb ed="#V" n="84"/>absolute: ita animam antexprisi non esse futuram impossibile est per 
@@ -437,7 +437,7 @@
             mor<lb ed="#V" n="12" break="no"/>taliter peccaturum. Potest ergo priscire plura quam prescit. 
           </p>
           <p xml:id="kzz7yh-a83276-d1e776">
-            <lb ed="#V" n="13"/>Respondeo viletur differre dicere deum 
+            <lb ed="#V" n="13"/>Respondeo videtur differre dicere deum 
             pos<lb ed="#V" n="14" break="no"/>se prescire aliquid quod non prescit 
             <lb ed="#V" n="15"/>et deum posse prescire plura quam prescit: quamuis enim deum 
             <lb ed="#V" n="16"/>posse prescire aliquid quod non prescit non sit possibile 

--- a/kzz7yh-a83276/cod-ve07v1_kzz7yh-a83276.xml
+++ b/kzz7yh-a83276/cod-ve07v1_kzz7yh-a83276.xml
@@ -151,10 +151,10 @@
           </p>
           <p xml:id="kzz7yh-a83276-d1e255">
             ¶ Contra quam opinionem dicunt 
-            <lb ed="#V" n="87"/>aliqui ese prloes auctoritates. Dicit. n Aqnlelin in de concor 
-            pare<lb ed="#V" n="88" break="no"/>scientie: et libero arbitrio longe post poeniteoa quod quamuis ibi nihil sit nisi poenientus: 
+            <lb ed="#V" enim="87"/>aliqui esse plures auctoritates. Dicit n Anselmus in de concordia 
+            pre<lb ed="#V" n="88" break="no"/>scientie: et libero arbitrio longe post poeniteoa quod quamuis ibi nihil sit nisi poenientus: 
             <lb ed="#V" n="89"/>non est tamen illud temporale: sicut nostrm: sed eternu: in quo cuncta 
-            <lb ed="#V" n="90"/>tempora continentur: siudem quemadmodum prenenus chmpsous continet omnem 
+            <lb ed="#V" n="90"/>tempora continentur: siudem quemadmodum praesens tempus continet omnem 
             locun<lb ed="#V" n="91" break="no"/>et que in quolibet loco sunt: ita eterno praesti simui clauditur 
             <lb ed="#V" n="92"/>omne tempus et que sunt in quolibet tempore. Pretuo Ansel. in eodem 
             <lb ed="#V" n="93"/>libro dicit sic sciendum est quoque quia sicut praescientia non dicitur in deo 
@@ -191,7 +191,7 @@
             <lb ed="#V" n="124"/>tem huic loco: sed si dico de aliqua re quod proesenus est divinae essentie 
             <lb ed="#V" n="125"/>non inquantum ipsa est praesenus huic loco: sed imquantum transcendit hunc 
             <lb ed="#V" n="126"/>locum: ex hoc non sequitur illam rem esse praesentem huic loco: et satis: 
-            per<lb ed="#V" n="127" break="no"/>ex dicttu quomodo hoc exsitum ad propsium valeat applicari. Qui volunt 
+            per<lb ed="#V" n="127" break="no"/>ex dictis quomodo hoc exemplum ad propositum valeat applicari. Qui volunt 
             su<lb ed="#V" n="128" break="no"/>stinere hanc opinionem secundam possunt respondem ad arius quae sunt contra eam.
           </p>
           <p xml:id="kzz7yh-a83276-d1e349">
@@ -201,7 +201,7 @@
             <!--00257.xml-->
             <pb ed="#V" n="122-r"/>
             <cb ed="#P" n="a"/>
-            <lb ed="#V" n="1"/>rei illimitate imquantum sibi coexisistit nostrum proesens: eternitas autem 
+            <lb ed="#V" n="1"/>rei illimitate imquantum sibi <sic>coexisistit</sic> nostrum proesens: eternitas autem 
             <lb ed="#V" n="2"/>est duro illimitata: et ideo futura: quamuis non sint: tamen bene 
             coexi<lb ed="#V" n="3" break="no"/>stunt eternitati non inquantum eternitas coexistit nostro praesenti: sed 
             <lb ed="#V" n="4"/>inquantum ratione sue immensitatis est vt ita loquer. vltra nosterum proesens 
@@ -211,12 +211,12 @@
             ¶ Ad 2m dicendum quod sicut dicimus quod futura sunt 
             rea<lb ed="#V" n="6" break="no"/>liter praesentia eternitati non imquantum coexistit nostro praesenti: nec imquam 
             <lb ed="#V" n="7"/>tum transcendit esse proesens creatum in infinitum a parte ante: sed imquantum 
-            <lb ed="#V" n="8"/>transcendit proesens creatum in insinitum a parte post: sic dico aliqualie 
+            <lb ed="#V" n="8"/>transcendit proesens creatum in infinitum a parte post: sic dico aliqualiter 
             <lb ed="#V" n="9"/>a simili quod omnia futura fuerunt eternitati realiter praesentia ab eterno: 
             <lb ed="#V" n="10"/>nec ex hoc sequitur quod ab eterno fuerunt: quia non ponuntur fuisse realiter 
             <lb ed="#V" n="11"/>praesentia eternitati ante mundum constitutionem: inquantum eternitas 
             <lb ed="#V" n="12"/>fuit ante principium instans temporis in infinitum: sed inquantum complectebatur 
-            <lb ed="#V" n="13"/>omnia futura tempora quia sicut dicit Anselis prosolus 20. c. Deus est ante 
+            <lb ed="#V" n="13"/>omnia futura tempora quia sicut dicit Anselmius prosologion 20. c. Deus est ante 
             <lb ed="#V" n="14"/>omnia et vltra omnia.
           </p>
           <p xml:id="kzz7yh-a83276-d1e397">
@@ -244,10 +244,10 @@
           </p>
           <p xml:id="kzz7yh-a83276-d1e437">
             <lb ed="#V" n="30"/>¶ Ad 6m quod arguebatur per illam glosam ad Ro. X. dicendum quod 
-            eli<lb ed="#V" n="31" break="no"/>gendos apod se habunit non in natura sui ipeius: quia non erant in deo 
+            eli<lb ed="#V" n="31" break="no"/>gendos apud se habuit non in natura sui ipsius: quia non erant in deo 
             <lb ed="#V" n="32"/>per modum rei intrinsece: nec etiam in natura electorum 
             inquan<lb ed="#V" n="33" break="no"/>tum sua eternitas est ante omnia: sed inquantum sua eternitas 
-            <lb ed="#V" n="34"/>complectebatur omnia futura: et quanuis uatura 
+            <lb ed="#V" n="34"/>complectebatur omnia futura: et quanuis <sic>uatura</sic> 
             electo<lb ed="#V" n="35" break="no"/>rum ab eterno non fuerit: tamen ab eterno omnino futura 
             <lb ed="#V" n="36"/>fuit.
           </p>
@@ -264,7 +264,7 @@
             <lb ed="#V" n="42"/>praesentialitate que est per ideas quantum ad bona futura: et de 
             poeste<lb ed="#V" n="43" break="no"/>tialitate quantum ad esse in cognitione obiectiue quantum ad 
             <lb ed="#V" n="44"/>bona et mala. Omnia enim futura sunt a deo cognita et sunt 
-            secunda<lb ed="#V" n="45" break="no"/>rium obiectum cognitionis: et hic raesponsio concordare videtur sententie magistre 
+            secunda<lb ed="#V" n="45" break="no"/>rium obiectum cognitionis: et haec responsio concordare videtur sententie magistri 
             <lb ed="#V" n="46"/>supra. 36. Di. c. i. vbi dicitque praesentia dei in qua sunt omnia 
             <lb ed="#V" n="47"/>ipsius cognitio est.
           </p>
@@ -307,7 +307,7 @@
             respe<lb ed="#V" n="65" break="no"/>ctu secundum dici: non propter hoc sit aliqua mutatio in re: ergo posito. 
             <lb ed="#V" n="66"/>quod deus non praesciat illud quod prescit: non propter hoc sequitur quod sit 
             <lb ed="#V" n="67"/>aliqua mutatio in divino scire. Sed non propter aliud negatur deum 
-            <lb ed="#V" n="68"/>posse non praescire illud quod prescit: nisi aduitandum mutabilita 
+            <lb ed="#V" n="68"/>posse non praescire illud quod prescit: nisi <sic>aduitandum</sic> mutabilita 
             <!--00257.xml-->
             <cb ed="#P" n="b"/>
             <lb ed="#V" n="69"/>tem in diuino scire ergo non est negandum deum posse 
@@ -316,8 +316,8 @@
           <p xml:id="kzz7yh-a83276-d1e559">
             <lb ed="#V" n="71"/>Ad istam quaestionem dit aliqui quod deum posse non praescire 
             ve<lb ed="#V" n="72" break="no"/>non praesciuisse illud quod praescit simpliciter falsum est. 
-            <lb ed="#V" n="73"/>Prescire enim duo dicit scilicet actum divinae scientie tanquam pncipale 
-            signo<lb ed="#V" n="74" break="no"/>tum: et aliquid esse futurum tanquam connotatum. Actus autem divinae 
+            <lb ed="#V" n="73"/>Prescire enim duo dicit scilicet actum divinae scientie tanquam principale 
+            signa<lb ed="#V" n="74" break="no"/>tum: et aliquid esse futurum tanquam connotatum. Actus autem divinae 
             <lb ed="#V" n="75"/>scientie non potest non esse: vel non fuisse.
           </p>
           <p xml:id="kzz7yh-a83276-d1e572">
@@ -354,8 +354,8 @@
             <lb ed="#V" n="98"/>non fuisse.
           </p>
           <p xml:id="kzz7yh-a83276-d1e631">
-            ¶ Item circunscripta futuraitione hitudo ipsius 
-            reri<lb ed="#V" n="99" break="no"/>inquantum scita est ad divinum scire: necessaria est. Necesarium est 
+            ¶ Item circunscripta futuraitione habitudo ipsius 
+            rei<lb ed="#V" n="99" break="no"/>inquantum scita est ad divinum scire: necessaria est. Necesarium est 
             <lb ed="#V" n="100"/>enim deum scire omnia notitia simplicis intelligentie. Futuratio tamen 
             <lb ed="#V" n="101"/>ipsius rei scire contingens est inquantum illa res non euenire potest 
             <lb ed="#V" n="102"/>et ideo ipsum praescire ratione illius futuronis sine quae scire dei non 


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve07v1_kzz7yh-a83276.xml`.

## Applied changes

- p. 121v l. 89: cucta → cuncta: missing n — transcription error
- p. 121v l. 129: coexistut → coexistunt: missing n — transcription error
- p. 122r l. 25: compeohendit → comprehendit: garbled — transcription error
- p. 122r l. 33: ominia → omnia: spurious i — transcription error
- p. 122r l. 36: sustiuere → sustinere: u/n misread — transcription error
- p. 122r l. 77: necestrii → necessarii: garbled — transcription error
- p. 122r l. 78: Opositum → Oppositum: missing p — transcription error
- p. 122r l. 81: oppsium → oppositum: garbled — transcription error
- p. 122v l. 13: viletur → videtur: l/d misread — transcription error

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_