### PR TITLE
Transcription corrections: cod-ve07v1_kzz7yh-a84085.xml (3 changes)

### DIFF
--- a/kzz7yh-a84085/cod-ve07v1_kzz7yh-a84085.xml
+++ b/kzz7yh-a84085/cod-ve07v1_kzz7yh-a84085.xml
@@ -412,7 +412,7 @@
             <lb ed="#V" n="20"/>ipsa nominat formaliter: et sic idem est 
             <lb ed="#V" n="21"/>quod ratio ordinis rerum in finem suum: que ratio est in 
             sum<lb ed="#V" n="22" break="no"/>mo omnium principe constituta. Potest etiam accipi pro executione 
-            <lb ed="#V" n="23"/>et admtratione huius ordinis: que gubernatio dicitur et 
+            <lb ed="#V" n="23"/>et admiratione huius ordinis: que gubernatio dicitur et 
             prouiden<lb ed="#V" n="24" break="no"/>tia: hoc modo accepta dependet ex prouidentia primo dicta. 
             <lb ed="#V" n="25"/>Loquendo de prouidentia primomon planum est quod deus immediate 
             <lb ed="#V" n="26"/>omnibus prouidet: quia in suo intellectu habet immediate rationem omnium 

--- a/kzz7yh-a84085/cod-ve07v1_kzz7yh-a84085.xml
+++ b/kzz7yh-a84085/cod-ve07v1_kzz7yh-a84085.xml
@@ -391,7 +391,7 @@
             ¶ Item Augu. 8. super Gensiem longe 
             <lb ed="#V" n="7"/>ante medium loquens de bipertito modo opere prouidentie 
             <lb ed="#V" n="8"/>naturalis scilicet et voluntarie dicit quod voluntaria 
-            administran<lb ed="#V" n="9"/>tur per angelorum opera et hominum: ergo videtur quod deus non 
+            administran<lb ed="#V" n="9" break="no"/>tur per angelorum opera et hominum: ergo videtur quod deus non 
             <lb ed="#V" n="10"/>omnibus prouidet immediate.
           </p>
           <p xml:id="kzz7yh-a84085-d1e713">
@@ -414,10 +414,10 @@
             sum<lb ed="#V" n="22" break="no"/>mo omnium principe constituta. Potest etiam accipi pro executione 
             <lb ed="#V" n="23"/>et admtratione huius ordinis: que gubernatio dicitur et 
             prouiden<lb ed="#V" n="24" break="no"/>tia: hoc modo accepta dependet ex prouidentia primo dicta. 
-            <lb ed="#V" n="25"/>Loquendo de prouidetia primomon planum est quod deus immediate 
+            <lb ed="#V" n="25"/>Loquendo de prouidentia primomon planum est quod deus immediate 
             <lb ed="#V" n="26"/>omnibus prouidet: quia in suo intellectu habet immediate rationem omnium 
             <lb ed="#V" n="27"/>etiam minimorum. Loquendo de prouidentia 2o modo: sic dico quod 
-            quo<lb ed="#V" n="28" break="no"/>busdam prouidet mediantibus aliis: quia inferiora gubennat per 
+            quo<lb ed="#V" n="28" break="no"/>busdam prouidet mediantibus aliis: quia inferiora gubernat per 
             superio<lb ed="#V" n="29" break="no"/>ra vnde <ref xml:id="kzz7yh-a84085-Rd1e825">Aug. de trinitate. c. 4.</ref> dicit de deo quod tanquam in excelsa et 
             <lb ed="#V" n="30"/>sancta et secreta sede praesidens velut in domo sua et in templo 
             <lb ed="#V" n="31"/>suo inde se quibusdam ordinatissimis creature motibus primo 


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve07v1_kzz7yh-a84085.xml`.

## Applied changes

- p. 123v l. 9: 'administran' + 'tur' split across line break without break="no" on lb n=9
- p. 123v l. 25: prouidetia → prouidentia: missing n
- p. 123v l. 28: gubennat → gubernat: extra n

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_