### PR TITLE
Transcription corrections: cod-ve07v1_kzz7yh-a85314.xml (5 changes)

### DIFF
--- a/kzz7yh-a85314/cod-ve07v1_kzz7yh-a85314.xml
+++ b/kzz7yh-a85314/cod-ve07v1_kzz7yh-a85314.xml
@@ -143,7 +143,7 @@
             <!--00262.xml-->
             <cb ed="#P" n="b"/>
             <lb ed="#V" n="69"/>tio est gratie preperatio: ibi subiungitur: comprehendens etiam 
-            glo<lb ed="#V" n="70" break="no"/>riam: ita tamen conotat sanctum effectum in 
+            glo<lb ed="#V" n="70" break="no"/>riam: ita tamen <sic>conotat</sic> sanctum effectum in 
             predestinato<lb ed="#V" n="71" break="no"/>quod ille effectus in reali et actuali existentia et ipsa 
             praedestina<lb ed="#V" n="72" break="no"/>tio simui esse non possunt. Illum enim qui iam saluatus est 
             <lb ed="#V" n="73"/>deus non praedestinat: sicut rem per quam proesenus est: deus non 
@@ -201,7 +201,7 @@
           </p>
           <p xml:id="kzz7yh-a85314-d1e362">
             <lb ed="#V" n="106"/>Contra praedestinatio est species dine prescientie. Sed 
-            <lb ed="#V" n="107"/>vomina prescita ab eterno sunt prescita: ergo 
+            <lb ed="#V" n="107"/>omina prescita ab eterno sunt prescita: ergo 
             <lb ed="#V" n="108"/>omnes predestinati ab eterno sunt predestinati.
           </p>
           <p xml:id="kzz7yh-a85314-d1e372">
@@ -216,7 +216,7 @@
             <lb ed="#V" n="114"/>sunt scilicet principale significatum: quod est dei scientia practica: 
             tem<lb ed="#V" n="115" break="no"/>porale connotatum: vt futurum scilicet finalis gratia: et 
             perpetua<lb ed="#V" n="116" break="no"/>gloria: et antecessio principalis significati ad connotatum 
-            <lb ed="#V" n="117"/>sed significatum: hoc est scientia dei practica eretnum est: et 
+            <lb ed="#V" n="117"/>sed significatum: hoc est scientia dei practica <sic>eretnum</sic> est: et 
             <lb ed="#V" n="118"/>illa antecessio eterna est: et connotatum ab eterno fuit futurum 
             <lb ed="#V" n="119"/>ergo predestinatio ab eterno est. 
           </p>
@@ -282,8 +282,8 @@
             <lb ed="#V" n="21"/>angelis bonis et malis. 
           </p>
           <p xml:id="kzz7yh-a85314-d1e510">
-            <lb ed="#V" n="22"/>Contra magiter cap. vlti. huius Di. dicit quod 
-            predestia<lb ed="#V" n="23" break="no"/>tio est scientia: et preperatio beneficiorum dei 
+            <lb ed="#V" n="22"/>Contra magister cap. vlti. huius Di. dicit quod 
+            predestina<lb ed="#V" n="23" break="no"/>tio est scientia: et preperatio beneficiorum dei 
             <lb ed="#V" n="24"/>quibus certissime liberantur quicunque liberantur. Et hoc 
             sum<lb ed="#V" n="25" break="no"/>ptum est ab Augu. in libro de bono perseuerantie quasi circa 
             <lb ed="#V" n="26"/>medium: sed liberari non conuenit nisi hominibus: Angeli enim 
@@ -325,7 +325,7 @@
             ¶ Ad 
             <lb ed="#V" n="52"/>3m dicendum quod Ansel. in illa auctoritate accepit predestinationem 
             <lb ed="#V" n="53"/>pro praeparatione cuiuscunque finalis retributionis: et sicut 
-            <lb ed="#V" n="54"/>fuisse perdestinatum connenit hominibus et angelis electis: et 
+            <lb ed="#V" n="54"/>fuisse perdestinatum <sic>connenit</sic> hominibus et angelis electis: et 
             trpro<lb ed="#V" n="55" break="no"/>bis. vnde Ansel. ibi improprie accepit nomen predestinationis. 
           </p>
           <p xml:id="kzz7yh-a85314-d1e598">

--- a/kzz7yh-a85314/cod-ve07v1_kzz7yh-a85314.xml
+++ b/kzz7yh-a85314/cod-ve07v1_kzz7yh-a85314.xml
@@ -176,12 +176,12 @@
           <head xml:id="kzz7yh-a85314-Hd1e316">Quaestio 2</head>
           <p xml:id="kzz7yh-a85314-d1e318">
             <lb ed="#V" n="89"/>¶ Questio. II. 
-            <lb ed="#V" n="90"/>Ecundo queritur vtrum praedestinatio sit 
+            <lb ed="#V" n="90"/>Secundo queritur vtrum praedestinatio sit 
             eter<lb ed="#V" n="91" break="no"/>na et videtur quod non: quia 
             predesti<lb ed="#V" n="92" break="no"/>natio importat ordinem predestinantis ad predest: 
             <lb ed="#V" n="93"/>natum non ad praedestinatum secundum esse quod habet in 
             <lb ed="#V" n="94"/>deo: ergo secundum esse quod habet in genere proprio quod esse temporale 
-            <lb ed="#V" n="95"/>est: fed illud quod importat ordinem ad aliquid temporale non est 
+            <lb ed="#V" n="95"/>est: sed illud quod importat ordinem ad aliquid temporale non est 
             <lb ed="#V" n="96"/>eternum: ergo praedestinatio non est eterna.
           </p>
           <p xml:id="kzz7yh-a85314-d1e338">
@@ -222,7 +222,7 @@
           </p>
           <p xml:id="kzz7yh-a85314-d1e401">
             <lb ed="#V" n="120"/>Ad primum i oppicum der quod iuis quod iportat 
-            or<lb ed="#V" n="121" break="no"/>dine ad aliquid temperale non est 
+            or<lb ed="#V" n="121" break="no"/>dine ad aliquid temporale non est 
             eter<lb ed="#V" n="122" break="no"/>num etc. dico quod verum est cum importat ordinem ad 
             tempo<lb ed="#V" n="123" break="no"/>rale: vt presens. predestinatio vero importat ordinem ad 
             ali<lb ed="#V" n="124" break="no"/>quid temporale non vt proaesens sit: sed vt futurum.
@@ -250,7 +250,7 @@
             <lb ed="#V" n="1"/>in praedestinato: quia secundum originem in glosa ad Ro i. 
             Prede<lb ed="#V" n="2" break="no"/>stinatur qui non est: et sicut dicit Auice i. Metaphy. sue. c. 
             <lb ed="#V" n="3"/>i. Non ens non habet proprietatem que est. restat ergo quod illa re 
-            <lb ed="#V" n="4"/>latio sit secundum rationem: ex quo sequitur quod non opetet quodlibet 
+            <lb ed="#V" n="4"/>latio sit secundum rationem: ex quo sequitur quod non oportet quodlibet 
             extre<lb ed="#V" n="5" break="no"/>mum huius relationis esse realiter in actu: sed vnum est realiter 
             <lb ed="#V" n="6"/>in actu scilicet praedestinans: aliud autem in esse cognito scilicet praedestinatus: 
             <lb ed="#V" n="7"/>quia omnes praedestinati ab eterno fuerunt cogniiti a deo.
@@ -298,8 +298,8 @@
           </p>
           <p xml:id="kzz7yh-a85314-d1e538">
             <lb ed="#V" n="32"/>Respondeo quod fuisse praedestinatum non conuenit 
-            so<lb ed="#V" n="33" break="no"/>lis hominibus: sed etiam angelis bea 
-            <lb ed="#V" n="34"/>tis: quia cum predestinatio sit prescientia practica salutis alicuius 
+            so<lb ed="#V" n="33" break="no"/>lis hominibus: sed etiam angelis 
+            bea<lb ed="#V" n="34" break="no"/>tis: quia cum predestinatio sit prescientia practica salutis alicuius 
             <lb ed="#V" n="35"/>et ordinationis ipsius in salutem: vt supra visum est: et hoc 
             <lb ed="#V" n="36"/>ab eterno in deo fuit non tantummodo respectu hominum: sed 
             re<lb ed="#V" n="37" break="no"/>spectu angelorum: videtur quod non solum hominibus conueniat 


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve07v1_kzz7yh-a85314.xml`.

## Applied changes

- p. 125r l. 4: opetet → oportet: missing or
- p. 125r l. 34: 'bea' + 'tis' split across line break without break="no" on lb n=34
- p. 124v l. 90: Ecundo → Secundo: S- lost at line start — transcription error
- p. 124v l. 95: fed → sed: f/s misread — transcription error
- p. 124v l. 121: temperale → temporale: e/o misread — transcription error

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_