### PR TITLE
Transcription corrections: cod-ve07v1_kzz7yh-a85827.xml (8 changes)

### DIFF
--- a/kzz7yh-a85827/cod-ve07v1_kzz7yh-a85827.xml
+++ b/kzz7yh-a85827/cod-ve07v1_kzz7yh-a85827.xml
@@ -94,7 +94,7 @@
             <lb ed="#V" n="74"/>non scribantur: ergo aliqui scripti sunt in libro vite: qui 
             postea<lb ed="#V" n="75" break="no"/>de illo delentur. Sed Augustinus xx. libro de ciui. dei. c. 15 liber 
             vi<lb ed="#V" n="76" break="no"/>te significat praedestinationem eorum quibus dabitur vita: ergo 
-            <lb ed="#V" n="77"/>aliqui praedstinati sunt quinon saluabuntur.
+            <lb ed="#V" n="77"/>aliqui praedstinati sunt qui non saluabuntur.
           </p>
           <p xml:id="kzz7yh-a85827-d1e169">
             ¶ Item Grego. 
@@ -119,7 +119,7 @@
             <lb ed="#V" n="88"/>predestinati non saluarentur. 
           </p>
           <p xml:id="kzz7yh-a85827-d1e204">
-            <lb ed="#V" n="89"/>Respondeo quod omnes praedestiati saluabutr: quia 
+            <lb ed="#V" n="89"/>Respondeo quod omnes praedestinati saluabuntur: quia 
             praede<lb ed="#V" n="90" break="no"/>stinatio est prescientia dei practica 
             salu<lb ed="#V" n="91" break="no"/>tis aliquorum et ordinationis ipsorum in salutem. Deus ergo 
             <lb ed="#V" n="92"/>prescit praedestinatos saluandos: et eos saluare proponit: ses 
@@ -318,8 +318,8 @@
             <lb ed="#V" n="89"/>constituisse apud se immutabiliter quod apud hominem priusquam fiat 
             <lb ed="#V" n="90"/>mutari potest: et Boe. 5 de consola. versus finem. Fatebor 
             rem<lb ed="#V" n="91" break="no"/>solidissime veritatis: sed cui vix aliquis nisi divini speculator 
-            <lb ed="#V" n="92"/>accesserit respondebo naturam idem futurum cum ad divinam notio 
-            <lb ed="#V" n="93"/>nem refertur necessarium: cum vero in sua natura perpenditur 
+            <lb ed="#V" n="92"/>accesserit respondebo naturam idem futurum cum ad divinam 
+            notio<lb ed="#V" n="93" break="no"/>nem refertur necessarium: cum vero in sua natura perpenditur 
             <lb ed="#V" n="94"/>liberum prorsus atque absolutum videri.
           </p>
           <p xml:id="kzz7yh-a85827-d1e580">
@@ -329,7 +329,7 @@
             <lb ed="#V" n="97"/>quomodo hoc sit possibile patet per illam veniam per quam ostensum 
             <lb ed="#V" n="98"/>est quod possibile est deum nunquam praedestinasse illos qui sunt 
             sal<lb ed="#V" n="99" break="no"/>uandi: cui sententie videtur consentire Ansel. in libro de concor. prescientie 
-            <lb ed="#V" n="100"/>et liberi arbtrii bene post principium dicens quod non est necesse deum 
+            <lb ed="#V" n="100"/>et liberi arbitrii bene post principium dicens quod non est necesse deum 
             <lb ed="#V" n="101"/>velle quod vult: et finis actus volendi secundum se absolute est 
             ne<lb ed="#V" n="102" break="no"/>cessarium.
           </p>
@@ -371,7 +371,7 @@
             prae<lb ed="#V" n="124" break="no"/>destinatorum augeatur: et videtur quod non: quia 
             <lb ed="#V" n="125"/>si aliqui possent praedestinari: qui non sunt praedestinati: 
             peri<lb ed="#V" n="126" break="no"/>ratione possent non praedestinari illi qui sunt praedestinati 
-            <lb ed="#V" n="127"/>sed non videtur verum quod predestinatus possit nonesse 
+            <lb ed="#V" n="127"/>sed non videtur verum quod predestinatus possit non esse 
             praede<lb ed="#V" n="128" break="no"/>stinatus: dicit enim Augu. in libro de bono perseuerantie 
             ma<lb ed="#V" n="129" break="no"/>gis prope finem libro quam prope medium quod non est dubitandum 
             <lb ed="#V" n="130"/>deum prescisse se esse daturum dona sua: et quibus daturus 
@@ -408,7 +408,7 @@
             praede<lb ed="#V" n="14" break="no"/>stinentur.
           </p>
           <p xml:id="kzz7yh-a85827-d1e735">
-            ¶ Item super illud psal. Qui numerat mltitudinem 
+            ¶ Item super illud psal. Qui numerat multitudinem 
             <lb ed="#V" n="15"/>stellarum: dicit glo. nouit deus quae sunt eius. Siquis vero ad non 
             <lb ed="#V" n="16"/>beata fidei specie se talibus interserit: nouit ille qui numerat: quia 
             su<lb ed="#V" n="17" break="no"/>pra numerum est. Unde aliqui multiplicati sunt super numerum 
@@ -465,10 +465,10 @@
             argue<lb ed="#V" n="56" break="no"/>batur per glo. super illud psal. Qui numerat multitudine stellarum 
             <lb ed="#V" n="57"/>Dico quod illa glosa soluitur per illud quod continue sequitur: quia post 
             <lb ed="#V" n="58"/>illud verbum multiplicati sunt super numerum immediate sub 
-            <lb ed="#V" n="59"/>iungitur: quia inter perietes praesentis ecclsie plures sunt quam 
+            <lb ed="#V" n="59"/>iungitur: quia inter parietes praesentis ecclesie plures sunt quam 
             futu<lb ed="#V" n="60" break="no"/>ri sint in regno dei. Tales ergo sunt in ecclesia ista 
             inferio<lb ed="#V" n="61" break="no"/>ri vltra numerum praedestinatorum sed cum predestinatus 
-            trium<lb ed="#V" n="62" break="no"/>phantem ecclsiam non intrabunt.
+            trium<lb ed="#V" n="62" break="no"/>phantem ecclesiam non intrabunt.
           </p>
           <p xml:id="kzz7yh-a85827-d1e855">
             ¶ Ad illud etiam quod 

--- a/kzz7yh-a85827/cod-ve07v1_kzz7yh-a85827.xml
+++ b/kzz7yh-a85827/cod-ve07v1_kzz7yh-a85827.xml
@@ -335,8 +335,8 @@
           </p>
           <p xml:id="kzz7yh-a85827-d1e601">
             ¶ Ad 4m cum dicitur quod impossibile est 
-            predestina<lb ed="#V" n="103" break="no"/>tum esse reprobatum etc. patere potest solutio per illud per quod osten 
-            <lb ed="#V" n="104"/>sum est deum potuisse non praedestinasse illos qui saluandi sunt 
+            predestina<lb ed="#V" n="103" break="no"/>tum esse reprobatum etc. patere potest solutio per illud per quod osten
+            <lb ed="#V" n="104" break="no"/>sum est deum potuisse non praedestinasse illos qui saluandi sunt 
           </p>
           <p xml:id="kzz7yh-a85827-d1e608">
             <lb ed="#V" n="105"/>¶ Ad 5m dicitur quod praedestinatus non potest non esse 

--- a/kzz7yh-a85827/cod-ve07v1_kzz7yh-a85827.xml
+++ b/kzz7yh-a85827/cod-ve07v1_kzz7yh-a85827.xml
@@ -304,7 +304,7 @@
             ¶ Ad 3m cum dicitur quod cum antes 
             <lb ed="#V" n="79"/>est necessarium et consena necessaria: consequens simpliciter est 
             neces<lb ed="#V" n="80" break="no"/>sarium etc. dicunt aliqui quod verum est per comperationem ad omnes: 
-            <lb ed="#V" n="81"/>non tamen opetet quod conseqens sit necessarium absolute: quod sic declarant: 
+            <lb ed="#V" n="81"/>non tamen oportet quod conseqens sit necessarium absolute: quod sic declarant: 
             <lb ed="#V" n="82"/>postquam christus predixit quod Petrus eum esset negaturus: hoc 
             <lb ed="#V" n="83"/>eum praedixisse fuit necessarium.
           </p>
@@ -335,7 +335,7 @@
           </p>
           <p xml:id="kzz7yh-a85827-d1e601">
             ¶ Ad 4m cum dicitur quod impossibile est 
-            predestina<lb ed="#V" n="103" break="no"/>tum esse reprobatum etc. patere potest solutio per illud per quod consten 
+            predestina<lb ed="#V" n="103" break="no"/>tum esse reprobatum etc. patere potest solutio per illud per quod osten 
             <lb ed="#V" n="104"/>sum est deum potuisse non praedestinasse illos qui saluandi sunt 
           </p>
           <p xml:id="kzz7yh-a85827-d1e608">
@@ -452,7 +452,7 @@
             pela<lb ed="#V" n="46" break="no"/>gianis donum praedestinationis etc. 
             <lb ed="#V" n="47"/>potest dici quod ibi vocat prdestinationis donum gratiam dei quae 
             <lb ed="#V" n="48"/>est praedestinationis effectus: vt videtur declarare littera sequens. 
-            <lb ed="#V" n="49"/>hoc autem douum optabat pelagianis: quia ignorabat vtrum 
+            <lb ed="#V" n="49"/>hoc autem <sic>douum</sic> optabat pelagianis: quia ignorabat vtrum 
             <lb ed="#V" n="50"/>aliquos illorum ab eterno praedestinasset: quia si aliqui de illis 
             ta<lb ed="#V" n="51" break="no"/>les erant: sciebat Aug. quod in suo errore non finaliter per 
             seue<lb ed="#V" n="52" break="no"/>rarent: et quia secundum quod dicit Aug. in eodem libero longe ante finem 


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve07v1_kzz7yh-a85827.xml`.

## Applied changes

- p. 125v l. 93: 'notio' + 'nem' split across line break without break="no" on lb n=93
- p. 125r l. 77: quinon → qui non: missing space — transcription error
- p. 125r l. 89: praedestiati → praedestinati: missing n — transcription error; saluabutr → saluabuntur: missing letters — transcription error
- p. 125v l. 100: arbtrii → arbitrii: missing i — transcription error
- p. 125v l. 127: nonesse → non esse: missing space — transcription error
- p. 126r l. 14: mltitudinem → multitudinem: missing u — transcription error
- p. 126r l. 59: perietes → parietes: e/a misread — transcription error; ecclsie → ecclesie: missing c — transcription error
- p. 126r l. 62: ecclsiam → ecclesiam: missing c — transcription error

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_