### PR TITLE
Fix: restore <head> structural tags lost in PR #636 (a74778)

### DIFF
--- a/kzz7yh-a74778/cod-ve07v1_kzz7yh-a74778.xml
+++ b/kzz7yh-a74778/cod-ve07v1_kzz7yh-a74778.xml
@@ -207,8 +207,8 @@
           </p>
         </div>
         <div xml:id="kzz7yh-a74778-Dd1e369">
-          Quaestio 2
-          Utrum cognoscat mala</head>
+          <head xml:id="kzz7yh-a74778-Hd1e371">Quaestio 2</head>
+          <head xml:id="kzz7yh-a74778-Hd1e384" type="question-title">Utrum cognoscat mala</head>
           <p xml:id="kzz7yh-a74778-d1e373">
             <lb ed="#V" n="114"/>¶ Questio. II. 
             <lb ed="#V" n="115"/>SEcundo queritur vtrum deus cognoscat 


### PR DESCRIPTION
Restores two `<head>` opening tags that were accidentally stripped when apply.py replaced `oldXml` with `newXml` across a structural tag boundary.

- `<head xml:id="kzz7yh-a74778-Hd1e371">Quaestio 2</head>`
- `<head xml:id="kzz7yh-a74778-Hd1e384" type="question-title">Utrum cognoscat mala</head>`