### PR TITLE
Transcription corrections: cod-ve07v1_kzz7yh-a87809.xml (4 changes)

### DIFF
--- a/kzz7yh-a87809/cod-ve07v1_kzz7yh-a87809.xml
+++ b/kzz7yh-a87809/cod-ve07v1_kzz7yh-a87809.xml
@@ -88,7 +88,7 @@
             ele<lb ed="#V" n="51" break="no"/>git neque ex tempore neque ab eterno. 
           </p>
           <p xml:id="kzz7yh-a87809-d1e161">
-            <lb ed="#V" n="52"/>Contra secundum <ref xml:id="kzz7yh-a87809-Rd1e175">apotolus ad Ephe. i</ref> elegit nos ante 
+            <lb ed="#V" n="52"/>Contra secundum <ref xml:id="kzz7yh-a87809-Rd1e175">apostolum ad Ephe. i</ref> elegit nos ante 
             mon<lb ed="#V" n="53" break="no"/>di constitutionem. 
           </p>
           <p xml:id="kzz7yh-a87809-d1e169">
@@ -169,13 +169,13 @@
             res<lb ed="#V" n="102" break="no"/>pectu futurorum bonorum principaliter et respectu 
             futu<lb ed="#V" n="103" break="no"/>rorum malorum propter bona. Ad bonum enim 
             prouiso<lb ed="#V" n="104" break="no"/>rem spectat non tantummodo bona ordinare: sed etiam quaedam 
-            <lb ed="#V" n="105"/>in illa prohibere et quedam mala permitttere: et actores eorum 
+            <lb ed="#V" n="105"/>in illa prohibere et quedam mala <sic>permitttere</sic>: et actores eorum 
             <lb ed="#V" n="106"/>punire: secundum quod preuidet expedire ordinationi bonorum in 
             <lb ed="#V" n="107"/>finem.
           </p>
           <p xml:id="kzz7yh-a87809-d1e320">
             ¶ Predestinatio vero est prouidentia non respectu 
-            quo<lb ed="#V" n="108" break="no"/>rumcumque futurorum: sed respectu saluandorum in gluatia: et 
+            quo<lb ed="#V" n="108" break="no"/>rumcumque futurorum: sed respectu saluandorum in gloria: et 
             repro<lb ed="#V" n="109" break="no"/>batio est prouidentia respectu damnatorum interminabili 
             pe<lb ed="#V" n="110" break="no"/>na. Sic ergo vides quod predestinatio est prouidentia: et 
             proui<lb ed="#V" n="111" break="no"/>dentia est prescientia: et prescientia est scientia: sed non conuertitur 

--- a/kzz7yh-a87809/cod-ve07v1_kzz7yh-a87809.xml
+++ b/kzz7yh-a87809/cod-ve07v1_kzz7yh-a87809.xml
@@ -92,7 +92,7 @@
             mon<lb ed="#V" n="53" break="no"/>di constitutionem. 
           </p>
           <p xml:id="kzz7yh-a87809-d1e169">
-            <lb ed="#V" n="54"/>Respondeo quod electio est duorum omstensorum ad 
+            <lb ed="#V" n="54"/>Respondeo quod electio est duorum ostensorum ad 
             <lb ed="#V" n="55"/>aliquid aliud ordinabilium quod est in 
             <lb ed="#V" n="56"/>potestate eligentis alterum alteri ad illud libere praeoptare vel 
             <lb ed="#V" n="57"/>alterum et non alterum ordinare. Oportet enim quod eligenda per 
@@ -190,7 +190,7 @@
           <p xml:id="kzz7yh-a87809-d1e346">
             ¶ 
             Re<lb ed="#V" n="119" break="no"/>probatio vero includit propositum permittendi reprobatos 
-            <lb ed="#V" n="120"/>permanere in obduraione finali: et retribuendi eis intermina 
+            <lb ed="#V" n="120"/>permanere in obduratione finali: et retribuendi eis intermina 
             <lb ed="#V" n="121"/>bilem penam propter eorum iniquitatem finalem
           </p>
           <p xml:id="kzz7yh-a87809-d1e355">
@@ -198,7 +198,7 @@
             Propo<lb ed="#V" n="122" break="no"/>situm vero est actus volendi tam respectu futurorum 
             agen<lb ed="#V" n="123" break="no"/>dorum quam permittendorum. Uult enim deus agere que 
             agen<lb ed="#V" n="124" break="no"/>da sunt: et permittere que permittenda sunt: quanuis enim deus 
-            <lb ed="#V" n="125"/>non velit mala futura: vel tamen permittere quod siant: prout tamen 
+            <lb ed="#V" n="125"/>non velit mala futura: vel tamen permittere quod fiant: prout tamen 
             <lb ed="#V" n="126"/>propositum est de ratione electionis: non est nisi respectu 
             sal<lb ed="#V" n="127" break="no"/>uandorum.
           </p>
@@ -207,7 +207,7 @@
             discretio<lb ed="#V" n="128" break="no"/>nem electi a suo contrario extendendo nomen contrarietatis ad 
             <lb ed="#V" n="129"/>illam differentiam que est inter bonos et malos: et inter 
             ma<lb ed="#V" n="130" break="no"/>gis bonos et minus bonos. Deus enim meliores elegit ad 
-            ali<lb ed="#V" n="131" break="no"/>quem gradum glarie: ad quem alios non elegit. Et sic patet 
+            ali<lb ed="#V" n="131" break="no"/>quem gradum gloriae: ad quem alios non elegit. Et sic patet 
             <lb ed="#V" n="132"/>quod propositum et electio formaliter dicunt actus voluntatis et 
             <!--00270.xml-->
             <pb ed="#V" n="128-v"/>


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve07v1_kzz7yh-a87809.xml`.

## Applied changes

- p. 128r l. 54: omstensorum → ostensorum: spurious 'om' prefix
- p. 128r l. 120: obduraione → obduratione: missing 't'
- p. 128r l. 125: siant → fiant: s/f misread
- p. 128r l. 131: glarie → gloriae: OCR misread of 'gloriae'

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_