### PR TITLE
Transcription corrections: cod-ve07v1_kzz7yh-a88116.xml (21 changes)

### DIFF
--- a/kzz7yh-a88116/cod-ve07v1_kzz7yh-a88116.xml
+++ b/kzz7yh-a88116/cod-ve07v1_kzz7yh-a88116.xml
@@ -177,7 +177,7 @@
           <p xml:id="kzz7yh-a88116-d1e316">
             ¶ Si autem consideramus 
             effe<lb ed="#V" n="81" break="no"/>ctum praedestinationis totaliter scilicet accipiendo omnes effectus 
-            <lb ed="#V" n="82"/>praedestinationis coniunctim: sic dico quod prescientia meritoum non 
+            <lb ed="#V" n="82"/>praedestinationis coniunctim: sic dico quod prescientia <sic>meritoum</sic> non 
             <lb ed="#V" n="83"/>est ratio quare deus praeordinauit se daturum aliquibus 
             praedestina<lb ed="#V" n="84" break="no"/>tionis totum effectum: quia omnis actus qui est in homine ordinans 
             <lb ed="#V" n="85"/>ipsum ad salutem etiam quantum ad initium totum 
@@ -237,7 +237,7 @@
             ¶ Item 
             <lb ed="#V" n="119"/>Augu. super Ioannem tractatu. 26. super illud verbum. Io. 6. 
             <lb ed="#V" n="120"/>Nemo potest venire ad me etc. quare hunc trahat et illum 
-            <lb ed="#V" n="121"/>non trahat noli velle diudicare si non vis errare: ergo 
+            <lb ed="#V" n="121"/>non trahat noli velle <sic>diudicare</sic> si non vis errare: ergo 
             vi<lb ed="#V" n="122" break="no"/>detur quod huius non sit alia ratio nisi tantum sua voluntas. 
           </p>
           <p xml:id="kzz7yh-a88116-d1e431">
@@ -271,7 +271,7 @@
             comprhen<lb ed="#V" n="10" break="no"/>ditur sub effectu predestinationis illius. 
           </p>
           <p xml:id="kzz7yh-a88116-d1e493">
-            <lb ed="#V" n="11"/>Alii dicunt quod quamuis perscia alicuius meriti non 
+            <lb ed="#V" n="11"/>Alii dicunt quod quamuis <sic>perscientia</sic> alicuius meriti non 
             <lb ed="#V" n="12"/>possit esse ratio nec necessitatis: nec 
             con<lb ed="#V" n="13" break="no"/>gruitatis ordinationis totius effectus praedestinationis ad actum 
             pre<lb ed="#V" n="14" break="no"/>destinationis: tamen huius est aliqua ratio apode deum: quia si non 
@@ -279,15 +279,15 @@
             oc<lb ed="#V" n="16" break="no"/>culta: sed manifesta nobis: quod falsum est: cum propter eius 
             oc<lb ed="#V" n="17" break="no"/>cultationem exclamet apostolus ad Ro. xi. O altitudo ditiarum 
             <lb ed="#V" n="18"/>sapientie et scientie dei quam incomprehensibilia sunt iudicia eius et 
-            inue<lb ed="#V" n="19" break="no"/>stigabiles vie eius. Dunt ergo quod ad hoc est ratio congruitatis: 
+            inue<lb ed="#V" n="19" break="no"/>stigabiles vie eius. Dicunt ergo quod ad hoc est ratio congruitatis: 
             quam<lb ed="#V" n="20" break="no"/>uis non sit nobis sub certitudine manifesta. vnde potest dici quod 
             <lb ed="#V" n="21"/>quia deus praesciuit aliquos si relinquerentur naturalibus suis cum 
             in<lb ed="#V" n="22" break="no"/>fluentia dei generali tantum: non ita cito consentire malo: vel non tot 
             <lb ed="#V" n="23"/>malis consentire: vel non tantis sicut facerent alii suis naturalibus 
             re<lb ed="#V" n="24" break="no"/>licti: ideo deus praeordinauit de congruo se daturum istius 
             praedena<lb ed="#V" n="25" break="no"/>tionis effectu: et non illis vel quia praesciuit aliquos cum equali gratia 
-            <lb ed="#V" n="26"/>non ita cito: vel non ita turpiter ab ea cadem: sicut si sibi 
-            di<lb ed="#V" n="27" break="no"/>mitterentur: ideo de congruo praeordinauit se manutenem istos per se 
+            <lb ed="#V" n="26"/>non ita cito: vel non ita turpiter ab ea cadere: sicut si sibi 
+            di<lb ed="#V" n="27" break="no"/>mitterentur: ideo de congruo praeordinauit se manutenere istos per se 
             <lb ed="#V" n="28"/>ipsum ne a gratia finaliter cadant et non alios: non consentire autem 
             <lb ed="#V" n="29"/>malo non semper est meritum nec semper est cum aliquo actu: et ideo dicunt 
             <lb ed="#V" n="30"/>quod ad hanc opinionem non sequitur quod prescientia alicuius meriti sit 
@@ -295,15 +295,15 @@
           </p>
           <p xml:id="kzz7yh-a88116-d1e541">
             <lb ed="#V" n="32"/>Sed contra hanc opinionem videtur esse: quia non tantummodo 
-            per<lb ed="#V" n="33" break="no"/>ficere: sed est non cadem in defectu videtur esse effectus 
+            per<lb ed="#V" n="33" break="no"/>ficere: sed est non cadere in defectu videtur esse effectus 
             praedestina<lb ed="#V" n="34" break="no"/>tionis divinae. vnde libro de ecclesiasticis dogmatibus. c. 20. Sicut 
             ini<lb ed="#V" n="35" break="no"/>tium salutis nostre deo miserante et inspirante habere nos credimus: 
-            <lb ed="#V" n="36"/>ita arbitrium nature nostre se: quax esse divine inspiraitionis libere 
+            <lb ed="#V" n="36"/>ita arbitrium nature nostre se: quae esse divine inspirationis libere 
             confite<lb ed="#V" n="37" break="no"/>mur: igitur vt non labamur a bono vel nature vel meriti 
-            solicitu<lb ed="#V" n="38" break="no"/>dinis nostre est et celestis periter adiutorii.
+            solicitu<lb ed="#V" n="38" break="no"/>dinis nostre est et celestis pariter adiutorii.
           </p>
           <p xml:id="kzz7yh-a88116-d1e559">
-            ¶ Premous si est aliqua 
+            ¶ Praeterea si est aliqua 
             <lb ed="#V" n="39"/>ratio quecumque sit illa quare deus praeordinauerit Iacob ad 
             ef<lb ed="#V" n="40" break="no"/>fectum praedestinationis et non Esau tunc rationabilius fuit 
             prae<lb ed="#V" n="41" break="no"/>destinare Iacob quam Esau: sed inconueniens est deum facere 
@@ -326,7 +326,7 @@
             <lb ed="#V" n="54"/>ordinis obiecti praedestinationis ad actum praedestinationis. Hoc enim 
             <lb ed="#V" n="55"/>est quia vult manifestare maxime misericordiam suam in effectum 
             <lb ed="#V" n="56"/>praedestinationis et iustitiam suam in effectu reprobonis. vnde 
-            <lb ed="#V" n="57"/>Aug. de ciui. dei li. 21. c. 12. Si omnes termanerent in penis iuste 
+            <lb ed="#V" n="57"/>Aug. de ciui. dei li. 21. c. 12. Si omnes remanerent in penis iuste 
             <lb ed="#V" n="58"/>damnationis in nullo appareret misericos gratia redimentis 
             <lb ed="#V" n="59"/>Rursus se omnes a tenebris transferrentur in lucem in nullo 
             ap<lb ed="#V" n="60" break="no"/>paret seueritas vltionis in qua propter ea multo plures quam in illa sunt 
@@ -344,7 +344,7 @@
             <lb ed="#V" n="70"/>in honorem: quedam in contumeliam comparari vasa 
             honorabi<lb ed="#V" n="71" break="no"/>lia praedestinatis: et vasa in contumeliam reprobis. Sed si 
             quae<lb ed="#V" n="72" break="no"/>ratur ratio praeordinationis istorum signatorum ver. ergo vt ratio 
-            <lb ed="#V" n="73"/>praeordinationis Iacob ad effctum praedestestinationis: et non 
+            <lb ed="#V" n="73"/>praeordinationis Iacob ad effectum <sic>praedestestinationis</sic>: et non 
             <lb ed="#V" n="74"/>praeordinationis Esau ad illum effectum. sic dicunt quod huiusmodi: non est 
             as<lb ed="#V" n="75" break="no"/>signare aliquam rationem nisi dei voluntatem. Eo enim ipso quo de 
             <lb ed="#V" n="76"/>noluit Iacob ordinare ad illum effectum: et non Esau: iustum fuit 
@@ -372,7 +372,7 @@
             <lb ed="#V" n="95"/>terre non fuit eadem in numero posita sub forma ignis 
             hu<lb ed="#V" n="96" break="no"/>ius non fuit assignare aliam causam quam divinam voluntatem: 
             <lb ed="#V" n="97"/>vnde eo ipso quod voluit sic fieri melius fuit sic fieri quam 
-            ali<lb ed="#V" n="98" break="no"/>ter. Qui vult tenere hanc vltimam opinionem potest rndere 
+            ali<lb ed="#V" n="98" break="no"/>ter. Qui vult tenere hanc vltimam opinionem potest respondere 
             <lb ed="#V" n="99"/>ad argumenta que sunt contra eam. 
           </p>
           <p xml:id="kzz7yh-a88116-d1e706">
@@ -407,7 +407,7 @@
           </p>
           <p xml:id="kzz7yh-a88116-d1e765">
             ¶ Qui vult sustinere vnam de duabus primis 
-            opinio<lb ed="#V" n="125" break="no"/>nibus potest sic ad argumenta prameo facta respondere. 
+            opinio<lb ed="#V" n="125" break="no"/>nibus potest sic ad argumenta primo facta respondere. 
           </p>
           <p xml:id="kzz7yh-a88116-d1e770">
             <lb ed="#V" n="126"/>Ad primum dicendum quod sacra scriptura 

--- a/kzz7yh-a88116/cod-ve07v1_kzz7yh-a88116.xml
+++ b/kzz7yh-a88116/cod-ve07v1_kzz7yh-a88116.xml
@@ -298,7 +298,7 @@
             per<lb ed="#V" n="33" break="no"/>ficere: sed est non cadere in defectu videtur esse effectus 
             praedestina<lb ed="#V" n="34" break="no"/>tionis divinae. vnde libro de ecclesiasticis dogmatibus. c. 20. Sicut 
             ini<lb ed="#V" n="35" break="no"/>tium salutis nostre deo miserante et inspirante habere nos credimus: 
-            <lb ed="#V" n="36"/>ita arbitrium nature nostre se: quae esse divine inspirationis libere 
+            <lb ed="#V" n="36"/>ita arbitrium nature nostre sequax esse divine inspirationis libere 
             confite<lb ed="#V" n="37" break="no"/>mur: igitur vt non labamur a bono vel nature vel meriti 
             solicitu<lb ed="#V" n="38" break="no"/>dinis nostre est et celestis pariter adiutorii.
           </p>

--- a/kzz7yh-a88116/cod-ve07v1_kzz7yh-a88116.xml
+++ b/kzz7yh-a88116/cod-ve07v1_kzz7yh-a88116.xml
@@ -75,7 +75,7 @@
             <lb ed="#V" n="12"/>PRimo ostendo quod praescia 
             merito<lb ed="#V" n="13" break="no"/>rum sit ratio 
             prede<lb ed="#V" n="14" break="no"/>stinationis saluandorum. Dicit enim glo. super illud 
-            <lb ed="#V" n="15"/><ref xml:id="kzz7yh-a88116-Rd1e142">Gen 25</ref> depraecatus est Isaac dominum pro vxore sua etcoe 
+            <lb ed="#V" n="15"/><ref xml:id="kzz7yh-a88116-Rd1e142">Gen 25</ref> depraecatus est Isaac dominum pro vxore sua etc. 
             <lb ed="#V" n="16"/>quod sanctorum precibus adiuuanda est dei prefinitio.
           </p>
           <p xml:id="kzz7yh-a88116-d1e141">
@@ -120,14 +120,14 @@
             prae<lb ed="#V" n="41" break="no"/>destinantis: et hoc est vtrum praeordinauit se daturum effectum 
             <lb ed="#V" n="42"/>praedestinationis alicui propter prescientiam meritorum. 
             <!--TODO: insert para break here-->
-            <lb ed="#V" n="43"/>Ad quod dixerunt quidam quod praiordinauit se 
+            <lb ed="#V" n="43"/>Ad quod dixerunt quidam quod praeordinauit se 
             datu<lb ed="#V" n="44" break="no"/>rum aliquibus effectum praedestinationis propter 
-            <lb ed="#V" n="45"/>merita animarum antequam essent corporiibus vnite cui opinioni 
+            <lb ed="#V" n="45"/>merita animarum antequam essent corporibus vnite cui opinioni 
             <lb ed="#V" n="46"/>dicunt quidam Origenem fauisse. 
           </p>
           <p xml:id="kzz7yh-a88116-d1e221">
             <lb ed="#V" n="47"/>Sed contra hoc est quod anime create non sunt ante 
-            cor<lb ed="#V" n="48" break="no"/>pora que informant. Preus <ref xml:id="kzz7yh-a88116-Rd1e238">apostolus ad 
+            cor<lb ed="#V" n="48" break="no"/>pora que informant. Praeterea <ref xml:id="kzz7yh-a88116-Rd1e238">apostolus ad 
               <lb ed="#V" n="49"/>Ro. 9.</ref> loquens de electione Iacob: et reprobatione Esau 
             <lb ed="#V" n="50"/>dicit: cum nondum nati fuissent: aut aliquid boni egissent: 
             <lb ed="#V" n="51"/>aut mali vt secundum electionem propositum dei maneret: non ex 
@@ -147,7 +147,7 @@
             ali<lb ed="#V" n="61" break="no"/>quid a nobis quasi ex nobis: sed sufficientia nostra ex deo est 
             <lb ed="#V" n="62"/>Sed primum initium bene operandi est cogitatio bona: 
             er<lb ed="#V" n="63" break="no"/>go initium in nobis bone operationis non solum est effectus 
-            <lb ed="#V" n="64"/>liberi arbicui sed etiam predestinationis. 
+            <lb ed="#V" n="64"/>liberi arbitrii sed etiam predestinationis. 
           </p>
           <p xml:id="kzz7yh-a88116-d1e269">
             <lb ed="#V" n="65"/>Alii dixerunt quod deus praedestinauit se aliquibus 
@@ -168,7 +168,7 @@
             ¶ Uidetur 
             er<lb ed="#V" n="74" break="no"/>go mihi dicendum quod si consideremus effectum 
             praedestinatio<lb ed="#V" n="75" break="no"/>nis in particulari quod prescientia vnius effectus bene est ratio 
-            qua<lb ed="#V" n="76" break="no"/>re deus praeordinaint se daturum saluando alium effectum 
+            qua<lb ed="#V" n="76" break="no"/>re deus praeordinauit se daturum saluando alium effectum 
             <lb ed="#V" n="77"/>vt quia presciuit se daturum aliquibus finalem gratiam: 
             ordina<lb ed="#V" n="78" break="no"/>uit eis se daturum interminabilem glutiam: et econuerso. secundum quod 
             <lb ed="#V" n="79"/>gloria est causa gratiae secundum rationem causae finalis: et gratia causa 
@@ -182,7 +182,7 @@
             praedestina<lb ed="#V" n="84" break="no"/>tionis totum effectum: quia omnis actus qui est in homine ordinans 
             <lb ed="#V" n="85"/>ipsum ad salutem etiam quantum ad initium totum 
             comprehe<lb ed="#V" n="86" break="no"/>ditur sub effectu praedestinationis: et huius opinionis videtur 
-            fuis<lb ed="#V" n="87" break="no"/>se magister sicut ptet in auctoritatibus adductis pro parte ista 
+            fuis<lb ed="#V" n="87" break="no"/>se magister sicut patet in auctoritatibus adductis pro parte ista 
             <lb ed="#V" n="88"/>in opponendo: et etiam apostolus secundum quod videntur sonare 
             verba<lb ed="#V" n="89" break="no"/>ad Romanos. 9. 
           </p>
@@ -200,7 +200,7 @@
           </p>
           <p xml:id="kzz7yh-a88116-d1e362">
             ¶ Ad 2m cum 
-            <lb ed="#V" n="100"/>diciturquod electio saluandorum venit de occultissimis 
+            <lb ed="#V" n="100"/>dicitur quod electio saluandorum venit de occultissimis 
             meri<lb ed="#V" n="101" break="no"/>tis etc. potest dicit secundum magistrum in praesenti. d. Aug. hoc retractas 
             <lb ed="#V" n="102"/>se in suo simili prae libro retractationum. c. 22. vbi satis claret ex 
             <lb ed="#V" n="103"/>sua sententia quod si Iacob propter merita electus fuisset iam non 
@@ -278,7 +278,7 @@
             ponere<lb ed="#V" n="15" break="no"/>mus aliam rationem nisi voluntate dei: tunc ratio huius non esset 
             oc<lb ed="#V" n="16" break="no"/>culta: sed manifesta nobis: quod falsum est: cum propter eius 
             oc<lb ed="#V" n="17" break="no"/>cultationem exclamet apostolus ad Ro. xi. O altitudo ditiarum 
-            <lb ed="#V" n="18"/>sapientie et scientie dei quam incompehensibilia sunt iudicia eius et 
+            <lb ed="#V" n="18"/>sapientie et scientie dei quam incomprehensibilia sunt iudicia eius et 
             inue<lb ed="#V" n="19" break="no"/>stigabiles vie eius. Dunt ergo quod ad hoc est ratio congruitatis: 
             quam<lb ed="#V" n="20" break="no"/>uis non sit nobis sub certitudine manifesta. vnde potest dici quod 
             <lb ed="#V" n="21"/>quia deus praesciuit aliquos si relinquerentur naturalibus suis cum 
@@ -296,8 +296,8 @@
           <p xml:id="kzz7yh-a88116-d1e541">
             <lb ed="#V" n="32"/>Sed contra hanc opinionem videtur esse: quia non tantummodo 
             per<lb ed="#V" n="33" break="no"/>ficere: sed est non cadem in defectu videtur esse effectus 
-            praedestina<lb ed="#V" n="34" break="no"/>tionis divinae. vnde libro de eccliasticis dogmatibus. c. 20. Sicut 
-            ini<lb ed="#V" n="35" break="no"/>tium falutis nostre deo miserante et inspirante habere nos credimus: 
+            praedestina<lb ed="#V" n="34" break="no"/>tionis divinae. vnde libro de ecclesiasticis dogmatibus. c. 20. Sicut 
+            ini<lb ed="#V" n="35" break="no"/>tium salutis nostre deo miserante et inspirante habere nos credimus: 
             <lb ed="#V" n="36"/>ita arbitrium nature nostre se: quax esse divine inspiraitionis libere 
             confite<lb ed="#V" n="37" break="no"/>mur: igitur vt non labamur a bono vel nature vel meriti 
             solicitu<lb ed="#V" n="38" break="no"/>dinis nostre est et celestis periter adiutorii.
@@ -311,8 +311,8 @@
             er<lb ed="#V" n="43" break="no"/>go impossibile fuit quod. deus praedestinasset Esau: et reprobasset 
             Ia<lb ed="#V" n="44" break="no"/>cob. Necesarium ergo fuit ipsum praedestinare Iacob: et non 
             praede<lb ed="#V" n="45" break="no"/>stinare Esau. Dicit enim Ansel. lib i. cur deus et homoc. x. 
-            Si<lb ed="#V" n="46" break="no"/>cut in deo quodlibet peruum inconueniens sequitur impossilblitas: ita 
-            quam<lb ed="#V" n="47" break="no"/>libet peruam rationem si maiori non vincitur communicatur necessitas. 
+            Si<lb ed="#V" n="46" break="no"/>cut in deo quodlibet peruum inconueniens sequitur impossibilitas: ita 
+            quam<lb ed="#V" n="47" break="no"/>libet paruam rationem si maiori non vincitur communicatur necessitas. 
           </p>
           <p xml:id="kzz7yh-a88116-d1e581">
             <lb ed="#V" n="48"/>¶ Contra autem istam opinionem videtur esse quedam Glo. super 
@@ -321,7 +321,7 @@
           </p>
           <p xml:id="kzz7yh-a88116-d1e590">
             <lb ed="#V" n="51"/>Ideo decent alii ad quaestionem quod ratio quaere deus predestinare 
-            <lb ed="#V" n="52"/>quosdam ad effectum perdestinationis et non alios: 
+            <lb ed="#V" n="52"/>quosdam ad effectum praedestinationis et non alios: 
             quam<lb ed="#V" n="53" break="no"/>uis nulla sit ex parte actus praedestinantis: tamen aliqua est respectu 
             <lb ed="#V" n="54"/>ordinis obiecti praedestinationis ad actum praedestinationis. Hoc enim 
             <lb ed="#V" n="55"/>est quia vult manifestare maxime misericordiam suam in effectum 
@@ -329,25 +329,25 @@
             <lb ed="#V" n="57"/>Aug. de ciui. dei li. 21. c. 12. Si omnes termanerent in penis iuste 
             <lb ed="#V" n="58"/>damnationis in nullo appareret misericos gratia redimentis 
             <lb ed="#V" n="59"/>Rursus se omnes a tenebris transferrentur in lucem in nullo 
-            ap<lb ed="#V" n="60" break="no"/>paret seueritas vltionis in qua propter ea multo plurles quam in illa sunt 
+            ap<lb ed="#V" n="60" break="no"/>paret seueritas vltionis in qua propter ea multo plures quam in illa sunt 
             <lb ed="#V" n="61"/>vt sic ostendatur quid omnibus deberetur: quod si omnibus redderetur: iustitiam 
             <lb ed="#V" n="62"/>iudicantis iuste nemo reprehenderet: huic est videtur concordare 
             <lb ed="#V" n="63"/>apostolus ad Ro. 9. d. quod si deus volens ostendere iram et notam facere 
             <lb ed="#V" n="64"/>potentiam suam sustinuit in multa patientia vasa ire apta in 
-            <lb ed="#V" n="65"/>interitum: vt ostenderet ditias glalie in vasa misericordie que 
+            <lb ed="#V" n="65"/>interitum: vt ostenderet ditias glorie in vasa misericordie que 
             <lb ed="#V" n="66"/>preperauit in gluliam. Ordinauit est deus hoc volens 
             manifesta<lb ed="#V" n="67" break="no"/>re decorem vniuersi: et suam magnificentiam: cui videtur 
             concorda<lb ed="#V" n="68" break="no"/>re apostolus 2. ad. Ti. 20. c. In magna domo non solum sunt va¬ 
             <!--00271.xml-->
             <cb ed="#P" n="b"/>
-            <lb ed="#V" n="69"/>sa aurea et argentea: sed etiam lignea et fictiilia: et quedam 
-            <lb ed="#V" n="70"/>in honorem: quedam in contumeliam comperari vasa 
+            <lb ed="#V" n="69"/>sa aurea et argentea: sed etiam lignea et fictilia: et quedam 
+            <lb ed="#V" n="70"/>in honorem: quedam in contumeliam comparari vasa 
             honorabi<lb ed="#V" n="71" break="no"/>lia praedestinatis: et vasa in contumeliam reprobis. Sed si 
             quae<lb ed="#V" n="72" break="no"/>ratur ratio praeordinationis istorum signatorum ver. ergo vt ratio 
             <lb ed="#V" n="73"/>praeordinationis Iacob ad effctum praedestestinationis: et non 
-            <lb ed="#V" n="74"/>praeordinationis Esau ad illum effanctum. sic dicunt quod huiusmodi: non est 
+            <lb ed="#V" n="74"/>praeordinationis Esau ad illum effectum. sic dicunt quod huiusmodi: non est 
             as<lb ed="#V" n="75" break="no"/>signare aliquam rationem nisi dei voluntatem. Eo enim ipso quo de 
-            <lb ed="#V" n="76"/>noluit Iacob ordinare ad illum effctum: et non Esau: iustum fuit 
+            <lb ed="#V" n="76"/>noluit Iacob ordinare ad illum effectum: et non Esau: iustum fuit 
             <lb ed="#V" n="77"/>quod si fuerit: nec iuste potest non praedestinatus de deo conqueri: quod 
             <lb ed="#V" n="78"/>videtur sentire apostolus ad Ro. 9. d. nunquid dicit sigmentum ei 
             <lb ed="#V" n="79"/>qui se finxit quid me fecisti sic. An non habet potestatem figulus 
@@ -379,7 +379,7 @@
             <lb ed="#V" n="100"/>Ad primum in oppositum cum dicitur quod omnis voluntas 
             <lb ed="#V" n="101"/>sicut vult aliquid ita vult propter 
             <lb ed="#V" n="102"/>aliquid etc. dico quod verum est vel in generali vel in singulari: et 
-            <lb ed="#V" n="103"/>bendico quod deus ordinauit Iacob ad effectum praedestinationis 
+            <lb ed="#V" n="103"/>benedico quod deus ordinauit Iacob ad effectum praedestinationis 
             <lb ed="#V" n="104"/>et non Esau propter manifestationem sue materie et iustitie quamuis 
             <lb ed="#V" n="105"/>illis ita potuisset eam manifestare: si voluisset 
             preordina<lb ed="#V" n="106" break="no"/>re ad effectum praedestinationis ipsum Esau: et non Iacob: vnde 


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve07v1_kzz7yh-a88116.xml`.

## Applied changes

- p. 128v l. 15: etcoe → etc.: garbled abbreviation
- p. 128v l. 43: praiordinauit → praeordinauit: 'ai' for 'ae'
- p. 128v l. 45: corporiibus → corporibus: doubled 'i'
- p. 128v l. 48: Preus → Praeterea: garbled abbreviation
- p. 128v l. 64: arbicui → arbitrii: OCR misread of 'arbitrii'
- p. 128v l. 76: praeordinaint → praeordinauit: 'int' → 'uit'
- p. 128v l. 87: ptet → patet: missing 'a'
- p. 128v l. 100: diciturquod → dicitur quod: missing space
- p. 129r l. 18: incompehensibilia → incomprehensibilia: missing 'r'
- p. 129r l. 34: eccliasticis → ecclesiasticis: missing 'e' in middle
- p. 129r l. 35: falutis → salutis: long-s (f→s)
- p. 129r l. 46: impossilblitas → impossibilitas: transposed letters
- p. 129r l. 47: peruam → paruam: e/a misread
- p. 129r l. 52: perdestinationis → praedestinationis: per- for prae-
- p. 129r l. 60: plurles → plures: transposed letters
- p. 129r l. 65: glalie → glorie: OCR misread; misericordie: valid medieval spelling
- p. 129r l. 69: fictiilia → fictilia: doubled 'i'
- p. 129r l. 70: comperari → comparari: e/a misread
- p. 129r l. 74: effanctum → effectum: garbled
- p. 129r l. 76: effctum → effectum: missing 'e'
- p. 129r l. 103: bendico → benedico: missing 'ne'

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_