### PR TITLE
Transcription corrections: cod-ve07v1_kzz7yh-a88822.xml (8 changes)

### DIFF
--- a/kzz7yh-a88822/cod-ve07v1_kzz7yh-a88822.xml
+++ b/kzz7yh-a88822/cod-ve07v1_kzz7yh-a88822.xml
@@ -64,7 +64,7 @@
         <p xml:id="kzz7yh-a88822-d1e116">
           ¶ primo vtrum 
           ho<lb ed="#V" n="3" break="no"/>minis demerita sit ratio reprobationis sue. 2o vtrum sit aliqua 
-          <lb ed="#V" n="4"/>ratio quaecumque sit illa: quare deus magit trprobauenit Esau quam Iacob. 
+          <lb ed="#V" n="4"/>ratio quaecumque sit illa: quare deus magis reprobauerit Esau quam Iacob. 
         </p>
         <div xml:id="kzz7yh-a88822-Dd1e123">
           <head xml:id="kzz7yh-a88822-Hd1e125">Quaestio 1</head>
@@ -92,7 +92,7 @@
             adconno<lb ed="#V" n="17" break="no"/>tatum quod est temporalis obduratio: et futura damnatio. obdurationis 
             <lb ed="#V" n="18"/>enim sunt causa effectiua et meritoria: sed ipsius 
             preordina<lb ed="#V" n="19" break="no"/>tionis ad futuram damnationem: ad quam reprobus praeordinatus 
-            <lb ed="#V" n="20"/>est ab eterno: non sunt causa effetiua neque meritoria. 
+            <lb ed="#V" n="20"/>est ab eterno: non sunt causa <sic>effetiua</sic> neque meritoria. 
             <!--TODO: insert para break-->
             <lb ed="#V" n="21"/>Ad primum in oppositum cum dicitur quod aliquem ordinare ad penam non propter 
             <lb ed="#V" n="22"/>demerita iniustum est etc. dico quod verum est sic 
@@ -106,9 +106,9 @@
             intel<lb ed="#V" n="27" break="no"/>ligenda est quo ad temporale connotatum non quo ad pncipale signatum. 
             <!--TODO: insert para break here-->
             <lb ed="#V" n="28"/>SEcundo quaerendum esset vtrum sit aliqua ratio quaecumque 
-            <lb ed="#V" n="29"/>sit illa quare deus magis reprebauit 
+            <lb ed="#V" n="29"/>sit illa quare deus magis <sic>reprebauit</sic> 
             <lb ed="#V" n="30"/>Esau quam Iacob: vbique ex supradictis de 
-            praedesti<lb ed="#V" n="31" break="no"/>natione patem potest intelligenti quid ad istam quaestionem 
+            praedesti<lb ed="#V" n="31" break="no"/>natione patere potest intelligenti quid ad istam quaestionem 
             <lb ed="#V" n="32"/>debeat responderi. 
             <!--TODO: insert para break-->
             <lb ed="#V" n="33"/>Consequenter queritur de 4 principali e de 
@@ -144,19 +144,19 @@
           </p>
           <p xml:id="kzz7yh-a88822-d1e250">
             <lb ed="#V" n="49"/>Respondeo quod deum scire quicquid sciuit potest intelligi dupliciter. 
-            <lb ed="#V" n="50"/>vnoo quod ita sciat esse verum quicquid sciuit ese 
+            <lb ed="#V" n="50"/>vno quod ita sciat esse verum quicquid sciuit ese 
             ve<lb ed="#V" n="51" break="no"/>rum Alio ita quod sciat quicquid sciuit scientia simplicis 
             intelligen<lb ed="#V" n="52" break="no"/>tie. Hoc 2s deus scit quicquid sciuit: quia omnes res: et o a 
             enunciabi<lb ed="#V" n="53" break="no"/>lia quae fuerunt et sunt et erut et esse possunt simplici cognitione intuetur: 
             <lb ed="#V" n="54"/>ita enim scit quid est hoc enunciabile christum nasciturum sicut sciebat 
-            <lb ed="#V" n="55"/>antequam christus esset natus. Ita enim scit illos terios: et compositionem eorum: 
+            <lb ed="#V" n="55"/>antequam christus esset natus. Ita enim scit illos terminos: et compositionem eorum: 
             <lb ed="#V" n="56"/>et significationem illius compositionis: sicut sciebat antequam christus esset natus. 
           </p>
           <p xml:id="kzz7yh-a88822-d1e270">
             <lb ed="#V" n="57"/>¶ Loquendo autem primo sicut adhuc dicunt quidam quod deus omne 
             enuncia<lb ed="#V" n="58" break="no"/>bile: quod semel sciuit esse verum semper scit esse verum: quia dicunt ipsi christum 
             <lb ed="#V" n="59"/>nasciturum: christum nasci: christum fuisse natum: vnum est enunciabile 
-            <lb ed="#V" n="60"/>propter vnitatem rei: quamuis significetur sub diuersis differeis temporis sicut 
+            <lb ed="#V" n="60"/>propter vnitatem rei: quamuis significetur sub diuersis differentiis temporis sicut 
             <lb ed="#V" n="61"/>idem est nomen albus alba album propter vnitatem rei: quamuis sub 
             di<lb ed="#V" n="62" break="no"/>uersis accidentibus significetur.
           </p>
@@ -170,11 +170,11 @@
             <lb ed="#V" n="68"/>stante: et sic non esset verum quod eadem oratio quandoque esset vera: et quandoque sta. 
             <!--00272.xml-->
             <cb ed="#P" n="b"/>
-            <lb ed="#V" n="69"/>Pre in haec quod dicunt idem esse nomen albus alba album: videtur nlaltis quod 
-            <lb ed="#V" n="70"/>stuum dicant: quia de essentia nominis est vox et signatio: quia secundum philosophum. 2. 
+            <lb ed="#V" n="69"/>Praeterea in hoc quod dicunt idem esse nomen albus alba album: videtur multis quod 
+            <lb ed="#V" n="70"/>falsum dicant: quia de essentia nominis est vox et signatio: quia secundum philosophum. 2. 
             peri<lb ed="#V" n="71" break="no"/>her. Nome est vox signatiua secundum placitum sine tempore. cum ergo dicendo 
             <lb ed="#V" n="72"/>albus alba album: vox non sit eadem: videtur quod non sit idem nomen propter 
-            defe<lb ed="#V" n="73" break="no"/>ctum identitatis ex parte materie nominis quae est vox maxtum cum non sit 
+            defe<lb ed="#V" n="73" break="no"/>ctum identitatis ex parte materie nominis quae est vox maxime cum non sit 
             <lb ed="#V" n="74"/>identitatis generis quamuis enim rem signari sic vel sic accidat rei 
             si<lb ed="#V" n="75" break="no"/>gnificate: tamen essentiale est dictioni. 
           </p>
@@ -195,7 +195,7 @@
             <lb ed="#V" n="87"/>Prima artus concludunt quod deus nescit esse verum omne 
             enunciabi<lb ed="#V" n="88" break="no"/>le quod sciuit esse verum loquendo de veritate inquantum 
             <lb ed="#V" n="89"/>est quaedam rectitudo in haec quod enunciabile signat illud ad quod 
-            siquan<lb ed="#V" n="90" break="no"/>dum sactum est: hoc est inquantum signt quod est esse: et quod est non esse. 
+            siquan<lb ed="#V" n="90" break="no"/>dum factum est: hoc est inquantum signat quod est esse: et quod est non esse. 
             <!--TODO: insert para break here-->
             <lb ed="#V" n="91"/>Primum argumentum ad partem aliam bene concludit quod deus scit quicquid 
             sci<lb ed="#V" n="92" break="no"/>uit siue sit res: siue enunciabile loquendo de scientia 
@@ -205,7 +205,7 @@
             ¶ Ad 2m dicendum quod quamuis 
             <lb ed="#V" n="94"/>deus vno actu summe simplici sciat omnia: tamen illo actu icit quid est 
             <lb ed="#V" n="95"/>vnumquodque siue res siue enunciabile: et scit omne enunciabile quod 
-            <lb ed="#V" n="96"/>est verum esse verum: et omne enunciabile quod est stntum esse sutum primo dicitur scirur 
+            <lb ed="#V" n="96"/>est verum esse verum: et omne enunciabile quod est falsum esse falsum primo dicitur scire 
             <lb ed="#V" n="97"/>scientia simplicis intelligentie quando dicitur scire scientia simplicis 
             intelligen<lb ed="#V" n="98" break="no"/>tie quicquid sciuit non modo 2o. Unde argumentum procedit de scientia simplicis 
             <lb ed="#V" n="99"/>intelligentie modo alio quam tendimus loqu: cum concedimus simpliciter deum 
@@ -222,22 +222,22 @@
           </p>
           <p xml:id="kzz7yh-a88822-d1e395">
             <lb ed="#V" n="103"/>Respondeo quod deum scire omnia praesentialiter dupliciter potest<!--abbreviation--> 
-            <lb ed="#V" n="104"/>intelligi. vnomod <!--abbreviation--> ita quod aduerbium 
-            praesen<lb ed="#V" n="105" break="no"/>tialiter deterinet hoc verbum scit: et sie est verum est enim sensus deus 
+            <lb ed="#V" n="104"/>intelligi. vnomodo <!--abbreviation--> ita quod aduerbium 
+            praesen<lb ed="#V" n="105" break="no"/>tialiter determinet hoc verbum scit: et sic est verum est enim sensus deus 
             presen<lb ed="#V" n="106" break="no"/>tialiter scit omnia. Certum est enim quod in divino scire non est praeteritum 
-            <lb ed="#V" n="107"/>neque suturum: quia est in praesenti eternitati. Alioo potest intelligi quod 
-            <lb ed="#V" n="108"/>hoc aduerbium praesentialiter deterinet hoc quod dico omnia per comparationem 
+            <lb ed="#V" n="107"/>neque suturum: quia est in praesenti eternitati. Alio potest intelligi quod 
+            <lb ed="#V" n="108"/>hoc aduerbium praesentialiter determinet hoc quod dico omnia per comparationem 
             <lb ed="#V" n="109"/>ad hoc verbum esse subiectum intellectum sub hoc sensu deus scit omnia esse praesentialiter: 
-            <lb ed="#V" n="110"/>et sic stum est. Non enim omnia quae deus scit praesentia sunt per comparationem adu 
-            <lb ed="#V" n="111"/>creatum proesens. Et quia ex illa quaestine vtrum omnia sint realiter praesentia 
+            <lb ed="#V" n="110"/>et sic falsum est. Non enim omnia quae deus scit praesentia sunt per comparationem ad 
+            <lb ed="#V" n="111"/>creatum proesens. Et quia ex illa quaestione vtrum omnia sint realiter praesentia 
             eter<lb ed="#V" n="112" break="no"/>nitati dependet illud quod est difficultatis in quaestione praesenti: ideo de 
-            <lb ed="#V" n="113"/>ista facilius transeo: et eam feci sine arguntem: et sic concessum est 
+            <lb ed="#V" n="113"/>ista facilius transeo: et eam feci sine argumentis: et sic concessum est 
             <lb ed="#V" n="114"/>deum praesentialiter scire ea quae non sunt praesentia: ita concedendum est deum 
             <lb ed="#V" n="115"/>immutabiliter scire ea quae non sunt immutabilia vnico enim actu 
             scien<lb ed="#V" n="116" break="no"/>di semper praesenti et immutabili scit futura et praeterita non hebere esse 
             possen<lb ed="#V" n="117" break="no"/>tialiter: et mutabilia non habere esse immutabiliter. Unde <ref xml:id="kzz7yh-a88822-Rd1e457">Boe. 5 de conso.</ref> 
             <lb ed="#V" n="118"/>parum ante finem. Omne futurum divinus praecurrit intuitus et ad praesentia proprie 
-            <lb ed="#V" n="119"/>cognitionis retorquit atque reuocat non alternat vt estinatur nunc 
+            <lb ed="#V" n="119"/>cognitionis retorquit atque reuocat non alternat vt estimatur nunc 
             <lb ed="#V" n="120"/>hoc nunc illud praenoscendi vice: sed vno actu mutationes tuas 
             ma<lb ed="#V" n="121" break="no"/>nens praeuenit atque complectitur. 
           </p>

--- a/kzz7yh-a88822/cod-ve07v1_kzz7yh-a88822.xml
+++ b/kzz7yh-a88822/cod-ve07v1_kzz7yh-a88822.xml
@@ -144,7 +144,7 @@
           </p>
           <p xml:id="kzz7yh-a88822-d1e250">
             <lb ed="#V" n="49"/>Respondeo quod deum scire quicquid sciuit potest intelligi dupliciter. 
-            <lb ed="#V" n="50"/>vno quod ita sciat esse verum quicquid sciuit ese 
+            <lb ed="#V" n="50"/>vno modo quod ita sciat esse verum quicquid sciuit ese 
             ve<lb ed="#V" n="51" break="no"/>rum Alio ita quod sciat quicquid sciuit scientia simplicis 
             intelligen<lb ed="#V" n="52" break="no"/>tie. Hoc 2s deus scit quicquid sciuit: quia omnes res: et o a 
             enunciabi<lb ed="#V" n="53" break="no"/>lia quae fuerunt et sunt et erut et esse possunt simplici cognitione intuetur: 
@@ -222,10 +222,10 @@
           </p>
           <p xml:id="kzz7yh-a88822-d1e395">
             <lb ed="#V" n="103"/>Respondeo quod deum scire omnia praesentialiter dupliciter potest<!--abbreviation--> 
-            <lb ed="#V" n="104"/>intelligi. vnomodo <!--abbreviation--> ita quod aduerbium 
+            <lb ed="#V" n="104"/>intelligi. vno modo ita quod aduerbium 
             praesen<lb ed="#V" n="105" break="no"/>tialiter determinet hoc verbum scit: et sic est verum est enim sensus deus 
             presen<lb ed="#V" n="106" break="no"/>tialiter scit omnia. Certum est enim quod in divino scire non est praeteritum 
-            <lb ed="#V" n="107"/>neque suturum: quia est in praesenti eternitati. Alio potest intelligi quod 
+            <lb ed="#V" n="107"/>neque suturum: quia est in praesenti eternitati. Alio modo potest intelligi quod 
             <lb ed="#V" n="108"/>hoc aduerbium praesentialiter determinet hoc quod dico omnia per comparationem 
             <lb ed="#V" n="109"/>ad hoc verbum esse subiectum intellectum sub hoc sensu deus scit omnia esse praesentialiter: 
             <lb ed="#V" n="110"/>et sic falsum est. Non enim omnia quae deus scit praesentia sunt per comparationem ad 

--- a/kzz7yh-a88822/cod-ve07v1_kzz7yh-a88822.xml
+++ b/kzz7yh-a88822/cod-ve07v1_kzz7yh-a88822.xml
@@ -89,9 +89,9 @@
           <p xml:id="kzz7yh-a88822-d1e156">
             <lb ed="#V" n="15"/>Respondeo quod hominis demerita non sunt ratio 
             <lb ed="#V" n="16"/>reprobationis sue nisi quantum 
-            adconno<lb ed="#V" n="17" break="no"/>tatum quod est temporalis obduratio: et futura damnatio. obduronis 
+            adconno<lb ed="#V" n="17" break="no"/>tatum quod est temporalis obduratio: et futura damnatio. obdurationis 
             <lb ed="#V" n="18"/>enim sunt causa effectiua et meritoria: sed ipsius 
-            preordina<lb ed="#V" n="19" break="no"/>tionis ad futuram damnationem: ad quam reprobus praeordinats 
+            preordina<lb ed="#V" n="19" break="no"/>tionis ad futuram damnationem: ad quam reprobus praeordinatus 
             <lb ed="#V" n="20"/>est ab eterno: non sunt causa effetiua neque meritoria. 
             <!--TODO: insert para break-->
             <lb ed="#V" n="21"/>Ad primum in oppositum cum dicitur quod aliquem ordinare ad penam non propter 
@@ -112,7 +112,7 @@
             <lb ed="#V" n="32"/>debeat responderi. 
             <!--TODO: insert para break-->
             <lb ed="#V" n="33"/>Consequenter queritur de 4 principali e de 
-            <lb ed="#V" n="34"/>hoc quaruntur duo.
+            <lb ed="#V" n="34"/>hoc quaeruntur duo.
           </p>
           <p xml:id="kzz7yh-a88822-d1e206">
             ¶ primo vtrum 
@@ -155,13 +155,13 @@
           <p xml:id="kzz7yh-a88822-d1e270">
             <lb ed="#V" n="57"/>¶ Loquendo autem primo sicut adhuc dicunt quidam quod deus omne 
             enuncia<lb ed="#V" n="58" break="no"/>bile: quod semel sciuit esse verum semper scit esse verum: quia dicunt ipsi christum 
-            <lb ed="#V" n="59"/>nasciturum: christum nasci: christum fuisse natum: vnum est enuciabile 
+            <lb ed="#V" n="59"/>nasciturum: christum nasci: christum fuisse natum: vnum est enunciabile 
             <lb ed="#V" n="60"/>propter vnitatem rei: quamuis significetur sub diuersis differeis temporis sicut 
             <lb ed="#V" n="61"/>idem est nomen albus alba album propter vnitatem rei: quamuis sub 
             di<lb ed="#V" n="62" break="no"/>uersis accidentibus significetur.
           </p>
           <p xml:id="kzz7yh-a88822-d1e286">
-            ¶ Sed contra hoc artur sic secundum philosophum libro 
+            ¶ Sed contra hoc arguitur sic secundum philosophum libro 
             <lb ed="#V" n="63"/>praentorum. Oratio manens eadem quandoque est vera: quandoque est falsa: vt si vera 
             <lb ed="#V" n="64"/>sit oratio quae dicitur quendam sedere eo surgente falsa est. Sed hoc non 
             <lb ed="#V" n="65"/>esset verum si propter rei vnitatem esset vnitas in enunciatione: quia tunc 
@@ -186,7 +186,7 @@
             <lb ed="#V" n="80"/>esse me nasciturum: et modo nescit hoc esse verum: quia ego amplius non 
             <lb ed="#V" n="81"/>sum nasciturus: et tamen me esse nasciturum idem est enunciabile sic 
             <lb ed="#V" n="82"/>antequam ego essem natus cum maneat identitas voci signationis 
-            <lb ed="#V" n="83"/>et modi signndi: et rei signate quantum ad esse signatum. Ident itas enim 
+            <lb ed="#V" n="83"/>et modi significandi: et rei signate quantum ad esse signatum. Identitas enim 
             <lb ed="#V" n="84"/>rei in sua reali existentia non requiritur ad identitatem enunciabilis: quia 
             <lb ed="#V" n="85"/>nec requiritur ad identitatem dictionis. Aliter enim destructa non 
             pos<lb ed="#V" n="86" break="no"/>set manere eandem dictio: quod falsum est. 
@@ -194,7 +194,7 @@
           <p xml:id="kzz7yh-a88822-d1e347">
             <lb ed="#V" n="87"/>Prima artus concludunt quod deus nescit esse verum omne 
             enunciabi<lb ed="#V" n="88" break="no"/>le quod sciuit esse verum loquendo de veritate inquantum 
-            <lb ed="#V" n="89"/>est quaedam rectitudo in haec quod enunciabile signt illud ad quod 
+            <lb ed="#V" n="89"/>est quaedam rectitudo in haec quod enunciabile signat illud ad quod 
             siquan<lb ed="#V" n="90" break="no"/>dum sactum est: hoc est inquantum signt quod est esse: et quod est non esse. 
             <!--TODO: insert para break here-->
             <lb ed="#V" n="91"/>Primum argumentum ad partem aliam bene concludit quod deus scit quicquid 
@@ -227,7 +227,7 @@
             presen<lb ed="#V" n="106" break="no"/>tialiter scit omnia. Certum est enim quod in divino scire non est praeteritum 
             <lb ed="#V" n="107"/>neque suturum: quia est in praesenti eternitati. Alioo potest intelligi quod 
             <lb ed="#V" n="108"/>hoc aduerbium praesentialiter deterinet hoc quod dico omnia per comparationem 
-            <lb ed="#V" n="109"/>ad hoc verbum esse subitcntitellectum sub hoc sensu deus scit omnia esse praesentialiter: 
+            <lb ed="#V" n="109"/>ad hoc verbum esse subiectum intellectum sub hoc sensu deus scit omnia esse praesentialiter: 
             <lb ed="#V" n="110"/>et sic stum est. Non enim omnia quae deus scit praesentia sunt per comparationem adu 
             <lb ed="#V" n="111"/>creatum proesens. Et quia ex illa quaestine vtrum omnia sint realiter praesentia 
             eter<lb ed="#V" n="112" break="no"/>nitati dependet illud quod est difficultatis in quaestione praesenti: ideo de 


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve07v1_kzz7yh-a88822.xml`.

## Applied changes

- p. 129v l. 17: obduronis → obdurationis: missing 'ati'
- p. 129v l. 19: praeordinats → praeordinatus: missing 'u'
- p. 129v l. 34: quaruntur → quaeruntur: missing 'ae'
- p. 129v l. 59: enuciabile → enunciabile: missing 'n'
- p. 129v l. 62: artur → arguitur: heavily contracted
- p. 129v l. 83: signndi → significandi: missing letters; Ident itas → Identitas: spurious space
- p. 129v l. 89: signt → signat: missing 'a'
- p. 129v l. 109: subitcntitellectum → subiectum intellectum: heavily garbled

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_