### PR TITLE
Transcription corrections: cod-ve07v1_kzz7yh-a89164.xml (2 changes)

### DIFF
--- a/kzz7yh-a89164/cod-ve07v1_kzz7yh-a89164.xml
+++ b/kzz7yh-a89164/cod-ve07v1_kzz7yh-a89164.xml
@@ -67,7 +67,7 @@
           mun<lb ed="#V" n="131" break="no"/>dum creandum postquam creatus est: sciuit eum creatum: nec est hoc scire 
           <lb ed="#V" n="132"/>diuersa: sed omnio idem de creatione mundi). Potest hic dici quod magister 
           <lb ed="#V" n="133"/>fuit opinionis illorum: qui tunc temporis dicebantur nominales: qui dicebant 
-          <lb ed="#V" n="134"/>idem enunciabile  vtrum de futuro. 2o de praesenti. 3o de praetenito. Qui 
+          <lb ed="#V" n="134"/>idem enunciabile primo vtrum de futuro. 2o de praesenti. 3o de praeterito. Qui 
           <lb ed="#V" n="135"/>tamen vellet excusare posset dicem quod magister non dicit quod hoc scire sit 
           <lb ed="#V" n="136"/>scire idem enunciabile: sed eandem rem significatam per diuersa enunciabilia.
         </p>

--- a/kzz7yh-a89164/cod-ve07v1_kzz7yh-a89164.xml
+++ b/kzz7yh-a89164/cod-ve07v1_kzz7yh-a89164.xml
@@ -55,7 +55,7 @@
       <div xml:id="kzz7yh-a89164"><!-- l1d41cl -->
         <head xml:id="kzz7yh-a89164-Hd1e101">Circa litteram</head>
         <p xml:id="kzz7yh-a89164-d1e103">
-          <lb ed="#V" n="122"/>Circa litteram. (Precedit aliquid in pecccatoribus: quia 
+          <lb ed="#V" n="122"/>Circa litteram. (Precedit aliquid in peccatoribus: quo 
           <lb ed="#V" n="123"/>quamuis nondum sint iustificati digni 
           effi<lb ed="#V" n="124" break="no"/>ciuntur iustificatione). Hic vocat dignitatem 
           congruita<lb ed="#V" n="125" break="no"/>tem scilicet quandam praeparationem ad gratiam: que peccatores non reddit 
@@ -67,7 +67,7 @@
           mun<lb ed="#V" n="131" break="no"/>dum creandum postquam creatus est: sciuit eum creatum: nec est hoc scire 
           <lb ed="#V" n="132"/>diuersa: sed omnio idem de creatione mundi). Potest hic dici quod magister 
           <lb ed="#V" n="133"/>fuit opinionis illorum: qui tunc temporis dicebantur nominales: qui dicebant 
-          <lb ed="#V" n="134"/>idem enunciabile pram vtrum de futuro. 2o de praesenti. 3o de praetenito. Qui 
+          <lb ed="#V" n="134"/>idem enunciabile  vtrum de futuro. 2o de praesenti. 3o de praetenito. Qui 
           <lb ed="#V" n="135"/>tamen vellet excusare posset dicem quod magister non dicit quod hoc scire sit 
           <lb ed="#V" n="136"/>scire idem enunciabile: sed eandem rem significatam per diuersa enunciabilia.
         </p>

--- a/kzz7yh-a89164/cod-ve07v1_kzz7yh-a89164.xml
+++ b/kzz7yh-a89164/cod-ve07v1_kzz7yh-a89164.xml
@@ -60,9 +60,9 @@
           effi<lb ed="#V" n="124" break="no"/>ciuntur iustificatione). Hic vocat dignitatem 
           congruita<lb ed="#V" n="125" break="no"/>tem scilicet quandam praeparationem ad gratiam: que peccatores non reddit 
           <lb ed="#V" n="126"/>dignos gratia: sed dispositos de congruo ad gratiam. Ex quo 
-          il<lb ed="#V" n="127" break="no"/>la que futura erant praesentia fiunt vel praetereut sub dei praescientia esse 
+          il<lb ed="#V" n="127" break="no"/>la que futura erant praesentia fiunt vel praetereunt sub dei praescientia esse 
           <lb ed="#V" n="128"/>desinunt) non est hoc sic intelligendum quod deus desinat aliquid praescire 
-          <lb ed="#V" n="129"/>ratione principalis signati praescientie: sed rone ordis connotati. (Cuius 
+          <lb ed="#V" n="129"/>ratione principalis signati praescientie: sed ratione ordis connotati. (Cuius 
           <lb ed="#V" n="130"/>alterum extremum est temporale scilicet res praescita. (Sciebat deus hunc 
           mun<lb ed="#V" n="131" break="no"/>dum creandum postquam creatus est: sciuit eum creatum: nec est hoc scire 
           <lb ed="#V" n="132"/>diuersa: sed omnio idem de creatione mundi). Potest hic dici quod magister 


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve07v1_kzz7yh-a89164.xml`.

## Applied changes

- p. 129v l. 127: praetereut → praetereunt: missing 'n'
- p. 129v l. 129: rone → ratione: heavily abbreviated

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_