### PR TITLE
Transcription corrections: cod-ve07v1_kzz7yh-a89204.xml (5 changes)

### DIFF
--- a/kzz7yh-a89204/cod-ve07v1_kzz7yh-a89204.xml
+++ b/kzz7yh-a89204/cod-ve07v1_kzz7yh-a89204.xml
@@ -248,7 +248,7 @@
           omni<lb ed="#V" n="36" break="no"/>potentem: quia potest omnia quae vult. ibi. Ex quibusdam tamen primo in tres. 
         </p>
         <p xml:id="kzz7yh-a89204-d1e480">
-          <lb ed="#V" n="37"/>¶ Primo deteriat quod deus est opstus.
+          <lb ed="#V" n="37"/>¶ Primo determinat quod deus est opstus.
         </p>
         <p xml:id="kzz7yh-a89204-d1e486">
           ¶ Secundo ad contrarium 
@@ -256,7 +256,7 @@
         </p>
         <p xml:id="kzz7yh-a89204-d1e491">
           ¶ Tertio ostendit in quis consistit dei 
-          omnipo<lb ed="#V" n="39" break="no"/>ibi. Hic igratur Media istarum diditur in tres instantias quae 
+          omnipo<lb ed="#V" n="39" break="no"/>ibi. Hic igitur Media istarum diditur in tres instantias quae 
           superficia<lb ed="#V" n="40" break="no"/>liter videntur contra suam deterinationem.
         </p>
         <p xml:id="kzz7yh-a89204-d1e498">
@@ -273,14 +273,14 @@
         </p>
         <p xml:id="kzz7yh-a89204-d1e513">
           ¶ Tunc sequitur illa pars que ibi incipit. Ex 
-          <lb ed="#V" n="44"/>quibusdam in qua deterinat auctoritates quaie videntur dicere ideo deum 
+          <lb ed="#V" n="44"/>quibusdam in qua determinat auctoritates quae videntur dicere ideo deum 
           di<lb ed="#V" n="45" break="no"/>ci omnipotentem: quia potest omnia quae vult. Et diditur in partes duas: 
-          <lb ed="#V" n="46"/>quia primo ponit alias auctoritates. Secundo deterinat eas. ibi. 
+          <lb ed="#V" n="46"/>quia primo ponit alias auctoritates. Secundo determinat eas. ibi. 
           <lb ed="#V" n="47"/>Sed ad hoc potest dici. Et ista in duas. Primo ponit ipsarum 
-          <lb ed="#V" n="48"/>auctoritatum deterinationem
+          <lb ed="#V" n="48"/>auctoritatum determinationem
         </p>
         <p xml:id="kzz7yh-a89204-d1e527">
-          ¶ Secundo contra illam deterinationem oppotionit et 
+          ¶ Secundo contra illam determinationem opponit et 
           <lb ed="#V" n="49"/>subiungit sue oppositionis solutionem. ibi. Sed forte dices.
         </p>
       </div>

--- a/kzz7yh-a89204/cod-ve07v1_kzz7yh-a89204.xml
+++ b/kzz7yh-a89204/cod-ve07v1_kzz7yh-a89204.xml
@@ -244,7 +244,7 @@
           ¶ primo in duas. Primo ostendit secundum quid ostenditur dei omnipo¬ 
         </p>
         <p xml:id="kzz7yh-a89204-d1e473">
-          <lb ed="#V" n="35"/>¶ deterinat auctoritates quae videntur dicere in deo ipsum dici 
+          <lb ed="#V" n="35"/>¶ determinat auctoritates quae videntur dicere in deo ipsum dici 
           omni<lb ed="#V" n="36" break="no"/>potentem: quia potest omnia quae vult. ibi. Ex quibusdam tamen primo in tres. 
         </p>
         <p xml:id="kzz7yh-a89204-d1e480">

--- a/kzz7yh-a89204/cod-ve07v1_kzz7yh-a89204.xml
+++ b/kzz7yh-a89204/cod-ve07v1_kzz7yh-a89204.xml
@@ -244,7 +244,7 @@
           ¶ primo in duas. Primo ostendit secundum quid ostenditur dei omnipo¬ 
         </p>
         <p xml:id="kzz7yh-a89204-d1e473">
-          <lb ed="#V" n="35"/>¶ determinat auctoritates quae videntur dicere in deo ipsum dici 
+          <lb ed="#V" n="35"/>¶ 2o determinat auctoritates quae videntur dicere in deo ipsum dici 
           omni<lb ed="#V" n="36" break="no"/>potentem: quia potest omnia quae vult. ibi. Ex quibusdam tamen primo in tres. 
         </p>
         <p xml:id="kzz7yh-a89204-d1e480">


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve07v1_kzz7yh-a89204.xml`.

## Applied changes

- p. 130v l. 37: deteriat → determinat: missing 'min', t/t
- p. 130v l. 39: igratur → igitur: OCR misread
- p. 130v l. 44: deterinat → determinat: missing 'min'; quaie → quae: spurious 'i'
- p. 130v l. 46: deterinat → determinat: missing 'min'
- p. 130v l. 48: deterinationem → determinationem: missing 'min'; oppotionit → opponit: garbled

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_