### PR TITLE
Transcription corrections: cod-ve07v1_kzz7yh-a89638.xml (61 changes)

### DIFF
--- a/kzz7yh-a89638/cod-ve07v1_kzz7yh-a89638.xml
+++ b/kzz7yh-a89638/cod-ve07v1_kzz7yh-a89638.xml
@@ -196,7 +196,7 @@
             <lb ed="#V" n="118"/>pene. Malum culpe est auersio a summo bono vel 
             obli<lb ed="#V" n="119" break="no"/>quatio secundum quod culpa diditur in mortalem et venialem. 
             <lb ed="#V" n="120"/>Deus autem facere non potest quod ipse auertatur a seipso: vel 
-            obliquanst<lb ed="#V" n="121" break="no"/>velle facere istam auersionem: vel obliquationem in alio: quia iam esset iam 
+            obliquanst<lb ed="#V" n="121" break="no"/>velle facere istam auersionem: vel obliquationem in alio: quia iam esset 
             <lb ed="#V" n="122"/>contrarius sibiipsi: et ideo deus non potest malum culpe. Cui veritati 
             <lb ed="#V" n="123"/>non tantum consentiunt sancti: sed est philosophi. Dicit enim Trimegistus in 
             <lb ed="#V" n="124"/>libro de divinitate ad Asclepium quod voluntas dei est omnis bonitas 
@@ -360,7 +360,7 @@
           <p xml:id="kzz7yh-a89638-d1e634">
             ¶ Item prima 
             muta<lb ed="#V" n="101" break="no"/>tio motus non remanet per totum motum: nec per partem motus. ad 
-            <lb ed="#V" n="102"/>quod sequitur quod perdat esse in eodem instanti in quo est: quia sint vno 
+            <lb ed="#V" n="102"/>quod sequitur quod perdat esse in eodem instanti in quo est: quia si in vno 
             <lb ed="#V" n="103"/>instanti esset: et in alio perderet esse maneret per totam illam partem 
             <lb ed="#V" n="104"/>motus quae esset in tempore medio inter illa duo instantia illa ergo 
             mu<lb ed="#V" n="105" break="no"/>tatio in eodem instanti est et non est: ergo deus simul facit 
@@ -609,8 +609,8 @@
           <p xml:id="kzz7yh-a89638-d1e1087">
             <lb ed="#V" n="126"/>Respondeo quod natura potest accipi dupliciter. 
             <lb ed="#V" n="127"/>vno modo pro vi rebus insita: qua 
-            <lb ed="#V" n="128"/>explent suos vsitatos cursus: siue in agendo siue in patien 
-            <lb ed="#V" n="129"/>do: et sic accipiendo naturam deus multa facit et plura posset 
+            <lb ed="#V" n="128"/>explent suos vsitatos cursus: siue in agendo siue in patien
+            <lb ed="#V" n="129" break="no"/>do: et sic accipiendo naturam deus multa facit et plura posset 
             <lb ed="#V" n="130"/>facere si vellet contra naturam.
           </p>
           <p xml:id="kzz7yh-a89638-d1e1100">
@@ -766,7 +766,7 @@
           </p>
           <p xml:id="kzz7yh-a89638-d1e1375">
             ¶ Item 
-            <lb ed="#V" n="96"/>psalmum. Ego cognoui quod magnus est dominus et deus noster prioribus diis 
+            <lb ed="#V" n="96"/>psalmum. Ego cognoui quod magnus est dominus et deus noster prae omnibus diis 
             <lb ed="#V" n="97"/>omnia quecumque voluit dominus fecit: hic videtur psal. reddere rationem 
             <lb ed="#V" n="98"/>magnitudinis divinae potentiae per hoc quod facit quicquid vult: ergo videtur quod est 
             <lb ed="#V" n="99"/>omnipotens: quia potest quicquid vult se posse.
@@ -780,7 +780,7 @@
           <p xml:id="kzz7yh-a89638-d1e1395">
             <lb ed="#V" n="103"/><ref xml:id="kzz7yh-a89638-Rd1e1488">Contra. Aug. 13 de tri. c. 5</ref> Omnes beati habent quod volunt: ergo 
             <lb ed="#V" n="104"/>quilibet beatus potest quicquid vult se posse: nec tamen quilibet btus 
-            <lb ed="#V" n="105"/>omnipotens: sed solus deus: ergo non ideo deus omnipotens: quia potest quicquid vult se posse. 
+            <lb ed="#V" n="105"/>est omnipotens: sed solus deus: ergo non ideo deus omnipotens: quia potest quicquid vult se posse. 
             <!--TODO insert para break here-->
             <lb ed="#V" n="106"/>Respondeo quod deus est omnipotens: et potest omina quae vult se posse: sed 
             <lb ed="#V" n="107"/>ipsum posse omnia quae vult se posse: non est precisa 

--- a/kzz7yh-a89638/cod-ve07v1_kzz7yh-a89638.xml
+++ b/kzz7yh-a89638/cod-ve07v1_kzz7yh-a89638.xml
@@ -129,7 +129,7 @@
           <p xml:id="kzz7yh-a89638-d1e213">
             ¶ Ad 
             <lb ed="#V" n="78"/>cuius intelligentiam sciendum quod secundum <ref xml:id="kzz7yh-a89638-Rd1e233">philosophum. 
-              <lb ed="#V" n="79"/>5. metaphy. c.</ref> de posmo Uno modo potentia est principium tramsmutandi 
+              <lb ed="#V" n="79"/>5. metaphy. c.</ref> de potentia Uno modo potentia est principium transmutandi 
             <lb ed="#V" n="80"/>aliud: et haec est pos actiua. Alio modo potentia dicitur principium transmutandi 
             <lb ed="#V" n="81"/>ab alio et hoc est potentia passiua. Cum ergo agere conueniat alicui 
             <lb ed="#V" n="82"/>secundum quod est ens actu: vt vult philosophus. 3. phy. Ideo pos actiua 
@@ -196,7 +196,7 @@
             <lb ed="#V" n="118"/>pene. Malum culpe est auersio a summo bono vel 
             obli<lb ed="#V" n="119" break="no"/>quatio secundum quod culpa diditur in mortalem et venialem. 
             <lb ed="#V" n="120"/>Deus autem facere non potest quod ipse auertatur a seipso: vel 
-            obliquanst<lb ed="#V" n="121" break="no"/>velle facere istam auersionem: vel obliquationem in alio: quia iam essetam 
+            obliquanst<lb ed="#V" n="121" break="no"/>velle facere istam auersionem: vel obliquationem in alio: quia iam esset iam 
             <lb ed="#V" n="122"/>contrarius sibiipsi: et ideo deus non potest malum culpe. Cui veritati 
             <lb ed="#V" n="123"/>non tantum consentiunt sancti: sed est philosophi. Dicit enim Trimegistus in 
             <lb ed="#V" n="124"/>libro de divinitate ad Asclepium quod voluntas dei est omnis bonitas 
@@ -225,7 +225,7 @@
           <p xml:id="kzz7yh-a89638-d1e384">
             <lb ed="#V" n="9"/>Ad primum ad partem aliam cum dicitur quod poter malorum 
             <lb ed="#V" n="10"/>sunt bone etc. dico quod verum est non sub 
-            <lb ed="#V" n="11"/>ratione quae sunt poster malorum: sed inquantum eedem sunt posrbonorum 
+            <lb ed="#V" n="11"/>ratione quae sunt potentie malorum: sed inquantum eedem sunt potentie bonorum 
             <lb ed="#V" n="12"/>posse vero malum dicit ordinabilitatem: immo vt proprius loquar 
             defe<lb ed="#V" n="13" break="no"/>ctibilitatem ipsius potentie respectu defectus boui debiti: qui 
             defe<lb ed="#V" n="14" break="no"/>ctus est malum.
@@ -255,10 +255,10 @@
             <lb ed="#V" n="30"/>biti carentia potest sciri: et ipsum scire est scire quod est voluntas potest 
             <lb ed="#V" n="31"/>velle vel nolle rem cognitam: ideo voluntas potest velle malum 
             <lb ed="#V" n="32"/>non tamen sub ratione qua malum: quamuis sub ratione mali possit ipsum 
-            <lb ed="#V" n="33"/>velle. et ideo velle malum etiam est velle. Poms vero respicit obictum 
+            <lb ed="#V" n="33"/>velle. et ideo velle malum etiam est velle. Potentia vero respicit obiectum 
             <lb ed="#V" n="34"/>secundum suum esse reale: et quia malum sub ratione qua malum non est res 
             <lb ed="#V" n="35"/>aliqua positiua: sed defectus boni debiti: ideo posse malum sub 
-            <lb ed="#V" n="36"/>ratione que malum est posse deficere: posse autem deficem vere est non 
+            <lb ed="#V" n="36"/>ratione que malum est posse deficere: posse autem deficere vere est non 
             <lb ed="#V" n="37"/>posse. Unde sicut dicit Ansel. prosolis. 7. c. Qui sic potest non 
             pos<lb ed="#V" n="38" break="no"/>potest: sed impotentia et quanto aliquis magis sic potest tanto 
             mi<lb ed="#V" n="39" break="no"/>serior est secundum Aug. 13 de tri. c. 5.
@@ -299,11 +299,11 @@
           <p xml:id="kzz7yh-a89638-d1e516">
             <lb ed="#V" n="55"/>Respondeo quod bonorum creature possibilium 
             que<lb ed="#V" n="56" break="no"/>dam de sui ratione nullam imperfectionem 
-            <lb ed="#V" n="57"/>includunt inquantum considerantur secundum siutam rationem generalem: quamuis 
+            <lb ed="#V" n="57"/>includunt inquantum considerantur secundum suam rationem generalem: quamuis 
             <lb ed="#V" n="58"/>imperfectionem dicant secundum esse quod habent in creatura: et talia sunt 
             in<lb ed="#V" n="59" break="no"/>telligere et velle plura alia: et talia inueniuntur principalius in 
             <lb ed="#V" n="60"/>creatore quam in creatura: et ea potest efficere et efficit in 
-            creatu<lb ed="#V" n="61" break="no"/>ra. Quedam autem de sni ratione impfectionem includunt est 
+            creatu<lb ed="#V" n="61" break="no"/>ra. Quedam autem de <sic>sni</sic> ratione impferctionem includunt est 
             considera<lb ed="#V" n="62" break="no"/>ta in ratione generali: cuiusmodi sunt ambulare et corporaliter. loqu 
             <lb ed="#V" n="63"/>hec enim ita includunt imperfectionem quod non possunt esse in re aliqua: nisi 
             <lb ed="#V" n="64"/>inquantum ni illa est aliqua imperfectio. Unde dicit phy. 3. physi. c. 
@@ -339,10 +339,10 @@
           <p xml:id="kzz7yh-a89638-d1e591">
             <lb ed="#V" n="84"/>¶ Item ponatur quod faba proiiciatur sursum et obuiet lapidi 
             mo<lb ed="#V" n="85" break="no"/>lari descendenti: tunc superficies fabe et mole iunguntur in aliqui 
-            <lb ed="#V" n="86"/>indiuisibili ipsius aertur in aliquo instanti: et in eodem instanti ab 
+            <lb ed="#V" n="86"/>indiuisibili ipsius aeris in aliquo instanti: et in eodem instanti ab 
             <lb ed="#V" n="87"/>illo indiuisibili separabuntur aliter faba ascendens faceret lapidem 
             <lb ed="#V" n="88"/>descendentem quiescere quod absurdum videtur: ergo videtur quod est potestate creata 
-            <lb ed="#V" n="89"/>possunt simul fieri contradictoria. ergo nulto fortius potestate increata. 
+            <lb ed="#V" n="89"/>possunt simul fieri contradictoria. ergo multo fortius potestate increata. 
           </p>
           <p xml:id="kzz7yh-a89638-d1e607">
             <lb ed="#V" n="90"/>¶ Item deus potest creare vnum lapidem in tali dispositione quod 
@@ -360,14 +360,14 @@
           <p xml:id="kzz7yh-a89638-d1e634">
             ¶ Item prima 
             muta<lb ed="#V" n="101" break="no"/>tio motus non remanet per totum motum: nec per partem motus. ad 
-            <lb ed="#V" n="102"/>quod sequitur quod perdat esse in eodem instanti in quo est: quia siin vno 
+            <lb ed="#V" n="102"/>quod sequitur quod perdat esse in eodem instanti in quo est: quia sint vno 
             <lb ed="#V" n="103"/>instanti esset: et in alio perderet esse maneret per totam illam partem 
-            <lb ed="#V" n="104"/>motus quai esset in tempore medio inter illa duo instantia illa ergo 
+            <lb ed="#V" n="104"/>motus quae esset in tempore medio inter illa duo instantia illa ergo 
             mu<lb ed="#V" n="105" break="no"/>tatio in eodem instanti est et non est: ergo deus simul facit 
             contradicto<lb ed="#V" n="106" break="no"/>ria.
           </p>
           <p xml:id="kzz7yh-a89638-d1e650">
-            ¶ Item Ansel. in libro de concor. prescientie. et libero arbro longe post 
+            ¶ Item Ansel. in libro de concor. prescientie. et libero arbitrio longe post 
             <lb ed="#V" n="107"/>prin. Que magis opposita sunt quam ad ire et ab ire. Uidemus 
             <lb ed="#V" n="108"/>tamen cum transit aliquis de loco ad locum: quia idem ire est ab ire et 
             <lb ed="#V" n="109"/>ad ire: ergo oppositio simul eueniunt eidem: sed quae simul eidem conuenire 
@@ -390,7 +390,7 @@
             <lb ed="#V" n="120"/>ex parte sui: sed quia illud non habet rationem post vllo modo. Et si 
             quaerai<lb ed="#V" n="121" break="no"/>quare hoc non habet rationem possibilis dicendum quod huius non est alia ratio 
             <lb ed="#V" n="122"/>reddenda nisi quod talis est natura: vel habitudo affirmationis et 
-            ne<lb ed="#V" n="123" break="no"/>gationis: sicut si quaereretur quatia omne totum comprehendit partem et plus 
+            ne<lb ed="#V" n="123" break="no"/>gationis: sicut si quaereretur quare omne totum comprehendit partem et plus 
             <lb ed="#V" n="124"/>non esset reddenda alia ratio: nisi quod talis est natura totius et partis 
             <lb ed="#V" n="125"/>et si aliam rationem velis quaerere non esset ratio ita manifesta: sicut 
             <lb ed="#V" n="126"/>illud cuius quaereres reddere rationem nisi recurreres ad causam 
@@ -401,10 +401,10 @@
           <p xml:id="kzz7yh-a89638-d1e710">
             ¶ Aliqui tamen volunt reddere aliam rationem dicentes quod 
             <lb ed="#V" n="130"/>omne possibile est respectu alicuius esse: sicut teri vel alicuius non ese. 
-            <lb ed="#V" n="131"/>contradictoria vero sicut esse et non esse: nec possunt esse terinus 
-            affirma<lb ed="#V" n="132" break="no"/>tionis propter non esse: nec terinus negationis propter esse: et ideo esse et 
+            <lb ed="#V" n="131"/>contradictoria vero sicut esse et non esse: nec possunt esse terminus 
+            affirma<lb ed="#V" n="132" break="no"/>tionis propter non esse: nec terminus negationis propter esse: et ideo esse et 
             <lb ed="#V" n="133"/>non esse simul nullo modo habet rationem possibilis. Sed hoc ratio non 
-            <lb ed="#V" n="134"/>est ita clara: sicut est illud cuius vult reddem rationem quod est 
+            <lb ed="#V" n="134"/>est ita clara: sicut est illud cuius vult reddere rationem quod est 
             con<lb ed="#V" n="135" break="no"/>cordia simul non posse esse. 
           </p>
           <p xml:id="kzz7yh-a89638-d1e727">
@@ -416,14 +416,14 @@
             <cb ed="#P" n="a"/>
             <lb ed="#V" n="1"/>vt processus pile ad parietem: et reuersio eius versus locum: vnde 
             <lb ed="#V" n="2"/>proiecta est: sit vnus motus contrarius: et sicut pila non signauit 
-            <lb ed="#V" n="3"/>aliquem locum in periete in actu. alio modo quam mobile est in quolibet 
+            <lb ed="#V" n="3"/>aliquem locum in pariete in actu. alio modo quam mobile est in quolibet 
             <lb ed="#V" n="4"/>spatio medii sibi equali dum mouetur quod non est ibi esse in 
             <lb ed="#V" n="5"/>actu puro: sed in potentia permixta acrui. 
           </p>
           <p xml:id="kzz7yh-a89638-d1e753">
             <lb ed="#V" n="6"/>Dicunt tamen quidam quod pila ibi quiescit tempore imperceptibili: 
             <lb ed="#V" n="7"/>quia virtus per quam adhuc poterat moueri in 
-            dire<lb ed="#V" n="8" break="no"/>ctum nisi esset peries: non ita cito potest in ea causare motum reflexum. 
+            dire<lb ed="#V" n="8" break="no"/>ctum nisi esset paries: non ita cito potest in ea causare motum reflexum. 
           </p>
           <p xml:id="kzz7yh-a89638-d1e762">
             <lb ed="#V" n="9"/>¶ Ad 2sm quod arguebatur de faba obuiante lapidi molari: dico 
@@ -448,7 +448,7 @@
             descen<lb ed="#V" n="25" break="no"/>sus esset in illo instanti. et ita superficies eius non contingeret in 
             <lb ed="#V" n="26"/>actu superficiem orbis lune: sed in pos secundum modum quo dicimus 
             <lb ed="#V" n="27"/>quod vltimum mobile est in posi quolibet indiuisibili ipsius spatii ante finem 
-            <lb ed="#V" n="28"/>motus ad esse ante alicui in poses: et non ad esse in actu non condicunt. 
+            <lb ed="#V" n="28"/>motus ad esse ante alicui in potentia: et non ad esse in actu non condicunt. 
           </p>
           <p xml:id="kzz7yh-a89638-d1e811">
             <lb ed="#V" n="29"/>Aliqui tamen dicunt quod positione retenta 
@@ -459,13 +459,13 @@
           <p xml:id="kzz7yh-a89638-d1e822">
             ¶ Ad 4m quod arguebatur de 
             prae<lb ed="#V" n="33" break="no"/>mutatione motus dicendum quod prima mutatio motus est nunc primo 
-            <lb ed="#V" n="34"/>ab esse terio a quo: et ita vltra hoc quod est ab esse terio a quo non 
-            <lb ed="#V" n="35"/>videtur dicere nisi ante hoc instans non abfuisse terio a quo: et ita 
+            <lb ed="#V" n="34"/>ab esse termino a quo: et ita vltra hoc quod est ab esse terio a quo non 
+            <lb ed="#V" n="35"/>videtur dicere nisi ante hoc instans non abfuisse termino a quo: et ita 
             prae<lb ed="#V" n="36" break="no"/>mutatio motus non dicit nisi ab esse huic signo a qui incipit 
             <lb ed="#V" n="37"/>motus: et immediatam ordinationem ad fuisse illi signo. quia sicut 
             <lb ed="#V" n="38"/>illa mutatio motus est nunc primo esse hic: et ante non fuisse ita 
             prae<lb ed="#V" n="39" break="no"/>mutatio motus est nunc primo non esse hic: quod est non esse hic: et 
-            <lb ed="#V" n="40"/>ante hoc instans sbi fuisse. dico ergo quod prima mutatio motus ratione 
+            <lb ed="#V" n="40"/>ante hoc instans ibi fuisse. dico ergo quod prima mutatio motus ratione 
             <lb ed="#V" n="41"/>huius quod est non adesse illi signo a quo incipit motus manet per 
             <lb ed="#V" n="42"/>totum motum: sed immediate ordinatio ipsius non ad esse illi 
             signo<lb ed="#V" n="43" break="no"/>ad hoc quod est ad esse illi signo corrumpitur non tamen in instanti: sed 
@@ -483,7 +483,7 @@
             ¶ 
             Ar<lb ed="#V" n="50" break="no"/>ad partem aliam gratia conclusionis concedantur. Sciendum tamen quod Auicena 
             <lb ed="#V" n="51"/>in auctoritate praeallegata non videtur sanum habuisse intellectum videtur enim ad hoc 
-            <lb ed="#V" n="52"/>eam adduxisse: vt ex hoc declaranet: nion posse fieni aliquid ni de aliquodo
+            <lb ed="#V" n="52"/>eam adduxisse: vt ex hoc declararet: non posse fieri aliquid nisi de aliquo
           </p>
         </div>
         <div xml:id="kzz7yh-a89638-Dd1e875">
@@ -510,13 +510,13 @@
           <p xml:id="kzz7yh-a89638-d1e908">
             ¶ Item Ansel. in libro de concor. praescientie et liero arbitri non multum 
             <lb ed="#V" n="63"/>post prin. Pariter verum est: quia fuit et est: et erit aliquid non ex 
-            ne<lb ed="#V" n="64" break="no"/>cessitate. sed illud quod erit non est ita neccessatum quin possit non 
+            ne<lb ed="#V" n="64" break="no"/>cessitate. sed illud quod erit non est ita necessarium quin possit non 
             fore<lb ed="#V" n="65" break="no"/>ergo illud quod fuit non est ita necessarium quin possit non fuisse. 
           </p>
           <p xml:id="kzz7yh-a89638-d1e918">
-            <lb ed="#V" n="66"/>Contra <ref xml:id="kzz7yh-a89638-Rd1e979">Ansel. in eo libro</ref> non multum post prienm non potest 
+            <lb ed="#V" n="66"/>Contra <ref xml:id="kzz7yh-a89638-Rd1e979">Ansel. in eo libro</ref> non multum post <unclear>principium</unclear> non potest 
             <lb ed="#V" n="67"/>fieri: vt res quae praeterita est: fiat non praeterita: sicut 
-            <lb ed="#V" n="68"/>res quaedam quie proesenus est: potest fieri non proaesenus. et aliqua res quie non 
+            <lb ed="#V" n="68"/>res quaedam quae praesens est: potest fieri non praesens. et aliqua res quae non 
             ne<lb ed="#V" n="69" break="no"/>cessitate futura est: potest fieri vt non sit futura. Item philosophus 6 libro 
             <!--00276.xml-->
             <cb ed="#P" n="b"/>
@@ -548,17 +548,17 @@
             <lb ed="#V" n="88"/>malum: non potest fieri praesens nisi deo permittente. deus autem potest 
             <lb ed="#V" n="89"/>prohibere: sed rem fuisse postquam praeterita est: nec dependet ex dei 
             <lb ed="#V" n="90"/>manutenentia nec ex eius operatione vel promissione. Unde si 
-            <lb ed="#V" n="91"/>omnis creatuta redigeretur in nihilum: adhuc deus verbo suo 
+            <lb ed="#V" n="91"/>omnis <sic>creatuta</sic> redigeretur in nihilum: adhuc deus verbo suo 
             <lb ed="#V" n="92"/>dicendo creaturam fuisse diceret verum.
           </p>
           <p xml:id="kzz7yh-a89638-d1e991">
             ¶ Ad 3m cum dicitur quod omne 
             <lb ed="#V" n="93"/>creatum deus potest destruere etc. dico quod verum est: non tamen potest 
             facen<lb ed="#V" n="94" break="no"/>quod creature non sint a deo intellecte: sicut non potest facere vt 
-            <lb ed="#V" n="95"/>essenus sua non sit creaturarum repraesentatiua. vnde quamuis deus possit de 
+            <lb ed="#V" n="95"/>essentia sua non sit creaturarum repraesentatiua. vnde quamuis deus possit de 
             <lb ed="#V" n="96"/>struere omne esse reale actualis veritatis create: non tamen potest 
-            <lb ed="#V" n="97"/>facere quan veritas creata sit ab eo intellecta. Unde si omnis creatura 
-            <lb ed="#V" n="98"/>redigeretur in nihilum adhuc detu dicendo verbo suo Paulum 
+            <lb ed="#V" n="97"/>facere quin veritas creata sit ab eo intellecta. Unde si omnis creatura 
+            <lb ed="#V" n="98"/>redigeretur in nihilum adhuc deus dicendo verbo suo Paulum 
             praedi<lb ed="#V" n="99" break="no"/>casse diceret verum: et intelligendo paulum praedicasse intelligeret 
             <lb ed="#V" n="100"/>veritatem creatam.
           </p>
@@ -586,7 +586,7 @@
             <lb ed="#V" n="112"/>¶ Item <ref xml:id="kzz7yh-a89638-Rd1e1116">Boe. 4o libro de conso.</ref> longe vltra medium dicit: qui 
             <lb ed="#V" n="113"/>ordo fatalis ex prouidentie simplicitate procedit: sed ordinem 
             <lb ed="#V" n="114"/>fatalem videtur vocare connexionem causarum secundum quam res 
-            <lb ed="#V" n="115"/>adminstrantur: ergo videtur quod sicut deus nihil potest facere enta 
+            <lb ed="#V" n="115"/>administrantur: ergo videtur quod sicut deus nihil potest facere contra 
             <lb ed="#V" n="116"/>simplicitatem prouidentie sue: cum sit ratio constituta in eius 
             <lb ed="#V" n="117"/>mente: vt habetur in eodem libro quod ita nihil potest facere contra 
             <lb ed="#V" n="118"/>connexionem causarum rebus inditam: et sic nihil potest facere 
@@ -609,7 +609,7 @@
           <p xml:id="kzz7yh-a89638-d1e1087">
             <lb ed="#V" n="126"/>Respondeo quod natura potest accipi dupliciter. 
             <lb ed="#V" n="127"/>vno modo pro vi rebus insita: qua 
-            <lb ed="#V" n="128"/>explent suos vsitatos cursus: siue in agendo siue in patiem 
+            <lb ed="#V" n="128"/>explent suos vsitatos cursus: siue in agendo siue in patien 
             <lb ed="#V" n="129"/>do: et sic accipiendo naturam deus multa facit et plura posset 
             <lb ed="#V" n="130"/>facere si vellet contra naturam.
           </p>
@@ -631,7 +631,7 @@
             <lb ed="#V" n="3"/>de causalibus rationibus mundo inditis. cum primum deus simul 
             <lb ed="#V" n="4"/>creauit omnia sic vicit: restat vt ad vtrumque modum hiles 
             crea<lb ed="#V" n="5" break="no"/>te sint ad istum quo vsitatissime temporalia recurrunt: siue ad 
-            <lb ed="#V" n="6"/>illum quo rara et mirabilia siunt: sicut deo facere 
+            <lb ed="#V" n="6"/>illum quo rara et mirabilia fiunt: sicut deo facere 
             placue<lb ed="#V" n="7" break="no"/>rit quod tempori congruat. Accipitur est hoc distinctio ex sententia 
             <lb ed="#V" n="8"/>eiusdem. 9. libro super Genses non multum ante finem libro vbi post 
             <lb ed="#V" n="9"/>quam locutus est de natura primo modo dicta. postea de natura 
@@ -679,7 +679,7 @@
             sim<lb ed="#V" n="36" break="no"/>pliciter secundum causam superiorem vel 
             inferio<lb ed="#V" n="37" break="no"/>rem et videtur quod secundum causam superiorem. Dicit enim <ref xml:id="kzz7yh-a89638-Rd1e1297">Aug. 6. 
               <lb ed="#V" n="38"/>super Genesem longe vltra medium libro</ref> quod multa secundum 
-            infe<lb ed="#V" n="39" break="no"/>riores causas sunt futura: sed si ita sunt in paentia dei vere 
+            infe<lb ed="#V" n="39" break="no"/>riores causas sunt futura: sed si ita sunt in praesentia dei vere 
             fu<lb ed="#V" n="40" break="no"/>tura sunt: si autem ibi aliter sunt ita post futura sunt: sicut ibi sunt 
             <lb ed="#V" n="41"/>vbi qui praescit falli non potest: ergo asimili que sunt possibilia: secundum causam 
             <lb ed="#V" n="42"/>superiorem vere possibilia sunt.
@@ -718,9 +718,9 @@
             di<lb ed="#V" n="63" break="no"/>co quod illud est possibile simpliciter quod contradictionem non includit. eo n. 
             <lb ed="#V" n="64"/>ipso quod extrema repugnantia contradictionis non includunt quantum 
             <lb ed="#V" n="65"/>est ex parte sua nata sunt coniungi per aliquam potentiam nisi ex parte 
-            <lb ed="#V" n="66"/>posio sit defectus. Et quia divina pos nullum pacieitus habet defectum. Ideo omne 
+            <lb ed="#V" n="66"/>potentiae sit defectus. Et quia divina potentia nullum penitus habet defectum. Ideo omne 
             <lb ed="#V" n="67"/>illud quod non includit contradictionem subitantum est divinae posti et hoc modo possibile 
-            <lb ed="#V" n="68"/>non dicitur: quia super ipsum possit causa superior vel inferior: sedeous 
+            <lb ed="#V" n="68"/>non dicitur: quia super ipsum possit causa superior vel inferior: sed econverso. 
             <!--00277.xml-->
             <cb ed="#P" n="b"/>
           </p>
@@ -766,7 +766,7 @@
           </p>
           <p xml:id="kzz7yh-a89638-d1e1375">
             ¶ Item 
-            <lb ed="#V" n="96"/>psalmum. Ego cognoui quod magnus est dominus et deus noster priomibus diis 
+            <lb ed="#V" n="96"/>psalmum. Ego cognoui quod magnus est dominus et deus noster prioribus diis 
             <lb ed="#V" n="97"/>omnia quecumque voluit dominus fecit: hic videtur psal. reddere rationem 
             <lb ed="#V" n="98"/>magnitudinis divinae potentiae per hoc quod facit quicquid vult: ergo videtur quod est 
             <lb ed="#V" n="99"/>omnipotens: quia potest quicquid vult se posse.
@@ -780,7 +780,7 @@
           <p xml:id="kzz7yh-a89638-d1e1395">
             <lb ed="#V" n="103"/><ref xml:id="kzz7yh-a89638-Rd1e1488">Contra. Aug. 13 de tri. c. 5</ref> Omnes beati habent quod volunt: ergo 
             <lb ed="#V" n="104"/>quilibet beatus potest quicquid vult se posse: nec tamen quilibet btus 
-            <lb ed="#V" n="105"/>estopsus: sed solus deus: ergo non ideo deus opostus: quia potest quicquid velt se posse. 
+            <lb ed="#V" n="105"/>omnipotens: sed solus deus: ergo non ideo deus omnipotens: quia potest quicquid vult se posse. 
             <!--TODO insert para break here-->
             <lb ed="#V" n="106"/>Respondeo quod deus est omnipotens: et potest omina quae vult se posse: sed 
             <lb ed="#V" n="107"/>ipsum posse omnia quae vult se posse: non est precisa 
@@ -795,9 +795,9 @@
           </p>
           <p xml:id="kzz7yh-a89638-d1e1425">
             ¶ Ad 2m dicendum quod in illo verbo non intendebat prsamsm 
-            redde<lb ed="#V" n="115" break="no"/>re rationem praecisam omnipotur dei per hoc quod fecit omnia quae voluit: sed 
-            intende<lb ed="#V" n="116" break="no"/>bat talem ostendem effcntum divinae omniposo quo possent corda hominum 
-            <lb ed="#V" n="117"/>reuocari et mannduci ad facilius credendum magnitudinem 
+            redde<lb ed="#V" n="115" break="no"/>re rationem praecisam omnipotentiae dei per hoc quod fecit omnia quae voluit: sed 
+            intende<lb ed="#V" n="116" break="no"/>bat talem ostendere effectum divinae omnipotentiae quo possent corda hominum 
+            <lb ed="#V" n="117"/>reuocari et manuduci ad facilius credendum magnitudinem 
             di<lb ed="#V" n="118" break="no"/>ne poe.
           </p>
           <p xml:id="kzz7yh-a89638-d1e1436">

--- a/kzz7yh-a89638/cod-ve07v1_kzz7yh-a89638.xml
+++ b/kzz7yh-a89638/cod-ve07v1_kzz7yh-a89638.xml
@@ -83,7 +83,7 @@
         </p>
         <p xml:id="kzz7yh-a89638-d1e141">
           ¶ Octauo vtrum deus ideo 
-          <lb ed="#V" n="58"/>dicatur opestus quia potest omnia quae vult se posse.
+          <lb ed="#V" n="58"/>dicatur omnipotens quia potest omnia quae vult se posse.
         </p>
         <div xml:id="kzz7yh-a89638-Dd1e146">
           <head xml:id="kzz7yh-a89638-Hd1e148">Quaestio 1</head>
@@ -101,7 +101,7 @@
           </p>
           <p xml:id="kzz7yh-a89638-d1e170">
             ¶ Item <ref xml:id="kzz7yh-a89638-Rd1e180">philosophus. 5. metaph. c. de ente.</ref> diuidit ens in ens 
-            <lb ed="#V" n="65"/>in actu: et in ens in postimus. cum ergo disio sit per opposmus: et oppotio non sint 
+            <lb ed="#V" n="65"/>in actu: et in ens in postimus. cum ergo disio sit per opposmus: et oppositio non sint 
             <lb ed="#V" n="66"/>in eodem. Uidetur cum deus sit actus simplex quod nullo modo est in 
             <lb ed="#V" n="67"/>ipso posimo.
           </p>
@@ -110,9 +110,9 @@
             pos<lb ed="#V" n="68" break="no"/>Sed in deo nihil est uo cuius sit aliquid prius. ergo in deo non est pos. 
           </p>
           <p xml:id="kzz7yh-a89638-d1e184">
-            <lb ed="#V" n="69"/>¶ Item sicut se habet infimum ens ad actum: ita se habet suprmum 
+            <lb ed="#V" n="69"/>¶ Item sicut se habet infimum ens ad actum: ita se habet supremum 
             <lb ed="#V" n="70"/>ens ad potentiam: sed in infimo ente: hoc est in ma nullus est 
-            <lb ed="#V" n="71"/>actus. Unde dicit philosophus. 2. de anima quod materia est pos: ergo in suprmo 
+            <lb ed="#V" n="71"/>actus. Unde dicit philosophus. 2. de anima quod materia est pos: ergo in supremo 
             <lb ed="#V" n="72"/>ente: hoc est in deo nullam est potentia. 
             <!--TODO: insert para break here-->
             <lb ed="#V" n="73"/>Contra prosal. ad deum. Potens es domine: et veritas tua 
@@ -120,7 +120,7 @@
           </p>
           <p xml:id="kzz7yh-a89638-d1e201">
             ¶ Item deus est 
-            <lb ed="#V" n="75"/>causa efficiens omnis creacure: sed non e causa efficiens sine posus ergo in 
+            <lb ed="#V" n="75"/>causa efficiens omnis creaturae: sed non est causa efficiens sine potentia ergo in 
             <lb ed="#V" n="76"/>deo est potentia respectu alterius a se. 
           </p>
           <p xml:id="kzz7yh-a89638-d1e208">
@@ -130,13 +130,13 @@
             ¶ Ad 
             <lb ed="#V" n="78"/>cuius intelligentiam sciendum quod secundum <ref xml:id="kzz7yh-a89638-Rd1e233">philosophum. 
               <lb ed="#V" n="79"/>5. metaphy. c.</ref> de posmo Uno modo potentia est principium tramsmutandi 
-            <lb ed="#V" n="80"/>aliud: et haec est pos actiua. Alio modo potentia dicitur principium tramsmutandi 
+            <lb ed="#V" n="80"/>aliud: et haec est pos actiua. Alio modo potentia dicitur principium transmutandi 
             <lb ed="#V" n="81"/>ab alio et hoc est potentia passiua. Cum ergo agere conueniat alicui 
             <lb ed="#V" n="82"/>secundum quod est ens actu: vt vult philosophus. 3. phy. Ideo pos actiua 
             <lb ed="#V" n="83"/>non repugnat puro actui: et ideo non obstante quod deus sit purus 
             <lb ed="#V" n="84"/>actus: immo concordante in deo est pos actiua: qua potest 
             tramsmu<lb ed="#V" n="85" break="no"/>tare alia a se: sed quia transmutari conuenit rei inquantum est 
-            possibile<lb ed="#V" n="86" break="no"/>secundum <ref xml:id="kzz7yh-a89638-Rd1e253">sententiam phlosophi. 3. phy.</ref> Qui vult quod nihil mouetur nisi imnquantum 
+            possibile<lb ed="#V" n="86" break="no"/>secundum <ref xml:id="kzz7yh-a89638-Rd1e253">sententiam phlosophi. 3. phy.</ref> Qui vult quod nihil mouetur nisi inquantum 
             <lb ed="#V" n="87"/>est possibile. et in deo nulla est possibilitas: cum sit purus actus: ideo 
             <lb ed="#V" n="88"/>in ipso nulla est potentia passiua respectu alterius a se. 
             <!--TODO: insert para break-->
@@ -145,9 +145,9 @@
           </p>
           <p xml:id="kzz7yh-a89638-d1e244">
             ¶ Ad 4m cum dicitur quod sicut se 
-            <lb ed="#V" n="91"/>habet infinitum ens ad actu: ita suprmum ens ad potentiam etc. potest 
+            <lb ed="#V" n="91"/>habet infinitum ens ad actu: ita supremum ens ad potentiam etc. potest 
             <lb ed="#V" n="92"/>dici quod verum est de potentia passiua quae est principium transmutandi 
-            <lb ed="#V" n="93"/>ab alio. et hoc potentia in suprimo ente non est. Quod quando non dicitur im 
+            <lb ed="#V" n="93"/>ab alio. et hoc potentia in supremo ente non est. Quod quando non dicitur im 
             mi<lb ed="#V" n="94" break="no"/>nori quod in materia nulla est actualitas: et supponitur quod est 
             infi<lb ed="#V" n="95" break="no"/>mum ens. hec dubia sunt apud aliquos et de hoc videbitur in 2o 
           </p>
@@ -174,7 +174,7 @@
           <p xml:id="kzz7yh-a89638-d1e287">
             <lb ed="#V" n="104"/>¶ Item scire malum est scire: et velle malum est velle: ergo a simil 
             <lb ed="#V" n="105"/>posse malum est posse: sed deus potest quicquid posse est posse: quia sicut 
-            <lb ed="#V" n="106"/>dicitur Exodi. 15 oprstus nomen eius: quod non esset verum nisi 
+            <lb ed="#V" n="106"/>dicitur Exodi. 15 omnipotens nomen eius: quod non esset verum nisi 
             <lb ed="#V" n="107"/>posset quicquid posse est posse: ergo potest malum. 
           </p>
           <p xml:id="kzz7yh-a89638-d1e299">
@@ -199,9 +199,9 @@
             obliquanst<lb ed="#V" n="121" break="no"/>velle facere istam auersionem: vel obliquationem in alio: quia iam essetam 
             <lb ed="#V" n="122"/>contrarius sibiipsi: et ideo deus non potest malum culpe. Cui veritati 
             <lb ed="#V" n="123"/>non tantum consentiunt sancti: sed est philosophi. Dicit enim Trimegistus in 
-            <lb ed="#V" n="124"/>libro de divinitate ad Asclepium quod voluntas dei est omnis bominitas 
+            <lb ed="#V" n="124"/>libro de divinitate ad Asclepium quod voluntas dei est omnis bonitas 
             <lb ed="#V" n="125"/>ex quo sequitur quod non potest peccare. Et Aui. 8. Meta. c. 3. 
-            di<lb ed="#V" n="126" break="no"/>cit quod bomnitas pura non est nisi necesse esse per se: et parumpost 
+            di<lb ed="#V" n="126" break="no"/>cit quod bonitas pura non est nisi necesse esse per se: et parumpost 
             di<lb ed="#V" n="127" break="no"/>cit quod est bonitas cui non subiectintrat perfectio: nec malitia. 
           </p>
           <p xml:id="kzz7yh-a89638-d1e351">
@@ -220,7 +220,7 @@
           <p xml:id="kzz7yh-a89638-d1e377">
             ¶ Argumenta ad partem secundam pro 
             <lb ed="#V" n="7"/>cedebant de malo culpe: et bene concessum est tale malum 
-            <lb ed="#V" n="8"/>non posse esse a deo ineque in se neque in alio. 
+            <lb ed="#V" n="8"/>non posse esse a deo neque in se neque in alio. 
           </p>
           <p xml:id="kzz7yh-a89638-d1e384">
             <lb ed="#V" n="9"/>Ad primum ad partem aliam cum dicitur quod poter malorum 
@@ -251,7 +251,7 @@
             <lb ed="#V" n="26"/>illud malum sit velle: tamen posse illud malum non est posse. Scire 
             <lb ed="#V" n="27"/>enim respicit rem quantum ad suum esse repraesentatum intellectui. et ideo 
             <lb ed="#V" n="28"/>quia carentia boni debiti repraesentatur intellectui per similitudinem 
-            <lb ed="#V" n="29"/>illuus boni debiti: cuius est carentia: ideo malitia quae est boni de 
+            <lb ed="#V" n="29"/>illius boni debiti: cuius est carentia: ideo malitia quae est boni de 
             <lb ed="#V" n="30"/>biti carentia potest sciri: et ipsum scire est scire quod est voluntas potest 
             <lb ed="#V" n="31"/>velle vel nolle rem cognitam: ideo voluntas potest velle malum 
             <lb ed="#V" n="32"/>non tamen sub ratione qua malum: quamuis sub ratione mali possit ipsum 
@@ -282,7 +282,7 @@
           </p>
           <p xml:id="kzz7yh-a89638-d1e489">
             ¶ Item posse bonum est posse: sed deus 
-            <lb ed="#V" n="47"/>est opistus: ergo potest omne bonum alicul rei possibile.
+            <lb ed="#V" n="47"/>est omnipotens: ergo potest omne bonum alicui rei possibile.
           </p>
           <p xml:id="kzz7yh-a89638-d1e494">
             ¶ Item non dicitur omnino 
@@ -304,35 +304,35 @@
             in<lb ed="#V" n="59" break="no"/>telligere et velle plura alia: et talia inueniuntur principalius in 
             <lb ed="#V" n="60"/>creatore quam in creatura: et ea potest efficere et efficit in 
             creatu<lb ed="#V" n="61" break="no"/>ra. Quedam autem de sni ratione impfectionem includunt est 
-            considera<lb ed="#V" n="62" break="no"/>ta in ratione generali: cuiusmoni sunt ambulare et corporaliter. loqu 
+            considera<lb ed="#V" n="62" break="no"/>ta in ratione generali: cuiusmodi sunt ambulare et corporaliter. loqu 
             <lb ed="#V" n="63"/>hec enim ita includunt imperfectionem quod non possunt esse in re aliqua: nisi 
             <lb ed="#V" n="64"/>inquantum ni illa est aliqua imperfectio. Unde dicit phy. 3. physi. c. 
             <lb ed="#V" n="65"/>de motu quod motus videtur esse actus sed imperfectus: quoniam imperfectum est cuius 
             <lb ed="#V" n="66"/>est actus: et talia deus non potest facere in seipso. illa tum efficit in 
             <lb ed="#V" n="67"/>creatura: et ideo sicut dicit magister in praesenti Di. c. 2. non per istas 
-            <lb ed="#V" n="68"/>actiones divinae potentie detrahitur aliquid: quia et hoc potest facere oprstus 
+            <lb ed="#V" n="68"/>actiones divinae potentie detrahitur aliquid: quia et hoc potest facere omnipotens 
             <lb ed="#V" n="69"/>deus.
           </p>
           <p xml:id="kzz7yh-a89638-d1e551">
-            ¶ Arguus ad partem primam concludunt quod omnium bonorum 
+            ¶ Arguo ad partem primam concludunt quod omnium bonorum 
             <!--00275.xml-->
             <cb ed="#P" n="b"/>
             <lb ed="#V" n="70"/>creature possibilium deus potest esse causa efficiens: et hoc verum est quia 
             <lb ed="#V" n="71"/>potest facere quod sint in alio. sed ex hoc non sequitur quod possit facere 
             <lb ed="#V" n="72"/>quod realiter sint in seipso: quia hoc posse non esset posse: quamuis hoc sit 
-            <lb ed="#V" n="73"/>posse in creautra quod potest illa facere esse in seipsa: sicut enim 
+            <lb ed="#V" n="73"/>posse in creatura quod potest illa facere esse in seipsa: sicut enim 
             di<lb ed="#V" n="74" break="no"/>cit magister in praesenti Di. c. 3. Sunt quaedam quae in aliis rebus 
             po<lb ed="#V" n="75" break="no"/>deputande sunt: in aliis vero minime
           </p>
           <p xml:id="kzz7yh-a89638-d1e571">
-            ¶ Argunenta ad partem aliam. 
+            ¶ Argumenta ad partem aliam. 
             <lb ed="#V" n="76"/>non plus concludunt nisi quod aliqua bona possunt esse realiter in creatura 
             <lb ed="#V" n="77"/>que realiter in deo esse non possunt: et hoc est verum. 
             <!--TODO: insert para break and question headers-->
             <lb ed="#V" n="78"/>QUarto queritur vtrum deus possit simul 
             contradicto<lb ed="#V" n="79" break="no"/>ria facere: et videtur quod sic: quia pila proiecta 
-            <lb ed="#V" n="80"/>contra parietem in eodem instanti in quo adest perieti abest 
-            <lb ed="#V" n="81"/>ei quia alioqun ibi quiesceret quod non videtur: sed ad esse et ab 
+            <lb ed="#V" n="80"/>contra parietem in eodem instanti in quo adest parieti abest 
+            <lb ed="#V" n="81"/>ei quia alioquin ibi quiesceret quod non videtur: sed ad esse et ab 
             <lb ed="#V" n="82"/>esse idem eidem in eodem instanti includit contradictionem: ergo 
             crea<lb ed="#V" n="83" break="no"/>tura potest facere contradictoriam simul: multo fortius ergo creator. 
           </p>
@@ -348,10 +348,10 @@
             <lb ed="#V" n="90"/>¶ Item deus potest creare vnum lapidem in tali dispositione quod 
             <lb ed="#V" n="91"/>superficies eius superior simul sit cum superficie quae est in concauo 
             or<lb ed="#V" n="92" break="no"/>bis lune: et quod ignis eius descensu in nullo resistat: nec aliquid sit 
-            <lb ed="#V" n="93"/>quod prohibeat lapidis descensum. tunc quaro autem in epdem instanti in quod 
+            <lb ed="#V" n="93"/>quod prohibeat lapidis descensum. tunc quaero autem in eodem instanti in quod 
             <lb ed="#V" n="94"/>creatus est separabitur eius superficies a superficie concaui orbis 
             lu<lb ed="#V" n="95" break="no"/>ne: aut in alio. si in alio cum inter qualibet duo instantia sit tempus 
-            <lb ed="#V" n="96"/>menum vt probatur 6 phy. tunc in illo medio tempore lapis quiescerat: 
+            <lb ed="#V" n="96"/>medium vt probatur 6 phy. tunc in illo medio tempore lapis quiescerat: 
             <lb ed="#V" n="97"/>quod irrationale videtur: quia nullum corpus extra suum locum quiescit nisi 
             vio<lb ed="#V" n="98" break="no"/>lenter. sequitur ergo quod in instanti sue creationis ab illa superficie se 
             <lb ed="#V" n="99"/>pararetur. et sic in eodem instanti illi superficiei adesset: et non ad 
@@ -370,13 +370,13 @@
             ¶ Item Ansel. in libro de concor. prescientie. et libero arbro longe post 
             <lb ed="#V" n="107"/>prin. Que magis opposita sunt quam ad ire et ab ire. Uidemus 
             <lb ed="#V" n="108"/>tamen cum transit aliquis de loco ad locum: quia idem ire est ab ire et 
-            <lb ed="#V" n="109"/>ad ire: ergo oppotmo simul eueniunt eidem: sed quae simul eidem conuenire 
+            <lb ed="#V" n="109"/>ad ire: ergo oppositio simul eueniunt eidem: sed quae simul eidem conuenire 
             <lb ed="#V" n="110"/>possunt: deus potest simul facere: ergo deus potest facere contradictoria simul. 
           </p>
           <p xml:id="kzz7yh-a89638-d1e661">
             <lb ed="#V" n="111"/>Contra <ref xml:id="kzz7yh-a89638-Rd1e716">Auice. 4 metaphy. c. 2.</ref> Agens non est potens 
             <lb ed="#V" n="112"/>super aliquid cum ipsum non fuerit in se possibile se 
-            <lb ed="#V" n="113"/>contradictoria simul esse non est in se possibile: ergo deus non potest facere contradictoria siml 
+            <lb ed="#V" n="113"/>contradictoria simul esse non est in se possibile: ergo deus non potest facere contradictoria simul 
           </p>
           <p xml:id="kzz7yh-a89638-d1e670">
             <lb ed="#V" n="114"/>¶ Item res non potest esse nisi per divinum velle: nec potest 
@@ -386,16 +386,16 @@
           </p>
           <p xml:id="kzz7yh-a89638-d1e681">
             <lb ed="#V" n="118"/>Respondeo quod deus non potest facere duo 
-            conradicto<lb ed="#V" n="119" break="no"/>ria simul esse non propter defectum poetentie
+            conradicto<lb ed="#V" n="119" break="no"/>ria simul esse non propter defectum potentie
             <lb ed="#V" n="120"/>ex parte sui: sed quia illud non habet rationem post vllo modo. Et si 
             quaerai<lb ed="#V" n="121" break="no"/>quare hoc non habet rationem possibilis dicendum quod huius non est alia ratio 
-            <lb ed="#V" n="122"/>reddenda nisi quod talis est natura: vel hitudo affirmationis et 
+            <lb ed="#V" n="122"/>reddenda nisi quod talis est natura: vel habitudo affirmationis et 
             ne<lb ed="#V" n="123" break="no"/>gationis: sicut si quaereretur quatia omne totum comprehendit partem et plus 
             <lb ed="#V" n="124"/>non esset reddenda alia ratio: nisi quod talis est natura totius et partis 
             <lb ed="#V" n="125"/>et si aliam rationem velis quaerere non esset ratio ita manifesta: sicut 
             <lb ed="#V" n="126"/>illud cuius quaereres reddere rationem nisi recurreres ad causam 
             <lb ed="#V" n="127"/>efficientem et exemplarem: dicendo quod talem instituit deus naturam toti 
-            <lb ed="#V" n="128"/>et partis et quod hoc exigit ratio sui exeplaris eterni: quod habent in 
+            <lb ed="#V" n="128"/>et partis et quod hoc exigit ratio sui exemplaris eterni: quod habent in 
             mente<lb ed="#V" n="129" break="no"/>dina.
           </p>
           <p xml:id="kzz7yh-a89638-d1e710">
@@ -422,7 +422,7 @@
           </p>
           <p xml:id="kzz7yh-a89638-d1e753">
             <lb ed="#V" n="6"/>Dicunt tamen quidam quod pila ibi quiescit tempore imperceptibili: 
-            <lb ed="#V" n="7"/>quia virtus per quam adhuc poterat moueni in 
+            <lb ed="#V" n="7"/>quia virtus per quam adhuc poterat moueri in 
             dire<lb ed="#V" n="8" break="no"/>ctum nisi esset peries: non ita cito potest in ea causare motum reflexum. 
           </p>
           <p xml:id="kzz7yh-a89638-d1e762">
@@ -468,7 +468,7 @@
             <lb ed="#V" n="40"/>ante hoc instans sbi fuisse. dico ergo quod prima mutatio motus ratione 
             <lb ed="#V" n="41"/>huius quod est non adesse illi signo a quo incipit motus manet per 
             <lb ed="#V" n="42"/>totum motum: sed immediate ordinatio ipsius non ad esse illi 
-            signo<lb ed="#V" n="43" break="no"/>ad hoc quod est ad esse illi signo corumpitur non tamen in instanti: sed 
+            signo<lb ed="#V" n="43" break="no"/>ad hoc quod est ad esse illi signo corrumpitur non tamen in instanti: sed 
             <lb ed="#V" n="44"/>in tempore: quia immediata ordinatio eorum non tollitur nisi per moram 
             in<lb ed="#V" n="45" break="no"/>termediam.
           </p>
@@ -477,7 +477,7 @@
             <lb ed="#V" n="46"/>respectu diuersorum ad ire et ab ire composita non sunt quamuis 
             re<lb ed="#V" n="47" break="no"/>spectu eiusdem sint composita: et respectu eiusdem teri simul esse 
             <lb ed="#V" n="48"/>non possunt: et quod hec fuerit intentio Anseli. patet per litteram immediate 
-            <lb ed="#V" n="49"/>astencedentem: et immediate sequentem auctoritatem paeallegatam.
+            <lb ed="#V" n="49"/>antecedentem: et immediate sequentem auctoritatem paeallegatam.
           </p>
           <p xml:id="kzz7yh-a89638-d1e865">
             ¶ 
@@ -499,17 +499,17 @@
           <p xml:id="kzz7yh-a89638-d1e892">
             ¶ Item de futuro potest facere quod numquam 
             eueni<lb ed="#V" n="58" break="no"/>at. ergo a simili de praeterito potest facere quod numquam fuerit: quia sicut 
-            <lb ed="#V" n="59"/>se habet futurum ad fore: ita praetenitum ad fuisse vt videtur.
+            <lb ed="#V" n="59"/>se habet futurum ad fore: ita praeteritum ad fuisse vt videtur.
           </p>
           <p xml:id="kzz7yh-a89638-d1e899">
             ¶ Item hoc 
             veri<lb ed="#V" n="60" break="no"/>tas: Paulus praedicauit est veritas creata: sed omne creatum deus 
-            <lb ed="#V" n="61"/>potest destruere: ergo potest sacere quod non sit verum Paulum 
+            <lb ed="#V" n="61"/>potest destruere: ergo potest facere quod non sit verum Paulum 
             praedi<lb ed="#V" n="62" break="no"/>casse.
           </p>
           <p xml:id="kzz7yh-a89638-d1e908">
             ¶ Item Ansel. in libro de concor. praescientie et liero arbitri non multum 
-            <lb ed="#V" n="63"/>post prin. Pariter verum est: quia fuit et est: et erit alquid non ex 
+            <lb ed="#V" n="63"/>post prin. Pariter verum est: quia fuit et est: et erit aliquid non ex 
             ne<lb ed="#V" n="64" break="no"/>cessitate. sed illud quod erit non est ita neccessatum quin possit non 
             fore<lb ed="#V" n="65" break="no"/>ergo illud quod fuit non est ita necessarium quin possit non fuisse. 
           </p>
@@ -526,13 +526,13 @@
           <p xml:id="kzz7yh-a89638-d1e938">
             <lb ed="#V" n="72"/>Respondeo quod deus non potest facere quod praeteritum non 
             fue<lb ed="#V" n="73" break="no"/>rit praeteritum: quia praeteritum non fuisse 
-            praeteri<lb ed="#V" n="74" break="no"/>tum non habet rationem possibilis vllomon: eo quod contradictionem 
+            praeteri<lb ed="#V" n="74" break="no"/>tum non habet rationem possibilis vllo modo: eo quod contradictionem 
             inclu<lb ed="#V" n="75" break="no"/>dit: sicut enim esse et non esse contradicunt: ita fuisse et non fuisse contradicunt 
             <lb ed="#V" n="76"/>sed rem esse praeteritam est ipsam fuisse: ergo rem esse praeteritam et ipsa 
             <lb ed="#V" n="77"/>numquam fuisse contradicunt. et ideo cum non hebeat rationem possibilem: 
-            vl<lb ed="#V" n="78" break="no"/>lo modo non subietacet divinae potentie. Unde Aug. libro 27. contra faustum 
+            vl<lb ed="#V" n="78" break="no"/>lo modo non subiacet divinae potentie. Unde Aug. libro 27. contra faustum 
             cir<lb ed="#V" n="79" break="no"/>ca medium: quisquis ita dicit. Si ipse deus est: faciat vt que facta 
-            <lb ed="#V" n="80"/>sunt non fuerint: non videt hoc se dicere: si ipse est oprstus faciat 
+            <lb ed="#V" n="80"/>sunt non fuerint: non videt hoc se dicere: si ipse est omnipotens faciat 
             <lb ed="#V" n="81"/>vt ea que vera sunt falsa sint. 
           </p>
           <p xml:id="kzz7yh-a89638-d1e962">
@@ -565,7 +565,7 @@
           <p xml:id="kzz7yh-a89638-d1e1011">
             ¶ Ad illud quod 4o arguebatur per auctoritatem 
             An<lb ed="#V" n="101" break="no"/>sel. dicendum quod intelligebat quod sicut res antequam esset praeterita non 
-            <lb ed="#V" n="102"/>erat neccessarium ipsam esse praeteritam: ita non fuit necessarium 
+            <lb ed="#V" n="102"/>erat necessarium ipsam esse praeteritam: ita non fuit necessarium 
             <lb ed="#V" n="103"/>creaturam esse praesentem antequam esset proaesens: nec creaturam esse 
             <lb ed="#V" n="104"/>futuram nisi cum hac conditione si esset futura.
           </p>
@@ -576,7 +576,7 @@
           <p xml:id="kzz7yh-a89638-d1e1027">
             <lb ed="#V" n="105"/>SExto quaeritur vtrum deus possit aliquid facere 
             <lb ed="#V" n="106"/>contra naturam: et videtur quod non <ref xml:id="kzz7yh-a89638-Rd1e1097">Augu. 6 de ci. dei. 
-              <lb ed="#V" n="107"/>c. 30</ref> dicit de deo quod sic admistrat omnia quae creauit vt ipsa 
+              <lb ed="#V" n="107"/>c. 30</ref> dicit de deo quod sic administrat omnia quae creauit vt ipsa 
             <lb ed="#V" n="108"/>proprios agere motus sinat: ergo deus nunquam facit contra proprios 
             <lb ed="#V" n="109"/>motus creature sibi naturaliter inditos: sed frustra est 
             po<lb ed="#V" n="110" break="no"/>tentia que interdum non reducitur ad actum: ergo 
@@ -639,7 +639,7 @@
             <lb ed="#V" n="11"/>et locutione asine. dedit quidem naturis: quas creauit: vt ex 
             <lb ed="#V" n="12"/>eis hec fieri posset: neque enim ex eis illa faceret: quod eis fieri non 
             <lb ed="#V" n="13"/>posset ipse praefigeret: quoniam seipso non est: nec ipse potentior. 
-            <lb ed="#V" n="14"/>verumtum alio modo dedit: vt non hoc heberent in motu 
+            <lb ed="#V" n="14"/>verumtamen alio modo dedit: vt non hoc heberent in motu 
             natura<lb ed="#V" n="15" break="no"/>li: sed in eo quod ita creata essent: vt eorum natura 
             volunta<lb ed="#V" n="16" break="no"/>ti potentiori amplius subiaceret. 
           </p>
@@ -654,10 +654,10 @@
             or<lb ed="#V" n="21" break="no"/>do fatalis ex prouidentie simplicitate procedit etc. dico quod 
             quam<lb ed="#V" n="22" break="no"/>uis connexio carum secundum quam agunt cursus naturales dependeat 
             <lb ed="#V" n="23"/>ex simplicitate divine prouidentie: tamen in simplicitate divinae proui 
-            <lb ed="#V" n="24"/>dentie est vt contra illa connexiionem ab actore creaturarum aliquid 
-            pos<lb ed="#V" n="25" break="no"/>set fieri. non enim illa connexio rebus temporalibus indita equit prouidetie 
+            <lb ed="#V" n="24"/>dentie est vt contra illa connexionem ab actore creaturarum aliquid 
+            pos<lb ed="#V" n="25" break="no"/>set fieri. non enim illa connexio rebus temporalibus indita equit providentiae 
             <lb ed="#V" n="26"/>divinae immensitatem. vnde sic dicit Boe. 4 de conso. parum post auctoritatem 
-            <lb ed="#V" n="27"/>praeallegatam: sicut ad eternitatem se habet tempus: et ad puctum 
+            <lb ed="#V" n="27"/>praeallegatam: sicut ad eternitatem se habet tempus: et ad punctum 
             me<lb ed="#V" n="28" break="no"/>dium circulus ita fati series mobilis ad prouidentie stabilem 
             <lb ed="#V" n="29"/>simplicitatem.
           </p>
@@ -666,7 +666,7 @@
             <lb ed="#V" n="30"/>secundum rationem rectam vt procedere debeat nisi cum deus ex speciali 
             di<lb ed="#V" n="31" break="no"/>spensatione vult quod eueniat contrarium. Unde et secundum rationem 
             <lb ed="#V" n="32"/>rectam est quod ille cursus intermittatur quando placet 
-            volunta<lb ed="#V" n="33" break="no"/>ti divine. Argumentad partem aliam probant deum posse facere contra naturam 
+            volunta<lb ed="#V" n="33" break="no"/>ti divine. Argumenta ad partem aliam probant deum posse facere contra naturam 
             <lb ed="#V" n="34"/>primo dictam: que secundum communem vsum vocatur natura.
           </p>
         </div>
@@ -682,7 +682,7 @@
             infe<lb ed="#V" n="39" break="no"/>riores causas sunt futura: sed si ita sunt in paentia dei vere 
             fu<lb ed="#V" n="40" break="no"/>tura sunt: si autem ibi aliter sunt ita post futura sunt: sicut ibi sunt 
             <lb ed="#V" n="41"/>vbi qui praescit falli non potest: ergo asimili que sunt possibilia: secundum causam 
-            <lb ed="#V" n="42"/>superiorem vere possibutia sunt.
+            <lb ed="#V" n="42"/>superiorem vere possibilia sunt.
           </p>
           <p xml:id="kzz7yh-a89638-d1e1232">
             ¶ Item glo. super illud i. ad Corum i 
@@ -696,7 +696,7 @@
             po<lb ed="#V" n="47" break="no"/>tentiam simpliciter: sed sola dei potentia: est simpliciter potentia: 
             <lb ed="#V" n="48"/>ergo simpliciter est possibile quod ille potentie est possibile. 
             <!--TODO: insert para break here-->
-            <lb ed="#V" n="49"/>Contra Si possibile simpliciter diceretur quicquid poetest diuina  
+            <lb ed="#V" n="49"/>Contra Si possibile simpliciter diceretur quicquid potest diuina  
             prouiden<lb ed="#V" n="50" break="no"/>tia: cum nihil sit impossibile apod ipsam: nihil posset 
             <lb ed="#V" n="51"/>dici impossibile simpliciter quod falsum videtur.
           </p>
@@ -709,9 +709,9 @@
             <lb ed="#V" n="54"/>¶ Respondeo quod simpliter possibile potest dici aliquid quantum est 
             <lb ed="#V" n="55"/>ex parte sua aliquo modo in comparatione ad aliquam 
             <lb ed="#V" n="56"/>positinam. primo modo est simpliciter possibile quod natum est esse subiectum 
-            <lb ed="#V" n="57"/>alicuius postnisi ex parte potentie sit defectus sicut dicimus aliquid 
+            <lb ed="#V" n="57"/>alicuius potentiae nisi ex parte potentie sit defectus sicut dicimus aliquid 
             <lb ed="#V" n="58"/>simpliciter possibile videri quantum est ex parte sua quod natum est esse 
-            <lb ed="#V" n="59"/>obisictetm alicuius visiue postinisi ex parte visiue possit defectus. Unde 
+            <lb ed="#V" n="59"/>obiectum alicuius visiue potentiae nisi ex parte visiue possit defectus. Unde 
             <lb ed="#V" n="60"/>si omnes potentie visiue essent ita obtuse quod non possent 
             viden<lb ed="#V" n="61" break="no"/>aliquid quod natum est videri a pos visiua si sit acuta: non propter 
             <lb ed="#V" n="62"/>hoc negaremus illud possibile videri quantum est ex parte sua. et sic 
@@ -731,15 +731,15 @@
             <lb ed="#V" n="72"/>super illud quod possit causa inferior siue non. vnde pluuiam 
             <lb ed="#V" n="73"/>fore possibile secundum causam superiorem quamuis cum hoc sit possibile secundum causam 
             in<lb ed="#V" n="74" break="no"/>feriorem animam creari: mortuum resurgere: et plura alia ita sunt 
-            <lb ed="#V" n="75"/>possilbitia secundum causam superiorem: quod non sunt poslbitia secundum causam inferiore 
+            <lb ed="#V" n="75"/>possibilia secundum causam superiorem: quod non sunt possibilia secundum causam inferiore 
             <lb ed="#V" n="76"/>et sic patet quod omne illud super quod potest causa superior tantum: vel causa superior 
             <lb ed="#V" n="77"/>et inferior simul est simpliciter et absolute possibile quantum est ex parte sua: 
             <lb ed="#V" n="78"/>aliter super ipsum non posset nec causa inferior: nec superior. Ex his 
             <lb ed="#V" n="79"/>patet quid dici debeat ad argumenta ad vtranque partem. 
             <!--TODO: insert para break here-->
             <lb ed="#V" n="80"/>Argumenta ad primam partem concludunt quod ea quae possibilia 
-            <lb ed="#V" n="81" break="no"/>sunt causae superiori simpliciter polbitia sunt: et 
-            <lb ed="#V" n="82"/>hoc est verum quia nulla poso potest super aliquid quod non est simpliciter
+            <lb ed="#V" n="81" break="no"/>sunt causae superiori simpliciter possibilia sunt: et 
+            <lb ed="#V" n="82"/>hoc est verum quia nulla potentia potest super aliquid quod non est simpliciter
             <lb ed="#V" n="83"/>et absolute possibile quantum est ex parte sua.
           </p>
           <p xml:id="kzz7yh-a89638-d1e1338">
@@ -757,7 +757,7 @@
           <head xml:id="kzz7yh-a89638-Hd1e1445" type="question-title">Utrum deus ideo dicatur omnipotens quia</head>
           <p xml:id="kzz7yh-a89638-d1e1359">
             ¶ Quaestio VIII 
-            <lb ed="#V" n="90"/>Etauo queritur vtrum deus ideo dicatur omnipotens 
+            <lb ed="#V" n="90"/>Octauo queritur vtrum deus ideo dicatur omnipotens 
             <lb ed="#V" n="91"/>quia potest omina quae vult se posse: et videtur quod 
             <lb ed="#V" n="92"/>sic: quia ideo est omnisciens: quia scit omnia quae vult se scire: ergo a 
             <lb ed="#V" n="93"/>simili ideo est omnipotens: quia potest omnia que vult se posse. 
@@ -768,13 +768,13 @@
             ¶ Item 
             <lb ed="#V" n="96"/>psalmum. Ego cognoui quod magnus est dominus et deus noster priomibus diis 
             <lb ed="#V" n="97"/>omnia quecumque voluit dominus fecit: hic videtur psal. reddere rationem 
-            <lb ed="#V" n="98"/>magnitudis divinae postuo per hoc quod facit quicquid vult: ergo videtur quod est 
+            <lb ed="#V" n="98"/>magnitudinis divinae potentiae per hoc quod facit quicquid vult: ergo videtur quod est 
             <lb ed="#V" n="99"/>omnipotens: quia potest quicquid vult se posse.
           </p>
           <p xml:id="kzz7yh-a89638-d1e1386">
-            ¶ Item non est opostus ideo 
-            <lb ed="#V" n="100"/>quia potest omnia possibitia creature: nec ideo quia potest omnia possibutia sibi: quia hoc 
-            <lb ed="#V" n="101"/>esset dicere quod ideo est oprstus quia est opstus. Restat ergo quod ideo 
+            ¶ Item non est omnipotens ideo 
+            <lb ed="#V" n="100"/>quia potest omnia possibilia creature: nec ideo quia potest omnia possibilia sibi: quia hoc 
+            <lb ed="#V" n="101"/>esset dicere quod ideo est omnipotens quia est opstus. Restat ergo quod ideo 
             <lb ed="#V" n="102"/>est omnipotens quia potest omnia que vult se posse. 
           </p>
           <p xml:id="kzz7yh-a89638-d1e1395">
@@ -782,15 +782,15 @@
             <lb ed="#V" n="104"/>quilibet beatus potest quicquid vult se posse: nec tamen quilibet btus 
             <lb ed="#V" n="105"/>estopsus: sed solus deus: ergo non ideo deus opostus: quia potest quicquid velt se posse. 
             <!--TODO insert para break here-->
-            <lb ed="#V" n="106"/>Respondeo quod deus est opistus: et potest omina quae vult se posse: sed 
+            <lb ed="#V" n="106"/>Respondeo quod deus est omnipotens: et potest omina quae vult se posse: sed 
             <lb ed="#V" n="107"/>ipsum posse omnia quae vult se posse: non est precisa 
-            <lb ed="#V" n="108"/>ratio omnipoieosue: sed ideo esse opstus dici debet: quia potest omne illud quod est possibile ab 
+            <lb ed="#V" n="108"/>ratio omnipotentiae: sed ideo esse omnipotens dici debet: quia potest omne illud quod est possibile ab 
             <lb ed="#V" n="109"/>solute: hoc est possibile quod in praecedenti quaestione dictum est pole quantum est 
             <lb ed="#V" n="110"/>ex parte sua: et hoc est omen illud quod non includit contradictionem. 
             <!--TODO insert para break here-->
             <lb ed="#V" n="111"/>Ad primum in oppositum cum dicitur quod ideo est omnisciens: quia scit omnia quae vult se 
             sci<lb ed="#V" n="112" break="no"/>re etc. dico quod quamuis sit omnisciens: et sciat omnia quae vult se 
-            sci<lb ed="#V" n="113" break="no"/>re: sen tamen dicitur omnisciens: ideo quia scit omnia quae vult se scire: sed quia scit omnia 
+            sci<lb ed="#V" n="113" break="no"/>re: sed tamen dicitur omnisciens: ideo quia scit omnia quae vult se scire: sed quia scit omnia 
             <lb ed="#V" n="114"/>scibilia.
           </p>
           <p xml:id="kzz7yh-a89638-d1e1425">
@@ -804,7 +804,7 @@
             ¶ Ad 3m dicendum quod ab insufficienti procedit quia ideo debet 
             di<lb ed="#V" n="119" break="no"/>ci omnipotens: quia potest omne illud: quod quantum est ex parte sua est 
             pos<lb ed="#V" n="120" break="no"/>sibile quod aliqui dicunt possibile absolutum: et hoc est omne 
-            il<lb ed="#V" n="121" break="no"/>lud quod non iucludit contradictionem vt iam dictum est. 
+            il<lb ed="#V" n="121" break="no"/>lud quod non includit contradictionem vt iam dictum est. 
           </p>
         </div>
       </div>


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve07v1_kzz7yh-a89638.xml`.

## Applied changes

- p. 130v l. 58: opestus → omnipotens: garbled OCR of 'omnipotens'
- p. 130v l. 65: oppotio → oppositio: missing 'si'
- p. 130v l. 69: suprmum → supremum: missing 'e'
- p. 130v l. 71: suprmo → supremo: missing 'e'
- p. 130v l. 75: creacure → creaturae; posus → potentia: OCR errors; missing 'est'
- p. 130v l. 80: tramsmutandi → transmutandi: transposed letters
- p. 130v l. 86: imnquantum → inquantum: spurious 'm'
- p. 130v l. 91: suprmum → supremum: missing 'e'
- p. 130v l. 93: suprimo → supremo: spurious 'i'
- p. 130v l. 106: oprstus → omnipotens: garbled OCR of 'omnipotens'
- p. 130v l. 124: bominitas → bonitas: OCR misread b-o-m/n
- p. 130v l. 126: bomnitas → bonitas: OCR misread
- p. 131r l. 8: ineque → neque: spurious 'i'
- p. 131r l. 29: illuus → illius: u/i transposition
- p. 131r l. 47: opistus → omnipotens; alicul → alicui: OCR errors
- p. 131r l. 62: cuiusmoni → cuiusmodi: OCR misread
- p. 131r l. 68: oprstus → omnipotens: garbled OCR
- p. 131r l. 69: Arguus → Arguo: doubled 'u'
- p. 131r l. 73: creautra → creatura: transposed letters
- p. 131r l. 75: Argunenta → Argumenta: missing 'm'
- p. 131r l. 80: perieti → parieti: e/a misread
- p. 131r l. 81: alioqun → alioquin: missing 'i'
- p. 131r l. 93: quaro → quaero: missing 'e'; epdem → eodem: OCR misread
- p. 131r l. 96: menum → medium: OCR misread
- p. 131r l. 109: oppotmo → oppositio: garbled
- p. 131r l. 113: siml → simul: missing 'u'
- p. 131r l. 119: poetentie → potentie: spurious 'e'
- p. 131r l. 122: hitudo → habitudo: missing 'ab'
- p. 131r l. 128: exeplaris → exemplaris: missing 'm'; eterni: valid medieval spelling
- p. 131v l. 7: moueni → moueri: n/r misread
- p. 131v l. 43: corumpitur → corrumpitur: missing 'r'
- p. 131v l. 49: astencedentem → antecedentem: OCR garble
- p. 131v l. 59: praetenitum → praeteritum: n/r misread
- p. 131v l. 61: sacere → facere: long-s misread
- p. 131v l. 63: alquid → aliquid: missing 'i'
- p. 131v l. 74: vllomon → vllo modo: contracted
- p. 131v l. 78: subietacet → subiacet: OCR garble
- p. 131v l. 80: oprstus → omnipotens: garbled OCR of 'omnipotens'
- p. 131v l. 102: neccessarium → necessarium: doubled c
- p. 131v l. 107: admistrat → administrat: missing in
- p. 132r l. 14: verumtum → verumtamen: missing amen
- p. 132r l. 24: connexiionem → connexionem: doubled i
- p. 132r l. 25: prouidetie → providentiae: OCR garble
- p. 132r l. 27: puctum → punctum: missing n
- p. 132r l. 33: Argumentad → Argumenta ad: missing space
- p. 132r l. 42: possibutia → possibilia: OCR garble
- p. 132r l. 49: poetest → potest: spurious e
- p. 132r l. 57: postnisi → potentiae nisi: OCR run-together
- p. 132r l. 59: obisictetm → obiectum: OCR garble; postinisi → potentiae nisi
- p. 132r l. 75: possilbitia poslbitia → possibilia: OCR garbles
- p. 132r l. 81: polbitia → possibilia: OCR garble
- p. 132r l. 82: poso → potentia: heavily abbreviated
- p. 132r l. 90: Etauo → Octauo: OCR misread of section heading
- p. 132r l. 98: magnitudis → magnitudinis: missing ni; postuo → potentiae: OCR garble
- p. 132r l. 99: opostus → omnipotens: garbled OCR
- p. 132r l. 100: possibitia possibutia → possibilia: OCR garbles
- p. 132r l. 101: oprstus → omnipotens: garbled OCR of 'omnipotens'
- p. 132r l. 106: opistus → omnipotens: garbled OCR
- p. 132r l. 108: omnipoieosue → omnipotentiae; opstus → omnipotens: OCR garbles
- p. 132r l. 113: sen → sed: OCR misread
- p. 132r l. 121: iucludit → includit: iu→in misread

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_