### PR TITLE
Transcription corrections: cod-ve07v1_kzz7yh-a91026.xml (1 change)

### DIFF
--- a/kzz7yh-a91026/cod-ve07v1_kzz7yh-a91026.xml
+++ b/kzz7yh-a91026/cod-ve07v1_kzz7yh-a91026.xml
@@ -276,7 +276,7 @@
           <div> l1d43prae 
           <head>Praeambulum</head> -->
         <p xml:id="kzz7yh-a91026-d1e567">
-          <lb ed="#V" n="87"/>Uidam tamen de suo sensu gltiantes etc. 
+          <lb ed="#V" n="87"/>Quidam tamen de suo sensu gloriantes etc. 
           <lb ed="#V" n="88"/>Superius agit magister de divinae 
           po<lb ed="#V" n="89" break="no"/>tentie vniuersalitate. In hac parte agit de divine 
           po<lb ed="#V" n="90" break="no"/>tentie immensitate et diditur pars ista in duas partes. 


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve07v1_kzz7yh-a91026.xml`.

## Applied changes

- p. 133r l. 87: Uidam → Quidam (U/Q misread); gltiantes → gloriantes (missing or)

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_