### PR TITLE
Transcription corrections: cod-ve07v1_kzz7yh-a91582.xml (57 changes)

### DIFF
--- a/kzz7yh-a91582/cod-ve07v1_kzz7yh-a91582.xml
+++ b/kzz7yh-a91582/cod-ve07v1_kzz7yh-a91582.xml
@@ -144,7 +144,7 @@
             nul<lb ed="#V" n="37" break="no"/>lam potentiam est finibilis neque finitus. 
           </p>
           <p xml:id="kzz7yh-a91582-d1e255">
-            <lb ed="#V" n="38"/>Ad primum cum dicctur quod infinitum secundum quod 
+            <lb ed="#V" n="38"/>Ad primum cum <sic>dicctur</sic> quod infinitum secundum quod 
             in<lb ed="#V" n="39" break="no"/>finitum est ignotum etc. dico quod 
             <lb ed="#V" n="40"/>intelligendum est de infinito opposito finitati: qua potentia 
             <lb ed="#V" n="41"/>sinitur per actum: quia potentia non cognoscitur a nobis nisi 
@@ -339,8 +339,8 @@
             rem<lb ed="#V" n="31" break="no"/>positiuam modo negatiuo. 
           </p>
           <p xml:id="kzz7yh-a91582-d1e616">
-            <lb ed="#V" n="32"/>Ad primum in oppositum dicendum quoillud verbum 
-            philosopi<lb ed="#V" n="33" break="no"/>debet intelligi de infinito 
+            <lb ed="#V" n="32"/>Ad primum in oppositum dicendum quod illud verbum 
+            philosophi<lb ed="#V" n="33" break="no"/>debet intelligi de infinito 
             oppo<lb ed="#V" n="34" break="no"/>sito finitati qua potentia finitur par actum: quia per talem 
             infini<lb ed="#V" n="35" break="no"/>tatem potentia recipit esse: et ideo infinitas opposita est 
             prae<lb ed="#V" n="36" break="no"/>uatio actus essendi. Talis autem infinitas in deo non est: sed 
@@ -372,7 +372,7 @@
             es<lb ed="#V" n="50" break="no"/>se finitum: et videtur quod sic: quia secundum philosophum. 8o physico. 
             <lb ed="#V" n="51"/>In essentia finita no est virtus infinita: sed quilibet 
             <lb ed="#V" n="52"/>creatura intellectualis habet virtutem infinitam intelligendo: 
-            <lb ed="#V" n="53"/>cum possit intelligere vniversale quod sub se virtualiter compehem 
+            <lb ed="#V" n="53"/>cum possit intelligere vniversale quod sub se virtualiter comprehen 
             <lb ed="#V" n="54"/>dit infinita: ergo quelibet creatura intellectualis habet 
             essen<lb ed="#V" n="55" break="no"/>tiam infinitam.
           </p>
@@ -406,7 +406,7 @@
           <p xml:id="kzz7yh-a91582-d1e731">
             <lb ed="#V" n="72"/>Contra. omne creatum habet esse receptum: sed esse tale 
             fi<lb ed="#V" n="73" break="no"/>nitum est versus superius scilicet versus illam actu 
-            <lb ed="#V" n="74"/>alitatem: quam recipit in se: ergo deus non potest producere aliquod 
+            <lb ed="#V" n="74"/>alietatem: quam recipit in se: ergo deus non potest producere aliquod 
             <lb ed="#V" n="75"/>creatum quod ex nulla parte sit futurum.
           </p>
           <p xml:id="kzz7yh-a91582-d1e742">
@@ -420,7 +420,7 @@
           <p xml:id="kzz7yh-a91582-d1e755">
             <lb ed="#V" n="81"/>Respondeo quod deus non posset facere aliquod 
             <lb ed="#V" n="82"/>infinitum quod ex nulla parte esset 
-            fi<lb ed="#V" n="83" break="no"/>nitum: quia quicquid deus potest facere aute est materia: aut est forma 
+            fi<lb ed="#V" n="83" break="no"/>nitum: quia quicquid deus potest facere aut est materia: aut est forma 
             <lb ed="#V" n="84"/>aut compositum ex vtroque sub materia comprehendendo omnem 
             <lb ed="#V" n="85"/>possibilitatem: et sub forma omnem actualitatem: sed aut deus non 
             <lb ed="#V" n="86"/>posset facere materiam per se: quia secundum aliquos hoc includit 
@@ -463,7 +463,7 @@
             <lb ed="#V" n="115"/>Ad primum in oppositum dicendum quod quamuis anima vel 
             <lb ed="#V" n="116"/>angelus intelligat vniuersale: 
             <lb ed="#V" n="117"/>non propter hoc sequitur quod habeat virtutem infinitam secundum 
-            omnem<lb ed="#V" n="118" break="no"/>respectum: sed quod se habet ad infinita in pontentia 
+            omnem<lb ed="#V" n="118" break="no"/>respectum: sed quod se habet ad infinita in <sic>pontentia</sic> 
             succes<lb ed="#V" n="119" break="no"/>siue: quod est habere virtutem infinitam secundum quid
           </p>
           <p xml:id="kzz7yh-a91582-d1e851">
@@ -638,7 +638,7 @@
             fi<lb ed="#V" n="97" break="no"/>nitum non imaginatur corpus non corpus. 
             <lb ed="#V" n="98"/>Alii dicunt quod esse dimensionem infinitam includit 
             <lb ed="#V" n="99"/>condictionem includendo partem equa 
-            <lb ed="#V" n="100"/>lem suo toti: quod declarant sic. Poitionatur linea infinita ex vtraque 
+            <lb ed="#V" n="100"/>lem suo toti: quod declarant sic. Ponatur linea infinita ex vtraque 
             <lb ed="#V" n="101"/>parte in quocumque loco signaueris disionem: diuidis eam in 
             <lb ed="#V" n="102"/>duas partes equales: quia ille partes si sibi supponantur nulla 
             ex<lb ed="#V" n="103" break="no"/>cedet aliam: tunc pono quod linea signetur in duobus locis. vnum 
@@ -653,7 +653,7 @@
             <lb ed="#V" n="109"/>equalis est illi: quia si superponatur sibi non excedet eam: nec 
             ex<lb ed="#V" n="110" break="no"/>cedetur ab ea: sed quecumque vni et eidem sunt equalia inter 
             <lb ed="#V" n="111"/>se sunt equalia: ergo sequitur quod illa pars linee que est vsque ad 
-            <lb ed="#V" n="112"/>a. et illud quod est inter a et bo siml sint equales: sed hec secunda 
+            <lb ed="#V" n="112"/>a. et illud quod est inter a et b simul sint equales: sed hec secunda 
             <lb ed="#V" n="113"/>est totum respectu prime: quia comprehendit totam primam: et tantum 
             <lb ed="#V" n="114"/>plus quantum est ab a. vsque ad b: et sic pars posset esse equalis toti. 
           </p>
@@ -856,7 +856,7 @@
           <head xml:id="kzz7yh-a91582-Hd1e1566">Quaestio 7</head>
           <p xml:id="kzz7yh-a91582-d1e1568">
             ¶ Quaesti. VII 
-            <lb ed="#V" n="112"/>Eptimo queritur vtrum deus possitalias 
+            <lb ed="#V" n="112"/>Septimo queritur vtrum deus possit aliqua 
             <lb ed="#V" n="113"/>de potentia absoluta que non 
             po<lb ed="#V" n="114" break="no"/>test de potentia ordinata: et videtur quod sic Aug. in libro de 
             <lb ed="#V" n="115"/>natura et gratia. cito post principium Dominus n<name xml:id="kzz7yh-a91582-Nd1e1578"/>
@@ -894,7 +894,7 @@
             <!--00284.xml-->
             <pb ed="#V" n="135-v"/>
             <cb ed="#P" n="a"/>
-            <lb ed="#V" n="1"/>et ratiotinabiliter disposuit: sic dico quod aliqua potest de poentia 
+            <lb ed="#V" n="1"/>et <sic>ratiotinabiliter</sic> disposuit: sic dico quod aliqua potest de <sic>poentia</sic> 
             <lb ed="#V" n="2"/>soluta que non potest de potentia ordinata: quia absolute potest 
             <lb ed="#V" n="3"/>quicquid non includit contradictionem vt superius ostensum est. 
             Si<lb ed="#V" n="4" break="no"/>autem dicatur posse de potentia ordinata posse illud quod se 
@@ -913,7 +913,7 @@
             An<lb ed="#V" n="15" break="no"/>sel. 2 libo cur deus et homo. c. 16 sic dicentem. Cur queritur 
             <lb ed="#V" n="16"/>vtrum idem deus homo potuerit seruare vitam suam vt 
             <lb ed="#V" n="17"/>nunquam moreretur dubitandum non est: quia semper. habuit 
-            potesta<lb ed="#V" n="18" break="no"/>tem seruandi: quamuis nequerit velle seruare: vt nunquam 
+            potesta<lb ed="#V" n="18" break="no"/>tem seruandi: quamuis <sic>nequerit</sic> velle seruare: vt nunquam 
             mo<lb ed="#V" n="19" break="no"/>reretur: sed prima solutio videtur mihi securior et 
             conuenien<lb ed="#V" n="20" break="no"/>tior: et secundum eam facilius est respondere ad vtriusque partis arguus. 
           </p>

--- a/kzz7yh-a91582/cod-ve07v1_kzz7yh-a91582.xml
+++ b/kzz7yh-a91582/cod-ve07v1_kzz7yh-a91582.xml
@@ -122,7 +122,7 @@
             <lb ed="#V" n="17"/>dicit quod credendum est deum esse infinitum. 
           </p>
           <p xml:id="kzz7yh-a91582-d1e209">
-            <lb ed="#V" n="18"/>Respondeo quod diuina esentia est infinita quod sic 
+            <lb ed="#V" n="18"/>Respondeo quod diuina essentia est infinita quod sic 
             <lb ed="#V" n="19"/>patet: sicut declaratum est supra. 8. Di. 
             <lb ed="#V" n="20"/>deus est summe simplex ex quo sequitur quod non componitur ex 
             <lb ed="#V" n="21"/>aliis: nec est componibilis: alii nec aliud componibile sibi 
@@ -133,7 +133,7 @@
             <lb ed="#V" n="26"/>ipso sit pars et pars: ita vt vna sit terminata par aliam. quod enim 
             <lb ed="#V" n="27"/>non est ex aliis componibile non habet partem et partem. 
             Re<lb ed="#V" n="28" break="no"/>stat ergo quod divina essentia ex nulla parte terminata est. Sed 
-            <lb ed="#V" n="29"/>omne finitum aliquomon terminatum est: aut versus superius 
+            <lb ed="#V" n="29"/>omne finitum aliquo modo terminatum est: aut versus superius 
             <lb ed="#V" n="30"/>inquantum in se recipit aliquid quod sibi aliqua actualitas 
             acqui<lb ed="#V" n="31" break="no"/>ritur: aut versus inferius inquantum recipitur in aliquo 
             ma<lb ed="#V" n="32" break="no"/>gis possibili autem intrinsecus cum partes habeat de sui 
@@ -153,7 +153,7 @@
           </p>
           <p xml:id="kzz7yh-a91582-d1e271">
             ¶ Ad 2m dicendum quod quamuis potentia que ita 
-            <lb ed="#V" n="44"/>potest hoc quod non illud sit finita: tamen ex hoc non sequtur 
+            <lb ed="#V" n="44"/>potest hoc quod non illud sit finita: tamen ex hoc non sequitur 
             <lb ed="#V" n="45"/>quod essentia que ita est hoc quod non illud sit finita: quia infinitas 
             <lb ed="#V" n="46"/>essentie non attenditur hoc quod sit in hoc ens: et illud ens et sit 
             <lb ed="#V" n="47"/>sine sine: sed in habendo in se perfectiones infinitorum 
@@ -172,7 +172,7 @@
           <head xml:id="kzz7yh-a91582-Hd1e301">Quaestio 2</head>
           <p xml:id="kzz7yh-a91582-d1e303">
             <lb ed="#V" n="54"/>¶ Questio. II. 
-            <lb ed="#V" n="55"/>Ecundo queritur vtrum potentia dei sit 
+            <lb ed="#V" n="55"/>Secundo queritur vtrum potentia dei sit 
             <lb ed="#V" n="56"/>infinita: et videtur quod non. 
             Infi<lb ed="#V" n="57" break="no"/>nitum a nullo exceditur nec a se: nec ab alio: sed 
             po<lb ed="#V" n="58" break="no"/>tentia dei exceditur a sua substantia. Multa enim scit deus quae 
@@ -180,9 +180,9 @@
             <lb ed="#V" n="60"/>infinita.
           </p>
           <p xml:id="kzz7yh-a91582-d1e321">
-            ¶ Item Aug. de symbolo. lib ist prope principium 
+            ¶ Item Aug. de symbolo. lib. i. prope principium 
             <lb ed="#V" n="61"/>hoc solum non potest deus quod non vult: sed non vult 
-            in<lb ed="#V" n="62" break="no"/>finita: ergo non potest ea: sua ergo poso infinita non est. 
+            in<lb ed="#V" n="62" break="no"/>finita: ergo non potest ea: sua ergo potentia infinita non est. 
           </p>
           <p xml:id="kzz7yh-a91582-d1e328">
             <lb ed="#V" n="63"/>¶ Item secundum philosophum 8. physi. si potentia alicuius corporis esset 
@@ -201,7 +201,7 @@
           </p>
           <p xml:id="kzz7yh-a91582-d1e356">
             ¶ Item cum non cognoscamus substantias separatas nisi 
-            <lb ed="#V" n="71"/>per effeccus: irrationabile iudicare videtur dei potentiam 
+            <lb ed="#V" n="71"/>per effectus: irrationabile iudicare videtur dei potentiam 
             in<lb ed="#V" n="72" break="no"/>finitam: cum in entibus nullum effectum videamus infinitum. 
           </p>
           <p xml:id="kzz7yh-a91582-d1e363">
@@ -217,11 +217,11 @@
             <lb ed="#V" n="79"/>Grego. libro 9. moralis cito post princi. super illud Iob. 9. 
             Sa<lb ed="#V" n="80" break="no"/>piens corde est forte robore sic dicit: tunc verius de nostra 
             in<lb ed="#V" n="81" break="no"/>firmitate concutimur: si qua sint immensa potentia iudicis 
-            con<lb ed="#V" n="82" break="no"/>siderando pensamus: sed omnis potentia immenfa est 
+            con<lb ed="#V" n="82" break="no"/>siderando pensamus: sed omnis potentia immensa est 
             po<lb ed="#V" n="83" break="no"/>tentia infinita. 
           </p>
           <p xml:id="kzz7yh-a91582-d1e392">
-            <lb ed="#V" n="84"/>Respondeo quod potentiu dei est infinita secundum inlue 
+            <lb ed="#V" n="84"/>Respondeo quod potentia dei est infinita secundum illud 
             <lb ed="#V" n="85"/>quod est: quia vt supra probatum est. 
             <lb ed="#V" n="86"/>di. 8. diuina essentia summe simplex est: ergo idem est secundum rem 
             <lb ed="#V" n="87"/>cum sua potentia. Cum ergo probatum sit in quaestione 
@@ -235,7 +235,7 @@
             extensio<lb ed="#V" n="95" break="no"/>nem: quia potest multiplicare diuersitatem effectuum sine fine 
             <lb ed="#V" n="96"/>est etiam infinita in vigore quod patet ex hoc quod in operando non 
             <lb ed="#V" n="97"/>est sibi necessaria materia de qua operetur: nec in operando est 
-            <lb ed="#V" n="98"/>sibi mora necessaria: nec a lienum auxilium: quod cooperetur 
+            <lb ed="#V" n="98"/>sibi mora necessaria: nec a alienum auxilium: quod cooperetur 
             ei<lb ed="#V" n="99" break="no"/>dem: et sic patet quod potentia dei etiam est in finita secundum illud quod 
             <lb ed="#V" n="100"/>est et secundum durationem: et extensionem et vigorem. 
           </p>
@@ -286,7 +286,7 @@
             <lb ed="#V" n="133"/>immobilem simpliciter: et omne ens per participationem ad 
             ali<lb ed="#V" n="134" break="no"/>quid ens per essentiam: et omne ens quod alii innititur ad hoc 
             <lb ed="#V" n="135"/>vt in esse conseruetur ad aliquam potentiam nulli alii 
-            initen<lb ed="#V" n="136" break="no"/>tem: sed potentia que nullomon est mutabilis: et per essentiam 
+            initen<lb ed="#V" n="136" break="no"/>tem: sed potentia que nullo modo est mutabilis: et per essentiam 
             <!--00281.xml-->
             <pb ed="#V" n="134-r"/>
             <cb ed="#P" n="a"/>
@@ -325,7 +325,7 @@
             er<lb ed="#V" n="19" break="no"/>go dicit in ipso aliquam potentiam. 
           </p>
           <p xml:id="kzz7yh-a91582-d1e587">
-            <lb ed="#V" n="20"/>Respondeo infnitas est in diuina esentia 
+            <lb ed="#V" n="20"/>Respondeo infinitas est in diuina essentia 
             po<lb ed="#V" n="21" break="no"/>tentia et duratione: et in quolibet istorum 
             <lb ed="#V" n="22"/>ponit spiritualem magnitudinem transcendentem omne 
             futu<lb ed="#V" n="23" break="no"/>rum quod est vel esse potest intelligi: transcendere autem omen 
@@ -367,7 +367,7 @@
           <head xml:id="kzz7yh-a91582-Hd1e661">Quaestio 4</head>
           <p xml:id="kzz7yh-a91582-d1e663">
             ¶ Quaestio IIII. 
-            <lb ed="#V" n="48"/>Uarto queritur vtrum deus posset facere 
+            <lb ed="#V" n="48"/>Quarto queritur vtrum deus posset facere 
             ali<lb ed="#V" n="49" break="no"/>quid infinitum: quod ex nulla parte 
             es<lb ed="#V" n="50" break="no"/>se finitum: et videtur quod sic: quia secundum philosophum. 8o physico. 
             <lb ed="#V" n="51"/>In essentia finita no est virtus infinita: sed quilibet 
@@ -381,7 +381,7 @@
             <lb ed="#V" n="56"/>quod in hiis que defluxerunt a primo bono aliud est in eis quod 
             <lb ed="#V" n="57"/>bona sunt: aliud quod sunt: sed rerum differentium deus potest 
             <lb ed="#V" n="58"/>vnam ab alia separare: ergo potest facere quandam bonitatem 
-            <lb ed="#V" n="59"/>per se subiesistentem: sed talis bonitas ex nulla parte esset 
+            <lb ed="#V" n="59"/>per se subsistentem: sed talis bonitas ex nulla parte esset 
             finita<lb ed="#V" n="60" break="no"/>ergo deus posset facere aliquod infinitum quod ex nulla parte esse 
             <lb ed="#V" n="61"/>finitum.
           </p>
@@ -394,13 +394,13 @@
           </p>
           <p xml:id="kzz7yh-a91582-d1e710">
             ¶ Item de 
-            <lb ed="#V" n="66"/>potest facere quicquid non est infinitum sibi: sed si esset aliquidi 
-            <lb ed="#V" n="67"/>aliud a se quod ex nulla parte esset finitum: adhuc eet sinitum 
+            <lb ed="#V" n="66"/>potest facere quicquid non est infinitum sibi: sed si esset aliquid 
+            <lb ed="#V" n="67"/>aliud a se quod ex nulla parte esset finitum: adhuc esset finitum 
             <lb ed="#V" n="68"/>deo: quia ipsemet qui ex nulla parte est finitus: est sibi finitus: quia 
             <!--00281.xml-->
             <cb ed="#P" n="b"/>
             <lb ed="#V" n="69"/>secundum Aug. lib. 83. q. q. 16. Quod comprehendit se finitum est 
-            <lb ed="#V" n="70"/>sibi. deus autem compehendit se: ergo videtur quod deus posset 
+            <lb ed="#V" n="70"/>sibi. deus autem comprehendit se: ergo videtur quod deus posset 
             fa<lb ed="#V" n="71" break="no"/>cere aliquod infinitum: quod ex nulla parte esset finitum. 
           </p>
           <p xml:id="kzz7yh-a91582-d1e731">
@@ -429,7 +429,7 @@
             <lb ed="#V" n="89"/>finita per formam tamen nata esset finiri per eam.
           </p>
           <p xml:id="kzz7yh-a91582-d1e777">
-            ¶ Preus non esset 
+            ¶ Praeterea non esset 
             <lb ed="#V" n="90"/>pura possibilitas: quia puram possibilitatem esse actu per se 
             in<lb ed="#V" n="91" break="no"/>cludit contradictionem: ergo esset tibi actualitas et possibilitas simul 
             <lb ed="#V" n="92"/>et terminetur possibilitas ad actualitatem: et actualitas ad 
@@ -446,12 +446,12 @@
             <lb ed="#V" n="103"/>infinitum secundum magnitudinem adhuc finitate que est secundum 
             essen<lb ed="#V" n="104" break="no"/>tiam materia finiretur per formam: et forma finiretur per materiam 
             <lb ed="#V" n="105"/>per quam finitionem essentia sua esset in determinato genere 
-            <lb ed="#V" n="106"/>et in determinata specie. in quo patet quod hec quaeostdo differt a 
+            <lb ed="#V" n="106"/>et in determinata specie. in quo patet quod hec quaestio differt a 
             sequen<lb ed="#V" n="107" break="no"/>ti.
           </p>
           <p xml:id="kzz7yh-a91582-d1e819">
             ¶ Nec potest dici quod deus posset facere actum essendi 
-            <lb ed="#V" n="108"/>per se ex nulla parte sinitum: quia si esset natus recipi in alio 
+            <lb ed="#V" n="108"/>per se ex nulla parte finitum: quia si esset natus recipi in alio 
             na<lb ed="#V" n="109" break="no"/>tus esset finiri per illud in quo posset recipi: si autem non esset 
             <lb ed="#V" n="110"/>natus recipi in alio: sed in se subsistens: ad hoc esset 
             limi<lb ed="#V" n="111" break="no"/>tatus per possibilitatem inquantum esset per aliud esse. vnde 
@@ -470,7 +470,7 @@
             ¶ Ad 2m 
             <lb ed="#V" n="120"/>dicendum quod si Boe. ibi loquebatur de bonitate essentiali rerum: 
             <lb ed="#V" n="121"/>tunc debet dici quod intendebat de alietate secundum rationem. Non 
-            <lb ed="#V" n="122"/>opoertet autem quod si aliqua duo differant secundum rationem quod deus in 
+            <lb ed="#V" n="122"/>oportet autem quod si aliqua duo differant secundum rationem quod deus in 
             effe<lb ed="#V" n="123" break="no"/>ctu possit vnum separare realiter ab alio: et etiam forte sunt 
             ali<lb ed="#V" n="124" break="no"/>qua duo realiter differentia quorum vnum esse in actu: alio 
             mo<lb ed="#V" n="125" break="no"/>do includeret contradictionem.
@@ -484,7 +484,7 @@
             ¶ Ad 4m cum dicitur quod deus potest 
             fa<lb ed="#V" n="128" break="no"/>cere quicquid non est insinitum sibi etc. dico quod verum esset si 
             cu<lb ed="#V" n="129" break="no"/>iusset: quod non esset infinitum deo: creatura capax esset. 
-            Crea<lb ed="#V" n="130" break="no"/>tura autem non est capax infinitatis simpliciter: vvel potest dici quod dicitur deus 
+            Crea<lb ed="#V" n="130" break="no"/>tura autem non est capax infinitatis simpliciter: vel potest dici quod dicitur deus 
             <lb ed="#V" n="131"/>finitus sibi: non quia sit finitus secundum aliquem respectum sed 
             <lb ed="#V" n="132"/>quia ita se comprehendit in intellectu: sicut comprehendit 
             <lb ed="#V" n="133"/>quodcumque sfinitum.
@@ -494,9 +494,9 @@
           <head xml:id="kzz7yh-a91582-Hd1e893">Quaestio 5</head>
           <p xml:id="kzz7yh-a91582-d1e895">
             ¶ Quaestio V 
-            <lb ed="#V" n="134"/>Uinto queritur vtrum deus posset facere 
-            ali<lb ed="#V" n="135" break="no"/>quod infinitum actu secundum dimensio 
-            <lb ed="#V" n="136"/>nem et videtur quod sic: quia secundum philosophum id es physico. Infi¬ 
+            <lb ed="#V" n="134"/>Quinto queritur vtrum deus posset facere 
+            ali<lb ed="#V" n="135" break="no"/>quod infinitum actu secundum 
+            dimensio<lb ed="#V" n="136" break="no"/>nem et videtur quod sic: quia secundum philosophum id es physico. Infi¬ 
             <!--00282.xml-->
             <pb ed="#V" n="134-v"/>
             <cb ed="#P" n="a"/>
@@ -504,7 +504,7 @@
             <lb ed="#V" n="2"/>ei non repugnat: ergo potest dare quantitati actualem infinitatem 
           </p>
           <p xml:id="kzz7yh-a91582-d1e915">
-            <lb ed="#V" n="3"/>¶ Item infinita duratio est per infmitam virtutem: quia si tanta virtus 
+            <lb ed="#V" n="3"/>¶ Item infinita duratio est per infinitam virtutem: quia si tanta virtus 
             <lb ed="#V" n="4"/>potest rem tam diu conseruare in esse: et maior diutius: et maxima 
             <lb ed="#V" n="5"/>diutissime: sed mundus in infinitum durabit: ergo habet 
             infinitan<lb ed="#V" n="6" break="no"/>virtutem. Sed secundum philosophum 8. physico. In magnitudine 
@@ -534,22 +534,22 @@
             <lb ed="#V" n="21"/>facere magnitudinem actu infinitam. 
           </p>
           <p xml:id="kzz7yh-a91582-d1e967">
-            <lb ed="#V" n="22"/>Contra. Sicut se habet forma subantialis ad naturam: ita 
+            <lb ed="#V" n="22"/>Contra. Sicut se habet forma substantialis ad naturam: ita 
             figu<lb ed="#V" n="23" break="no"/>ra ad soliditatem. Unde videtur velle philosophus 
             <lb ed="#V" n="24"/>in predictis quod figura que est qualitas in quantitate est sicut 
             <lb ed="#V" n="25"/>quantitatis forma: sed deus non potest facere materiam sine forma 
             <lb ed="#V" n="26"/>cum omne esse sit per formam secundum quod dicit Boe. lib. i. de tri. 
             <lb ed="#V" n="27"/>ca. 2. ergo deus non potest facere soliditatem sine figura. Sed 
-            <lb ed="#V" n="28"/>soliditas terminatur ad figuram: ergo cum nullu 
+            <lb ed="#V" n="28"/>soliditas terminatur ad figuram: ergo cum nullum 
             termina<lb ed="#V" n="29" break="no"/>tum sit infinitum: deus non posset actu facere soliditatem 
             in<lb ed="#V" n="30" break="no"/>finitatem.
           </p>
           <p xml:id="kzz7yh-a91582-d1e989">
-            ¶ Item Aug. in eplura ad Dioscorum longe vltra 
+            ¶ Item Aug. in epistola ad Dioscorum longe vltra 
             <lb ed="#V" n="31"/>medium: hoc corporum est: vt quecumque infinita fuerint sint 
             <lb ed="#V" n="32"/>informia: sed secundum Boe i. li.o de tri. c. 3. Nihil secundum materiam esse 
             <lb ed="#V" n="33"/>dicitur: sed secundum propriam formam: ergo impossibile est aliquod 
-            <lb ed="#V" n="34"/>eorpus actu infinitum esse.
+            <lb ed="#V" n="34"/>corpus actu infinitum esse.
           </p>
           <p xml:id="kzz7yh-a91582-d1e1000">
             ¶ Item secundum philosophum. 3 physi. c. de 
@@ -559,7 +559,7 @@
             mathe<lb ed="#V" n="38" break="no"/>maticum neque insensibile. 
           </p>
           <p xml:id="kzz7yh-a91582-d1e1011">
-            <lb ed="#V" n="39"/>Respondeo quod quamris deus possit facem dimensionem 
+            <lb ed="#V" n="39"/>Respondeo quod quamuis deus possit facem dimensionem 
             <lb ed="#V" n="40"/>maiorem et minorem sine sine: ita 
             <lb ed="#V" n="41"/>tamen quod semper totum acceptum sit finitum quod solet dici 
             infini<lb ed="#V" n="42" break="no"/>tum in actu permixto potentie: vel in fieri tamen est possibile quod 
@@ -579,12 +579,12 @@
             protrahum<lb ed="#V" n="53" break="no"/>tur a centro quanto magis elongantur a centro: tanto magis 
             <lb ed="#V" n="54"/>distant inter se: vnde si protracte essent in infinitum inter se 
             dista<lb ed="#V" n="55" break="no"/>rent in infinitum: et sic nunquam vna posset ad locum alterius 
-            per<lb ed="#V" n="56" break="no"/>tingere: quia impossibile est spatiu infinitum esse per transitum. 
+            per<lb ed="#V" n="56" break="no"/>tingere: quia impossibile est spatium infinitum esse per transitum. 
             <lb ed="#V" n="57"/>vnde philosophus id s posteriorum dicit quod impossibile est infinita transire. 
           </p>
           <p xml:id="kzz7yh-a91582-d1e1059">
-            <lb ed="#V" n="58"/>Sed hec ratio quamuis de necessitate concludat quod pone 
-            <lb ed="#V" n="59"/>re corpus infinitum secundum omnem dimensionem 
+            <lb ed="#V" n="58"/>Sed hec ratio quamuis de necessitate concludat quod 
+            pone<lb ed="#V" n="59" break="no"/>re corpus infinitum secundum omnem dimensionem 
             <lb ed="#V" n="60"/>et quod moueatur incompossibilia sint: tamen non concludit 
             impossi<lb ed="#V" n="61" break="no"/>bile esse corpus infinite dimensionis quod non moueatur. 
             <lb ed="#V" n="62"/>Alii declarant principale propositum sic. Dicunt enim quod 
@@ -593,7 +593,7 @@
             <lb ed="#V" n="65"/>questione praecedenti: sed corporis finiti secundum essentiam non 
             pos<lb ed="#V" n="66" break="no"/>sunt esse infinite dimensiones: quia finitam essentiam 
             consequun<lb ed="#V" n="67" break="no"/>tur determinata accidentia: et ideo dicunt ipsi: non potest deus 
-            <lb ed="#V" n="68"/>facere corpua: quod habeat infinitam dimensionem. 
+            <lb ed="#V" n="68"/>facere corpus: quod habeat infinitam dimensionem. 
           </p>
           <p xml:id="kzz7yh-a91582-d1e1085">
             <!--00282.xml-->
@@ -604,19 +604,19 @@
             <lb ed="#V" n="72"/>hoc probatum est: quin ibi possent esse per supernaturalem potentiam. 
           </p>
           <p xml:id="kzz7yh-a91582-d1e1101">
-            <lb ed="#V" n="73"/>¶ Premo cum aliquid est pertibile secundum plures respectus sicut 
+            <lb ed="#V" n="73"/>¶ Premo cum aliquid est partibile secundum plures respectus sicut 
             <lb ed="#V" n="74"/>motus corporis qui est partibilis: et per comperationem ad mobile et 
             <lb ed="#V" n="75"/>ad spatium: et ad tempus secundum philosophum 6 physi. potest esse 
-            dimen<lb ed="#V" n="76" break="no"/>sio eius magna per comperationem ad vnum: et perua secundum 
+            dimen<lb ed="#V" n="76" break="no"/>sio eius magna per comperationem ad vnum: et parua secundum 
             con<lb ed="#V" n="77" break="no"/>parationem ad aliud. Unde quantitas velocis motus magna 
-            <lb ed="#V" n="78"/>est per comparationem ad spatium: et quandoque perua per 
+            <lb ed="#V" n="78"/>est per comparationem ad spatium: et quandoque parua per 
             comparatio<lb ed="#V" n="79" break="no"/>nem ad tempus: et econtra. In tardo motu et ita posset 
-            di<lb ed="#V" n="80" break="no"/>ci nisi aliud obstaret: quod corpus posset hebere sinitatem 
+            di<lb ed="#V" n="80" break="no"/>ci nisi aliud obstaret: quod corpus posset hebere finitatem 
             inquan<lb ed="#V" n="81" break="no"/>tum eius materia et fora finiuntur per se inuicem: et tamen habere 
             infi<lb ed="#V" n="82" break="no"/>nitatem per comperationem ad dimensiones.
           </p>
           <p xml:id="kzz7yh-a91582-d1e1125">
-            ¶ Preus deus 
+            ¶ Praeterea deus 
             <lb ed="#V" n="83"/>posset facere dimensiones separatas a substantia sicut videmus in 
             <lb ed="#V" n="84"/>sacramento altaris. Unde et si illud argumentum 
             conclude<lb ed="#V" n="85" break="no"/>ret quod in substantia non possent esse dimensiones infinite non 
@@ -632,11 +632,11 @@
             <lb ed="#V" n="91"/>Sed hec ratio non videtur satis euidens: quia sicut 
             di<lb ed="#V" n="92" break="no"/>cit Auice. 7. Metaphysi. c. 2. Non. oportet vt 
             <lb ed="#V" n="93"/>in corpore ex hoc quod corpus est sit superficies: quia non oret quod sit 
-            superfi<lb ed="#V" n="94" break="no"/>cies nisi ex hoc quod est sinitum: et parum post. Finito enim accidentale est 
-            <lb ed="#V" n="95"/>ei et concomitans: et ideo: ad imaginandu corpus non est necesse 
+            superfi<lb ed="#V" n="94" break="no"/>cies nisi ex hoc quod est finitum: et parum post. Finito enim accidentale est 
+            <lb ed="#V" n="95"/>ei et concomitans: et ideo: ad imaginandum corpus non est necesse 
             <lb ed="#V" n="96"/>imaginare corpus finitum. Qui autem imaginatur corpus 
             fi<lb ed="#V" n="97" break="no"/>nitum non imaginatur corpus non corpus. 
-            <lb ed="#V" n="98"/>Alii dicunt quod esse dimensionem infinitam iucludit 
+            <lb ed="#V" n="98"/>Alii dicunt quod esse dimensionem infinitam includit 
             <lb ed="#V" n="99"/>condictionem includendo partem equa 
             <lb ed="#V" n="100"/>lem suo toti: quod declarant sic. Poitionatur linea infinita ex vtraque 
             <lb ed="#V" n="101"/>parte in quocumque loco signaueris disionem: diuidis eam in 
@@ -648,7 +648,7 @@
           </p>
           <p xml:id="kzz7yh-a91582-d1e1185">
             ¶ 
-            Pre<lb ed="#V" n="107" break="no"/>terea illa pars linee que est vsque ad. a. tantum si comperetur illi 
+            Pre<lb ed="#V" n="107" break="no"/>terea illa pars linee que est vsque ad. a. tantum si comparetur illi 
             perti<lb ed="#V" n="108" break="no"/>linee que est vltra. bo dimissa parte finita: que est inter a et b.o 
             <lb ed="#V" n="109"/>equalis est illi: quia si superponatur sibi non excedet eam: nec 
             ex<lb ed="#V" n="110" break="no"/>cedetur ab ea: sed quecumque vni et eidem sunt equalia inter 
@@ -680,13 +680,13 @@
             <lb ed="#V" n="131"/>terminatur: cum determinate contratrahitur ad alteram partem 
             <lb ed="#V" n="132"/>esse: ergo in effectu includit terminationem essentie 
             recipien<lb ed="#V" n="133" break="no"/>tis esse in effectu: dimensio ergo in effectum existens per suum esse 
-            <lb ed="#V" n="134"/>in esfectu recipit terminationem: non terminationem quae 
+            <lb ed="#V" n="134"/>in effectu recipit terminationem: non terminationem quae 
             deter<lb ed="#V" n="135" break="no"/>minetur ad genus: vel speciem: quia si nulla superficies esset in et 
             <lb ed="#V" n="136"/>fectu: nominaret tamen essentiam spectantem ad genus quantitatis: 
             <!--00283.xml-->
             <pb ed="#V" n="135-r"/>
             <cb ed="#P" n="a"/>
-            <lb ed="#V" n="1"/>ergo seuitur quod per suum esse in effectu terminationem sub ratione 
+            <lb ed="#V" n="1"/>ergo sequitur quod per suum esse in effectu terminationem sub ratione 
             <lb ed="#V" n="2"/>qua disio est recipit: hoc est terminationem secundum terminos 
             <lb ed="#V" n="3"/>longitudinis vel latitudinis: vel profunditatis. Infinitas 
             <lb ed="#V" n="4"/>repugnat dimensioni per suum esse in effectu. 
@@ -746,7 +746,7 @@
             po<lb ed="#V" n="39" break="no"/>tentia: tamen verum est actu esse in continuo infinita puncta in 
             po<lb ed="#V" n="40" break="no"/>tentia: quia verum est actu quod ens in potentia est in potentia: 
             er<lb ed="#V" n="41" break="no"/>go sicut sunt in continuo infinita puncta in potentiam ita existen 
-            <lb ed="#V" n="42"/>tiarum infinitorum punctorum in poentia: sunt infinite 
+            <lb ed="#V" n="42"/>tiarum infinitorum punctorum in potentia: sunt infinite 
             vnita<lb ed="#V" n="43" break="no"/>tes in actu.
           </p>
           <p xml:id="kzz7yh-a91582-d1e1378">
@@ -754,7 +754,7 @@
             <lb ed="#V" n="44"/>esse nullum sequitur impossibile: sed sicut hebetur ex sententia phlosoph 
             <lb ed="#V" n="45"/>3 physicorum et 6 et restat Augu. 2. super Gensem longe post 
             prin<lb ed="#V" n="46" break="no"/>cipium: omne continuum est disibile in infinitum: ergo ponere 
-            <lb ed="#V" n="47"/>quod continuum sit actu disum in infinita non est impossibile.
+            <lb ed="#V" n="47"/>quod continuum sit actu diuisum in infinita non est impossibile.
           </p>
           <p xml:id="kzz7yh-a91582-d1e1389">
             ¶ Item 
@@ -767,7 +767,7 @@
           </p>
           <p xml:id="kzz7yh-a91582-d1e1405">
             ¶ Item Agazel. i. Metaphy. sue disione. 6 dicit 
-            <lb ed="#V" n="54"/>sic. Aimas humanas que sunt separabiles a corporibus per mortem 
+            <lb ed="#V" n="54"/>sic. Animas humanas que sunt separabiles a corporibus per mortem 
             <lb ed="#V" n="55"/>concedimus esse infinitas numero quamuis hebeant esse simul. 
           </p>
           <p xml:id="kzz7yh-a91582-d1e1413">
@@ -806,10 +806,10 @@
           </p>
           <p xml:id="kzz7yh-a91582-d1e1475">
             ¶ Preterea si ab infinita multitudine in 
-            effec<lb ed="#V" n="78" break="no"/>ctu remoueantur due virtutes tantum adhuc remanet mtiltudo 
-            <lb ed="#V" n="79"/>infinita: et constat quod illa est pars totius multitudis illas duas 
+            effec<lb ed="#V" n="78" break="no"/>ctu remoueantur due virtutes tantum adhuc remanet multitudo 
+            <lb ed="#V" n="79"/>infinita: et constat quod illa est pars totius multitudinis illas duas 
             <lb ed="#V" n="80"/>vnitates con. ludentis: si ergo infinitum non est maius 
-            infi<lb ed="#V" n="81" break="no"/>nito: vt videtur velle philosophus 8. physi. supponens hanc conseam est 
+            infi<lb ed="#V" n="81" break="no"/>nito: vt videtur velle philosophus 8. physi. supponens hanc consequentiam est 
             <lb ed="#V" n="82"/>minus infinito: ergo est finitum: videtur quod ad posse esse 
             mul<lb ed="#V" n="83" break="no"/>titudinem infinitam in effectu sequitur posse falsificari istud 
             <lb ed="#V" n="84"/>principium. Omne totum maius est sua parte¬ 
@@ -819,7 +819,7 @@
             <lb ed="#V" n="86"/>est in re: vel est in intellecti. 
             Re<lb ed="#V" n="87" break="no"/>rum autem existentium in potentia: non est veritas actu in re. vnde 
             <lb ed="#V" n="88"/>infinitorum punctorum existentium in potenia in continuo non 
-            <lb ed="#V" n="89"/>sunt veritates actuin re: sed in potentia eo modo quo illa 
+            <lb ed="#V" n="89"/>sunt veritates actu in re: sed in potentia eo modo quo illa 
             in<lb ed="#V" n="90" break="no"/>finita puncta sunt in pos: non ergo possunt dici ille veritates 
             <lb ed="#V" n="91"/>esse in actu nisi per comperationem ad divinum intellectum quod 
             <lb ed="#V" n="92"/>solus intelligit infinita.
@@ -869,15 +869,15 @@
             ¶ Item Glo. 
             <lb ed="#V" n="120"/>super illud <ref xml:id="kzz7yh-a91582-Rd1e1602">Gen. 19</ref> <quote xml:id="kzz7yh-a91582-Qd1e1604" source="http://scta.info/resource/gen19_22@6-9">Non potero facere quicquam</quote> etc. quod poterat 
             <lb ed="#V" n="121"/>pomo non poterat de iustitia: sed nullus potest aliquid de 
-            po<lb ed="#V" n="122" break="no"/>tentia ordinata nisi secundum institiam possit illud: ergo aliquid 
+            po<lb ed="#V" n="122" break="no"/>tentia ordinata nisi secundum iustitiam possit illud: ergo aliquid 
             <lb ed="#V" n="123"/>potest deus de potentia absoluta quod non potest de potentia 
             <lb ed="#V" n="124"/>ordinata.
           </p>
           <p xml:id="kzz7yh-a91582-d1e1603">
             ¶ Item <ref xml:id="kzz7yh-a91582-Rd1e1619">Aug. 13 libro de trinitate. c. X.</ref> dicit loquens 
-            <lb ed="#V" n="125"/>de modo liberationis nre: non alium modum possipilem 
+            <lb ed="#V" n="125"/>de modo liberationis nostrae: non alium modum possibilem 
             <lb ed="#V" n="126"/>deo defuisse cuius potestati cuncta equaliter subiacent: sed 
-            sa<lb ed="#V" n="127" break="no"/>nande nostre meserie conuenientiorem modum alium non 
+            sa<lb ed="#V" n="127" break="no"/>nande nostre miseriae conuenientiorem modum alium non 
             <lb ed="#V" n="128"/>fuisse: ergo deus potuit nos liberare alio modo quam 
             liberaue<lb ed="#V" n="129" break="no"/>rit: sed nos alio modo liberare non fuisset ordinatum: cum 
             <lb ed="#V" n="130"/>iste modus liberandi conuenientissimus fuerit: ergo alio 
@@ -903,7 +903,7 @@
             <lb ed="#V" n="7"/>potentia absoluta: quod non possit de potentia ordinata. 
             ni<lb ed="#V" n="8" break="no"/>hil enim potest facere nisi quod potest velle et disponere se 
             factu<lb ed="#V" n="9" break="no"/>rum quia secundum quod dicit Ansel. 2 lib. cur deus et homo. c. x. potestas se 
-            <lb ed="#V" n="10"/>quaitur voluntatem: quod in deo intelligendum est secundum 
+            <lb ed="#V" n="10"/>quaeritur voluntatem: quod in deo intelligendum est secundum 
             ra<lb ed="#V" n="11" break="no"/>tionem intelligendi. 
           </p>
           <p xml:id="kzz7yh-a91582-d1e1668">
@@ -918,7 +918,7 @@
             conuenien<lb ed="#V" n="20" break="no"/>tior: et secundum eam facilius est respondere ad vtriusque partis arguus. 
           </p>
           <p xml:id="kzz7yh-a91582-d1e1690">
-            <lb ed="#V" n="21"/>Ad primum dicendum quod praocedit secundum quod posse 
+            <lb ed="#V" n="21"/>Ad primum dicendum quod procedit secundum quod posse 
             <lb ed="#V" n="22"/>de potentia ordinata dicitur posse 
             il<lb ed="#V" n="23" break="no"/>lud quod proposuit et rationabiliter disposuit se esse facturum.
           </p>
@@ -935,7 +935,7 @@
           </p>
           <p xml:id="kzz7yh-a91582-d1e1719">
             ¶ Ad 3m potest patere solutio per iam dicta. 
-            <lb ed="#V" n="32"/>Argumenta ad partem aliam procaedunt secundum quod 
+            <lb ed="#V" n="32"/>Argumenta ad partem aliam procedunt secundum quod 
             pos<lb ed="#V" n="33" break="no"/>se de potentia ordinata dicitur 
             pos<lb ed="#V" n="34" break="no"/>se non tantummodo respectu illius quod est propositum et 
             rationabi<lb ed="#V" n="35" break="no"/>liter dispositum: sed etiam respectu illius: quod proponi et 

--- a/kzz7yh-a91582/cod-ve07v1_kzz7yh-a91582.xml
+++ b/kzz7yh-a91582/cod-ve07v1_kzz7yh-a91582.xml
@@ -372,8 +372,8 @@
             es<lb ed="#V" n="50" break="no"/>se finitum: et videtur quod sic: quia secundum philosophum. 8o physico. 
             <lb ed="#V" n="51"/>In essentia finita no est virtus infinita: sed quilibet 
             <lb ed="#V" n="52"/>creatura intellectualis habet virtutem infinitam intelligendo: 
-            <lb ed="#V" n="53"/>cum possit intelligere vniversale quod sub se virtualiter comprehen 
-            <lb ed="#V" n="54"/>dit infinita: ergo quelibet creatura intellectualis habet 
+            <lb ed="#V" n="53"/>cum possit intelligere vniversale quod sub se virtualiter comprehen
+            <lb ed="#V" n="54" break="no"/>dit infinita: ergo quelibet creatura intellectualis habet 
             essen<lb ed="#V" n="55" break="no"/>tiam infinitam.
           </p>
           <p xml:id="kzz7yh-a91582-d1e683">


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve07v1_kzz7yh-a91582.xml`.

## Applied changes

- p. 133v l. 18: esentia → essentia: missing 's'
- p. 133v l. 29: aliquomon → aliquo modo: contracted form
- p. 133v l. 44: sequtur → sequitur: missing 'i'
- p. 133v l. 55: Ecundo → Secundo: missing 'S'
- p. 133v l. 60: lib ist → lib. i.: OCR misread of 'libro i.'
- p. 133v l. 62: poso → potentia: heavily garbled abbreviation
- p. 133v l. 71: effeccus → effectus: doubled 'c' for 'ct'
- p. 133v l. 82: immenfa → immensa: long-s (f→s)
- p. 133v l. 84: potentiu → potentia: garbled ending; inlue → illud: OCR garble
- p. 133v l. 98: lienum → alienum: missing 'a'
- p. 133v l. 136: nullomon → nullo modo: contracted form
- p. 134r l. 20: infnitas → infinitas: missing 'i'; esentia → essentia: missing 's'
- p. 134r l. 48: Uarto → Quarto: U/Q misread (U for Qu)
- p. 134r l. 59: subiesistentem → subsistentem: OCR garble
- p. 134r l. 66: aliquidi → aliquid: spurious 'i'
- p. 134r l. 67: eet → esset: missing 'ss'; sinitum → finitum: s/f misread
- p. 134r l. 70: compehendit → comprehendit: missing 'r'
- p. 134r l. 89: Preus → Praeterea: garbled abbreviation
- p. 134r l. 106: quaeostdo → quaestio: OCR garble
- p. 134r l. 108: sinitum → finitum: s/f misread (long-s)
- p. 134r l. 122: opoertet → oportet: spurious 'e'
- p. 134r l. 130: vvel → vel: doubled 'v'
- p. 134r l. 134: Uinto → Quinto: U/Qu misread (like Uarto→Quarto)
- p. 134r l. 136: 'dimensio' + 'nem' split across line break without break="no" on lb n=136
- p. 134v l. 3: infmitam → infinitam: missing 'ni'
- p. 134v l. 22: subantialis → substantialis: missing 'st'
- p. 134v l. 28: nullu → nullum: missing final 'm'
- p. 134v l. 30: eplura → epistola: garbled abbreviation
- p. 134v l. 34: eorpus → corpus: spurious 'e'
- p. 134v l. 39: quamris → quamuis: OCR misread
- p. 134v l. 56: spatiu → spatium: missing final 'm'
- p. 134v l. 59: 'pone' + 're' split across line break without break="no" on lb n=59
- p. 134v l. 68: corpua → corpus: OCR misread
- p. 134v l. 73: pertibile → partibile: e/a misread
- p. 134v l. 76: perua → parua: e/a misread
- p. 134v l. 78: perua → parua: e/a misread
- p. 134v l. 80: sinitatem → finitatem: s/f misread
- p. 134v l. 82: Preus → Praeterea: garbled abbreviation
- p. 134v l. 94: sinitum → finitum: s/f misread (long-s)
- p. 134v l. 95: imaginandu → imaginandum: missing final 'm'
- p. 134v l. 98: iucludit → includit: OCR misread 'iu'→'in'
- p. 134v l. 107: comperetur → comparetur: e/a misread
- p. 134v l. 134: esfectu → effectu: spurious 's'
- p. 135r l. 1: seuitur → sequitur: OCR misread
- p. 135r l. 42: poentia → potentia: missing 't'
- p. 135r l. 47: disum → diuisum: missing 'ui'
- p. 135r l. 54: Aimas → Animas: OCR misread A/I confusion and missing 'n'
- p. 135r l. 78: mtiltudo → multitudo: OCR transposition
- p. 135r l. 79: multitudis → multitudinis: missing 'in'
- p. 135r l. 81: conseam → consequentiam: heavily abbreviated
- p. 135r l. 89: actuin → actu in: missing space
- p. 135r l. 122: institiam → iustitiam: missing 'u'
- p. 135r l. 125: nre → nostrae: abbreviated; possipilem → possibilem: OCR transposition
- p. 135r l. 127: meserie → miseriae: OCR misread
- p. 135v l. 10: quaitur → quaeritur: missing 'er'
- p. 135v l. 21: praocedit → procedit: spurious 'a'
- p. 135v l. 32: procaedunt → procedunt: spurious 'a'

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_