### PR TITLE
Transcription corrections: cod-ve07v1_kzz7yh-a93220.xml (5 changes)

### DIFF
--- a/kzz7yh-a93220/cod-ve07v1_kzz7yh-a93220.xml
+++ b/kzz7yh-a93220/cod-ve07v1_kzz7yh-a93220.xml
@@ -57,7 +57,7 @@
         <p xml:id="kzz7yh-a93220-d1e103">
           <lb ed="#V" n="38"/>Circa litteram. (Iustitia dei ipsius equssima 
           vo<lb ed="#V" n="39" break="no"/>luntas accipitur) . In quo datur 
-          intelli<lb ed="#V" n="40" break="no"/>gi quod voluntas dei est ipsa reglibura iustitie: et quod de eo 
+          intelli<lb ed="#V" n="40" break="no"/>gi quod voluntas dei est ipsa regula iustitie: et quod de eo 
           <lb ed="#V" n="41"/>ipso iustum est aliquid fieri vel non fieri: quod deus vult 
           <lb ed="#V" n="42"/>vt fiat: vel non fiat. (Poterat per potentiam: sed non poterat 
           <lb ed="#V" n="43"/>per iustitiam) secundum enim quod dicit Ansel. prosoluis. c. x. Iustitia dicitur vel 
@@ -66,14 +66,14 @@
           conceden<lb ed="#V" n="46" break="no"/>tiam bonitatis diuine: quia si hoc fecisset bonitatem suam 
           de<lb ed="#V" n="47" break="no"/>cuisset: sed non poterat de iustitia secundum exigentiam 
           merito<lb ed="#V" n="48" break="no"/>rum: quia secundum quod dicit Petrus. 2 cano. sua. c. 2. ipse Loth 
-          as<lb ed="#V" n="49" break="no"/>pectu etauditu iustus erat habitans apud eos qui de die in 
+          as<lb ed="#V" n="49" break="no"/>pectu et auditu iustus erat habitans apud eos qui de die in 
           <lb ed="#V" n="50"/>diem animam iusti iniquis operibus cruciabant. (hoc verbum 
           <lb ed="#V" n="51"/>debet venenum habet. Hoc ideo dicit: quia debitum ex 
           commis<lb ed="#V" n="52" break="no"/>so obligat de necessitate: et tale debitum non cadit in deo 
           <lb ed="#V" n="53"/>sed debitum ex promisso magis sonat in gratiam et liberalitatem 
-          <lb ed="#V" n="54"/>quam in obligationem: et tale debitum aliquomon est in deo. (Non 
+          <lb ed="#V" n="54"/>quam in obligationem: et tale debitum aliquo modo est in deo. (Non 
           <lb ed="#V" n="55"/>est debitor nobis nisi forte ex promisso: et dicit sorte quia etiam 
-          <lb ed="#V" n="56"/>hoc quod promittit deus ex gratia est: et per conseqens promissum 
+          <lb ed="#V" n="56"/>hoc quod promittit deus ex gratia est: et per consequens promissum 
           redde<lb ed="#V" n="57" break="no"/>re gratia est. Dicitur enim debitum quasi de alio habitum: 
           <lb ed="#V" n="58"/>ideo quicquid possumus ei debemus. Ipse vero proprie 
           loquen<lb ed="#V" n="59" break="no"/>do nulli debitor est. Eadem manente ratione et causa alia 
@@ -88,7 +88,7 @@
           <lb ed="#V" n="68"/>thyro etes. Quod proposuerit christus fines: iudee non excedere ne¬ 
           <!--00284.xml-->
           <cb ed="#P" n="b"/>
-          <lb ed="#V" n="69"/>iustam phariseits et sacerdotibus persecutionis occasionem 
+          <lb ed="#V" n="69"/>iustam phariseis et sacerdotibus persecutionis occasionem 
           da<lb ed="#V" n="70" break="no"/>ret: et erant tunc qui incoronati essent vocandi in tyro qui 
           <lb ed="#V" n="71"/>non essent vocandi: nec tamen de contemptu grauius puniendi. 
           <lb ed="#V" n="72"/>(Nunquid dicendum est non potuit iudam suscitare in 

--- a/kzz7yh-a93220/cod-ve07v1_kzz7yh-a93220.xml
+++ b/kzz7yh-a93220/cod-ve07v1_kzz7yh-a93220.xml
@@ -85,7 +85,7 @@
           fa<lb ed="#V" n="65" break="no"/>cere quam proposuerit se facturum quamuis non possit plura facere 
           <lb ed="#V" n="66"/>quam possit velle se facturum. (Cur apud quosdam non sunt 
           <lb ed="#V" n="67"/>facte virtutes). Respondeo secundum Glo. Matth. xi. super illud. Si in 
-          <lb ed="#V" n="68"/>thyro et Sidone. Quod proposuerit christus fines: iudee non excedere ne¬ 
+          <lb ed="#V" n="68"/>thyro etc. Quod proposuerit christus fines: iudee non excedere ne¬ 
           <!--00284.xml-->
           <cb ed="#P" n="b"/>
           <lb ed="#V" n="69"/>iustam phariseis et sacerdotibus persecutionis occasionem 

--- a/kzz7yh-a93220/cod-ve07v1_kzz7yh-a93220.xml
+++ b/kzz7yh-a93220/cod-ve07v1_kzz7yh-a93220.xml
@@ -55,13 +55,13 @@
       <div xml:id="kzz7yh-a93220"><!-- l1d43cl -->
         <head xml:id="kzz7yh-a93220-Hd1e101">Circa litteram</head>
         <p xml:id="kzz7yh-a93220-d1e103">
-          <lb ed="#V" n="38"/>Circa litteram. (Iustitia dei ipsius equssima 
+          <lb ed="#V" n="38"/>Circa litteram. (Iustitia dei ipsius equissima 
           vo<lb ed="#V" n="39" break="no"/>luntas accipitur) . In quo datur 
           intelli<lb ed="#V" n="40" break="no"/>gi quod voluntas dei est ipsa regula iustitie: et quod de eo 
           <lb ed="#V" n="41"/>ipso iustum est aliquid fieri vel non fieri: quod deus vult 
           <lb ed="#V" n="42"/>vt fiat: vel non fiat. (Poterat per potentiam: sed non poterat 
           <lb ed="#V" n="43"/>per iustitiam) secundum enim quod dicit Ansel. prosoluis. c. x. Iustitia dicitur vel 
-          <lb ed="#V" n="44"/>exigentia meritorum: vel concedescentia divinae bonitatis: dico 
+          <lb ed="#V" n="44"/>exigentia meritorum: vel <sic>concedescentia</sic> divinae bonitatis: dico 
           er<lb ed="#V" n="45" break="no"/>go quod poterat per iustitiam punire loth. secundum quod dicit 
           conceden<lb ed="#V" n="46" break="no"/>tiam bonitatis diuine: quia si hoc fecisset bonitatem suam 
           de<lb ed="#V" n="47" break="no"/>cuisset: sed non poterat de iustitia secundum exigentiam 
@@ -85,7 +85,7 @@
           fa<lb ed="#V" n="65" break="no"/>cere quam proposuerit se facturum quamuis non possit plura facere 
           <lb ed="#V" n="66"/>quam possit velle se facturum. (Cur apud quosdam non sunt 
           <lb ed="#V" n="67"/>facte virtutes). Respondeo secundum Glo. Matth. xi. super illud. Si in 
-          <lb ed="#V" n="68"/>thyro etes. Quod proposuerit christus fines: iudee non excedere ne¬ 
+          <lb ed="#V" n="68"/>thyro et Sidone. Quod proposuerit christus fines: iudee non excedere ne¬ 
           <!--00284.xml-->
           <cb ed="#P" n="b"/>
           <lb ed="#V" n="69"/>iustam phariseis et sacerdotibus persecutionis occasionem 


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve07v1_kzz7yh-a93220.xml`.

## Applied changes

- p. 135v l. 40: reglibura → regula: OCR misread
- p. 135v l. 49: etauditu → et auditu: missing space
- p. 135v l. 54: aliquomon → aliquo modo: contracted form
- p. 135v l. 56: conseqens → consequens: missing 'u'
- p. 135v l. 69: phariseits → phariseis: spurious 't'

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_