### PR TITLE
Transcription corrections: cod-ve07v1_kzz7yh-a93632.xml (45 changes)

### DIFF
--- a/kzz7yh-a93632/cod-ve07v1_kzz7yh-a93632.xml
+++ b/kzz7yh-a93632/cod-ve07v1_kzz7yh-a93632.xml
@@ -232,8 +232,8 @@
           <p xml:id="kzz7yh-a93632-d1e423">
             <!--00286.xml-->
             <cb ed="#P" n="b"/>
-            <lb ed="#V" n="69"/>Argumenta ad partem primam procedunt de melio 
-            <lb ed="#V" n="70"/>ratione vniuersi quantum ad 
+            <lb ed="#V" n="69"/>Argumenta ad partem primam procedunt de
+            melio<lb ed="#V" n="70" break="no"/>ratione vniuersi quantum ad 
             ordi<lb ed="#V" n="71" break="no"/>nem partium inter se et omnium partium simul ad finem secundum 
             <lb ed="#V" n="72"/>statum bonitatis: quam creature habent secundum se: sic enim 
             ve<lb ed="#V" n="73" break="no"/>rum est quod vniuersum non posset fieri melius. 
@@ -633,8 +633,8 @@
             producen<lb ed="#V" n="65" break="no"/>necessitate nature: ergo deus non posuit producem vniuersum de necessitate 
           </p>
           <p xml:id="kzz7yh-a93632-d1e1167">
-            <lb ed="#V" n="66"/>¶ Respondeo quod deus non produxit nec producem po¬ fnane. 
-            <lb ed="#V" n="67"/>tuit vniuersum de necessitate nature. Quod autem de 
+            <lb ed="#V" n="66"/>¶ Respondeo quod deus non produxit nec producem
+            po<lb ed="#V" n="67" break="no"/>tuit vniuersum de necessitate nature. Quod autem de 
             <lb ed="#V" n="68"/>necessitate nature non produxerit: patet sic: quia perfectiones communicate di¬ 
             <!--00288.xml-->
             <cb ed="#P" n="b"/>

--- a/kzz7yh-a93632/cod-ve07v1_kzz7yh-a93632.xml
+++ b/kzz7yh-a93632/cod-ve07v1_kzz7yh-a93632.xml
@@ -418,7 +418,7 @@
           <p xml:id="kzz7yh-a93632-d1e772">
             ¶ Item quia pater generando se perfectissime expressit in vno 
             <lb ed="#V" n="61"/>filio ideo non potest alium filium generare ergo a simili cum 
-            <lb ed="#V" n="62"/>deus creando: se ita expressit in homoousios: sicut per creaturam possit 
+            <lb ed="#V" n="62"/>deus creando: se ita expressit in uno modo: sicut per creaturam possit 
             <lb ed="#V" n="63"/>exprimi: ideo non potest alium mundum creare: qua propter etiam 
             <lb ed="#V" n="64"/>Trimegistus de divinitate ad Asclepium mundum dicit esse 
             <lb ed="#V" n="65"/>imaginem dei: videtur quod cum ista vniuersitate aliam non 
@@ -469,8 +469,7 @@
             <lb ed="#V" n="98"/>posset facere plures mundos. 
           </p>
           <p xml:id="kzz7yh-a93632-d1e873">
-            <lb ed="#V" n="99"/>Ad primum in oppositum  solutio er dicta in 
-            cor<lb ed="#V" n="100" break="no"/>pore quaestionis in quo satis ostensum est 
+            <lb ed="#V" n="99"/>Ad primum in oppositum patet solutio per dicta in cor<lb ed="#V" n="100" break="no"/>pore quaestionis in quo satis ostensum est 
             <lb ed="#V" n="101"/>quod inefficax est ista argumentatio phlosophi.
           </p>
           <p xml:id="kzz7yh-a93632-d1e882">
@@ -497,7 +496,7 @@
         <div xml:id="kzz7yh-a93632-Dd1e919">
           <head xml:id="kzz7yh-a93632-Hd1e921">Quaestio 5</head>
           <p xml:id="kzz7yh-a93632-d1e923">
-            <lb ed="#V" n="116"/> l 
+            <lb ed="#V" n="116"/>Quaestio. V 
             <lb ed="#V" n="117"/>QUinto queritur vtrum deus easdem partes 
             vni<lb ed="#V" n="118" break="no"/>uersi adhuc facere possit: et videtur quod 
             <lb ed="#V" n="119"/>sic: deus quicquid semel sciuit scientia simplicis 
@@ -527,8 +526,7 @@
           </p>
           <p xml:id="kzz7yh-a93632-d1e975">
             <lb ed="#V" n="135"/>¶ Item Hugo. prim libro de sacramentis. per. 5. c. 24. Quod potest 
-            <lb ed="#V" n="136"/>in praescientiam si de praesenti non potest: tamen non nisi ad suturum potest. 
-            <!--00288.xml-->
+            <lb ed="#V" n="136"/>in praesenti et si de praesenti non potest: tamen non nisi ad futurum potest.<!--00288.xml-->
             <pb ed="#V" n="137-v"/>
             <cb ed="#P" n="a"/>
             <lb ed="#V" n="1"/>Deus autem non potest facere nisi quod futurum est: sed hoc vniuersum 

--- a/kzz7yh-a93632/cod-ve07v1_kzz7yh-a93632.xml
+++ b/kzz7yh-a93632/cod-ve07v1_kzz7yh-a93632.xml
@@ -65,7 +65,7 @@
         </p>
         <p xml:id="kzz7yh-a93632-d1e117">
           ¶ Secundo vtrum post iudicium posset 
-          <lb ed="#V" n="80"/>aliquid addem ad bonitatem vniuersi.
+          <lb ed="#V" n="80"/>aliquid addere ad bonitatem vniuersi.
         </p>
         <p xml:id="kzz7yh-a93632-d1e122">
           ¶ Tertio vtrum potuit 
@@ -94,7 +94,7 @@
             <lb ed="#V" n="89"/>prouidentia: omnino necesse est omnia que prouidentia 
             <lb ed="#V" n="90"/>fiunt secundum rectam rationem et optimam: et deo decentissimam fieri. 
             <lb ed="#V" n="91"/>et vt non est melius fieri: sed et ipsum vniuersum regitur 
-            pro<lb ed="#V" n="92" break="no"/>uidentia: ergo non potesti melius fieri.
+            pro<lb ed="#V" n="92" break="no"/>uidentia: ergo non ponenti melius fieri.
           </p>
           <p xml:id="kzz7yh-a93632-d1e167">
             ¶ Item Aug. 3. de 
@@ -111,7 +111,7 @@
           <p xml:id="kzz7yh-a93632-d1e185">
             <lb ed="#V" n="99"/>¶ Item arguo sicut arguit <ref xml:id="kzz7yh-a93632-Rd1e191">Augu. x. super Gen. circa 
             me<lb ed="#V" n="100" break="no"/>dium</ref>. bona facere si non possit: nulla esset potentia. si autem 
-            <lb ed="#V" n="101"/>posset nec faceret: magna esset inuidia: quia ergo est oprstus et 
+            <lb ed="#V" n="101"/>posset nec faceret: magna esset inuidia: quia ergo est opus et 
             bo<lb ed="#V" n="102" break="no"/>nus: omnia bona valde fecit. ergo vniuersum non potest 
             fa<lb ed="#V" n="103" break="no"/>cere melius.
           </p>
@@ -148,7 +148,7 @@
             <!--00286.xml-->
             <pb ed="#V" n="136-v"/>
             <cb ed="#P" n="a"/>
-            <lb ed="#V" n="1"/>creaturarum secundum se. Primomon nec potest nec potuit vniuer 
+            <lb ed="#V" n="1"/>creaturarum secundum se. Primo modo nec potest nec potuit vniuer 
             <lb ed="#V" n="2"/>sum melius fieri: quia finis vniuersitatis creaturarum deus est: 
             <lb ed="#V" n="3"/>quia secundum quod dicitur pro verbi. 16. Uniuersa propter semetipsum operatus 
             <lb ed="#V" n="4"/>est dominus.
@@ -160,7 +160,7 @@
             maio<lb ed="#V" n="7" break="no"/>rem bonitatem. Nec etiam tertio modo quia vniuersitas 
             creatura<lb ed="#V" n="8" break="no"/>rum simul sumpta ita bene ordinata est respectu finis: quod 
             ser<lb ed="#V" n="9" break="no"/>uato eodem statu bonitatis creaturarum secundum se melius 
-            ordi<lb ed="#V" n="10" break="no"/>nari non potest: nec mirum quia ad exemplar ordis pulcherimum 
+            ordi<lb ed="#V" n="10" break="no"/>nari non potest: nec mirum quia ad exemplar ordis <sic>pulcherimum</sic> 
             <lb ed="#V" n="11"/>ipsum vniuersum est ordinatum quantum ad ordinem partium 
             in<lb ed="#V" n="12" break="no"/>ter se: et vniuersi respectu finis. Est enim ordinatum ad 
             exemplar<lb ed="#V" n="13" break="no"/>mondi intelligibilis qui est ratio sempiterna et 
@@ -184,7 +184,7 @@
             propor<lb ed="#V" n="31" break="no"/>tio chordarum inter se: et sicut tu vides quod quamuis niger 
             color<lb ed="#V" n="32" break="no"/>turpis sit secundum se: et quod secundum se pulchrior est albus color: tamen quandoque 
             <lb ed="#V" n="33"/>si de pulchra pictura varietate decorata velles nigru re 
-            <lb ed="#V" n="34"/>mouem colorem vbicumque esset: et loco huius albismo ponere 
+            <lb ed="#V" n="34"/>mouere colorem vbicumque esset: et loco huius albus ponere 
             frequen<lb ed="#V" n="35" break="no"/>ter deturparetur pictura. vnde Augu. xi. de ciui. dei. c. 22. 
             Si<lb ed="#V" n="36" break="no"/>cut pictura cum colore nigro et loco suo posita: ita 
             vniuer<lb ed="#V" n="37" break="no"/>sitas rerum siquis posset intueri est cum peccoribus pulchra est: 
@@ -208,7 +208,7 @@
             perti<lb ed="#V" n="49" break="no"/>tibus de nouo additis se haberet ad praesens vniuersum sicut 
             <lb ed="#V" n="50"/>totum ad partem. Totum autem et pars quanuis non sint 
             diuer<lb ed="#V" n="51" break="no"/>sa numero simpliciter tamen non sunt simpliciter idem numero: sed 
-            <lb ed="#V" n="52"/>partim idem: partim diuersa secundum quod videtur innuere philosophus ids 
+            <lb ed="#V" n="52"/>partim i.: partim diuersa secundum quod videtur innuere philosophus idem 
             phy<lb ed="#V" n="53" break="no"/>sico. quamuis expresse non determinet: et Commentator super eum 
             <lb ed="#V" n="54"/>dem locum dicit quod vna queque partium dicitur esse aliud 
             a<lb ed="#V" n="55" break="no"/>toto: sed omnes insimul non possunt dici simul esse aliud a 
@@ -232,7 +232,7 @@
           <p xml:id="kzz7yh-a93632-d1e423">
             <!--00286.xml-->
             <cb ed="#P" n="b"/>
-            <lb ed="#V" n="69"/>Argumenta ad partem primam procedunt de menlio 
+            <lb ed="#V" n="69"/>Argumenta ad partem primam procedunt de melio 
             <lb ed="#V" n="70"/>ratione vniuersi quantum ad 
             ordi<lb ed="#V" n="71" break="no"/>nem partium inter se et omnium partium simul ad finem secundum 
             <lb ed="#V" n="72"/>statum bonitatis: quam creature habent secundum se: sic enim 
@@ -241,8 +241,8 @@
             meliora<lb ed="#V" n="75" break="no"/>tione aliquarum partium vniuersi et bene 
             conce<lb ed="#V" n="76" break="no"/>do quod possibile est multas partes vniuersi meliorari: et etiam 
             bine<lb ed="#V" n="77" break="no"/>procedit de melioratione vniuersi omnium partium 
-            melioratio<lb ed="#V" n="78" break="no"/>nem. accidentalem optima proportione inter earum melioratio. 
-            <lb ed="#V" n="79"/>nem seruata. Et sic hoc idem vniuersum in numero potest 
+            melioratio<lb ed="#V" n="78" break="no"/>nem. accidentalem optima proportione inter earum . 
+            melioratio<lb ed="#V" n="79" break="no"/>nem seruata. Et sic hoc idem vniuersum in numero potest 
             me<lb ed="#V" n="80" break="no"/>lius fieri.
           </p>
           <p xml:id="kzz7yh-a93632-d1e456">
@@ -277,7 +277,7 @@
             <lb ed="#V" n="94"/>TErtio queritur vtrum deus potuit facere 
             vniuer<lb ed="#V" n="95" break="no"/>sum antequam fecit: et videtur quod non: quia 
             <lb ed="#V" n="96"/>mundus non potuit fieri ab eterno vt circa 
-            prin<lb ed="#V" n="97" break="no"/>cipium 2 declarabitur et supponatur: sed ante praiemum 
+            prin<lb ed="#V" n="97" break="no"/>cipium 2 declarabitur et supponatur: sed ante primum 
             <lb ed="#V" n="98"/>instans quo mundus factus est. non fuit nisi eternitas: ergo 
             <lb ed="#V" n="99"/>ante illud instans non potuit mundus a deo fieri.
           </p>
@@ -317,16 +317,16 @@
           </p>
           <p xml:id="kzz7yh-a93632-d1e580">
             ¶ Item deus posset facere mundum maiorem in 
-            extem<lb ed="#V" n="124" break="no"/>sione: ergo a simili potuit facere ipsum antiquorem in duratione 
+            extem<lb ed="#V" n="124" break="no"/>sione: ergo a simili potuit facere ipsum <sic>antiquorem</sic> in duratione 
           </p>
           <p xml:id="kzz7yh-a93632-d1e585">
             <lb ed="#V" n="125"/>Respondeo quod deum potuisse facere mundum 
-            <lb ed="#V" n="126"/>antequam fecit potest intelltgi 
+            <lb ed="#V" n="126"/>antequam fecit potest <sic>intelltgi</sic> 
             duplie<lb ed="#V" n="127" break="no"/>vno non faciendo aliquam partem temporis que principium instans in quo 
             <lb ed="#V" n="128"/>mundus fuit creatus praecessisset et si dico quod mundus non 
             po<lb ed="#V" n="129" break="no"/>tuit fieri antequam factus est: quia ante instans in quo factus fuit 
             <lb ed="#V" n="130"/>non fuit aliqua mensura prior in qua esset prius et posterius 
-            <lb ed="#V" n="131"/>quia ante illud instans non fuit nisi soilna eternitas: in qua 
+            <lb ed="#V" n="131"/>quia ante illud instans non fuit nisi sola eternitas: in qua 
             mun<lb ed="#V" n="132" break="no"/>dus fieri nullo modo potuit: vel faciendo aliquam partem temporis 
             <lb ed="#V" n="133"/>ante illud instans in quo mundus fuit creatus: cuius partis 
             <lb ed="#V" n="134"/>temporis illud instans esset terminus: et sic dico quod deus potuit 
@@ -340,7 +340,7 @@
             <lb ed="#V" n="3"/>temporis non potuit facem esse antequam fuit: tamen ante illud instans potuit 
             <lb ed="#V" n="4"/>aliud facem ita quod inter illud instans: quod facem potuit et non 
             <lb ed="#V" n="5"/>fecit: et illud instans in quo mondus incepit cucurrissent 
-            mul<lb ed="#V" n="6" break="no"/>ta milia annorum si voluisset. Ex dictis patet solutio ad principium in opsim¬ 
+            mul<lb ed="#V" n="6" break="no"/>ta milia annorum si voluisset. Ex dictis patet solutio ad principium in oppositum 
           </p>
           <p xml:id="kzz7yh-a93632-d1e633">
             <lb ed="#V" n="7"/>¶ Ad 2m dicendum quod quamuis nullum tempus fuerit ante mundum: tamen 
@@ -418,7 +418,7 @@
           <p xml:id="kzz7yh-a93632-d1e772">
             ¶ Item quia pater generando se perfectissime expressit in vno 
             <lb ed="#V" n="61"/>filio ideo non potest alium filium generare ergo a simili cum 
-            <lb ed="#V" n="62"/>deus creando: se ita expressit in vnomouso: sicut per creaturam possit 
+            <lb ed="#V" n="62"/>deus creando: se ita expressit in homoousios: sicut per creaturam possit 
             <lb ed="#V" n="63"/>exprimi: ideo non potest alium mundum creare: qua propter etiam 
             <lb ed="#V" n="64"/>Trimegistus de divinitate ad Asclepium mundum dicit esse 
             <lb ed="#V" n="65"/>imaginem dei: videtur quod cum ista vniuersitate aliam non 
@@ -469,7 +469,7 @@
             <lb ed="#V" n="98"/>posset facere plures mundos. 
           </p>
           <p xml:id="kzz7yh-a93632-d1e873">
-            <lb ed="#V" n="99"/>Ad primum in oppositum beriet solutio er dicta in 
+            <lb ed="#V" n="99"/>Ad primum in oppositum  solutio er dicta in 
             cor<lb ed="#V" n="100" break="no"/>pore quaestionis in quo satis ostensum est 
             <lb ed="#V" n="101"/>quod inefficax est ista argumentatio phlosophi.
           </p>
@@ -497,8 +497,8 @@
         <div xml:id="kzz7yh-a93632-Dd1e919">
           <head xml:id="kzz7yh-a93632-Hd1e921">Quaestio 5</head>
           <p xml:id="kzz7yh-a93632-d1e923">
-            <lb ed="#V" n="116"/>Ciueie l 
-            <lb ed="#V" n="117"/>QUinto queritur vtrum deus euidem partes 
+            <lb ed="#V" n="116"/> l 
+            <lb ed="#V" n="117"/>QUinto queritur vtrum deus easdem partes 
             vni<lb ed="#V" n="118" break="no"/>uersi adhuc facere possit: et videtur quod 
             <lb ed="#V" n="119"/>sic: deus quicquid semel sciuit scientia simplicis 
             intelligen<lb ed="#V" n="120" break="no"/>tie semper scit vt superius ostensum est: ergo a simili ad 
@@ -521,13 +521,13 @@
             <lb ed="#V" n="131"/>faciat 
           </p>
           <p xml:id="kzz7yh-a93632-d1e965">
-            <lb ed="#V" n="132"/>Contra ibshu ib vidicamentbus c de quantitute. 
+            <lb ed="#V" n="132"/>Contra Philosophum libro praedi.c.amentibus c de quantitate. 
             <lb ed="#V" n="133"/>Quod dictum est amplius sumi non 
             po<lb ed="#V" n="134" break="no"/>test: ergo a simili quod factum est amplius non potest fieri. 
           </p>
           <p xml:id="kzz7yh-a93632-d1e975">
             <lb ed="#V" n="135"/>¶ Item Hugo. prim libro de sacramentis. per. 5. c. 24. Quod potest 
-            <lb ed="#V" n="136"/>in presantiet si de praesenti non potest: tamen non nisi ad suturum potest. 
+            <lb ed="#V" n="136"/>in praescientiam si de praesenti non potest: tamen non nisi ad suturum potest. 
             <!--00288.xml-->
             <pb ed="#V" n="137-v"/>
             <cb ed="#P" n="a"/>
@@ -543,32 +543,32 @@
           <p xml:id="kzz7yh-a93632-d1e1004">
             ¶ primo 
             conce<lb ed="#V" n="7" break="no"/>dendum est deum posse adhuc facem easdem partes vniuersi in 
-            nu<lb ed="#V" n="8" break="no"/>mero: quia deus posset subtrahem influentiam suam quae partes vniuersi 
+            nu<lb ed="#V" n="8" break="no"/>mero: quia deus posset subtrahere influentiam suam quae partes vniuersi 
             com<lb ed="#V" n="9" break="no"/>seruat in esse: quae subtracta destruentur: et destructas deus posset eatur 
             <lb ed="#V" n="10"/>dem in numero reparare vt ostendetur in quarto.
           </p>
           <p xml:id="kzz7yh-a93632-d1e1015">
             ¶ 2o autem modo dicendum 
             <lb ed="#V" n="11"/>non posse adhuc facere easdem partes vniuersi in numero: non 
-            <lb ed="#V" n="12"/>ideo quia deus minorem hebeat poteonm quam solebat: quia eius potentia nec 
+            <lb ed="#V" n="12"/>ideo quia deus minorem hebeat potentiam quam solebat: quia eius potentia nec 
             <lb ed="#V" n="13"/>augeri potest: nec minui: sed quia iste partes vniuersi antequam essent 
             <lb ed="#V" n="14"/>facte habebant rationem factibilis modo non habent eo quod facte sunt 
             <lb ed="#V" n="15"/>quia creaturam fieri est ipsam de non esse in esse produci. 
           </p>
           <p xml:id="kzz7yh-a93632-d1e1028">
             <lb ed="#V" n="16"/>Ad primum dicendum quod sic deus scientia simplicis intelligentie scit quicquid 
-            sci<lb ed="#V" n="17" break="no"/>uit: ita dico quod habet positeom super omnem rem super quam vnquam potest 
-            <lb ed="#V" n="18"/>hunit: quia super illam rem super quam huit poiteom causa faciendi antequaem 
-            <lb ed="#V" n="19"/>scta esset: ita postque facta est: habet super illam positionm eam conseruandi et 
+            sci<lb ed="#V" n="17" break="no"/>uit: ita dico quod habet potentiam super omnem rem super quam vnquam potest 
+            <lb ed="#V" n="18"/>habuit: quia super illam rem super quam habuit potentiam causa faciendi antequam 
+            <lb ed="#V" n="19"/>facta esset: ita postquam facta est: habet super illam potentiam eam conseruandi et 
             <lb ed="#V" n="20"/>destruendi et reparandi destructam: et sic deus nescit esse verum quicquid 
             <lb ed="#V" n="21"/>sciuit esse verum non propter mutationem factam ex parte scientie dei: sed ex parte 
             <lb ed="#V" n="22"/>rei: ita deus non potest facere quicquid aliquando facem potuit non propter 
-            di<lb ed="#V" n="23" break="no"/>ne poster mutabilitatem: sed propter mutationem rei a futurione in 
-            proesen<lb ed="#V" n="24" break="no"/>tialitatem.
+            di<lb ed="#V" n="23" break="no"/>ne potentiae mutabilitatem: sed propter mutationem rei a futuritione in 
+            praesen<lb ed="#V" n="24" break="no"/>tialitatem.
           </p>
           <p xml:id="kzz7yh-a93632-d1e1050">
             ¶ Ad 2m dicendum quod potentia coniuncta actui dicitur 
-            respe<lb ed="#V" n="25" break="no"/>ctu effectus dum sit non rmo effectuus quando factus est.
+            respe<lb ed="#V" n="25" break="no"/>ctu effectuus dum sit non respectu effectus quando factus est.
           </p>
           <p xml:id="kzz7yh-a93632-d1e1056">
             ¶ Ad 3m dicendum 
@@ -582,7 +582,7 @@
         <div xml:id="kzz7yh-a93632-Dd1e1070">
           <head xml:id="kzz7yh-a93632-Hd1e1072">Quaestio 6</head>
           <p xml:id="kzz7yh-a93632-d1e1074">
-            <lb ed="#V" n="31"/>SExto queritur vtrum dina post siec vniuersum de necesita 
+            <lb ed="#V" n="31"/>SExto queritur vtrum divina potentia hoc vniuersum de necessita 
             <lb ed="#V" n="32"/>te nature produxerit: vel producem potuerit: et 
             <lb ed="#V" n="33"/>videtur quod sic: quia deus creauit mundum per suam bonitatem. Unde 
             <lb ed="#V" n="34"/>Aug. i. de doc. christiana longe ante finem. Quia bonus est 
@@ -592,7 +592,7 @@
           <p xml:id="kzz7yh-a93632-d1e1090">
             ¶ Item secundum philosophum. 3. ethi. c. 
             <lb ed="#V" n="37"/>5. voluntas est finis: sed deus nullum habet finem: ergo deus nihil potest 
-            <lb ed="#V" n="38"/>facem per voluntatem: ergo nihil potest agem nisi per nature necessitatem.
+            <lb ed="#V" n="38"/>facem per voluntatem: ergo nihil potest agere nisi per nature necessitatem.
           </p>
           <p xml:id="kzz7yh-a93632-d1e1097">
             ¶ Item 
@@ -625,12 +625,12 @@
             <lb ed="#V" n="57"/>effectum: cuius productioni non potest praeuenire voluntas imperfecta: 
             si<lb ed="#V" n="58" break="no"/>talem effectum potest producem non directa per intellectum: nec determinata 
             <lb ed="#V" n="59"/>ad producendum per voluntarem: quia ex imperfectione est quod natura possit 
-            <lb ed="#V" n="60"/>exire in actum praeter regitram et imperium poser superioris. Sed deus est . 
+            <lb ed="#V" n="60"/>exire in actum praeter regulam et impotentiaeium per superioris. Sed deus est . 
             <lb ed="#V" n="61"/>substantia habens intellectum: et voluntatem et est summe perfecta: ergo natura in 
             deo<lb ed="#V" n="62" break="no"/>quamuis non sit inferior intellectu et voluntate eo quod sunt realiter idem 
             <lb ed="#V" n="63"/>non potest exire in aliquem actum exteriorem nisi directe per 
             intelle<lb ed="#V" n="64" break="no"/>ctum et determinata per voluntatem: sed sic producem non est 
-            producen<lb ed="#V" n="65" break="no"/>necessitate nature: ergo deus non posuit producem vniuersum de necestate 
+            producen<lb ed="#V" n="65" break="no"/>necessitate nature: ergo deus non posuit producem vniuersum de necessitate 
           </p>
           <p xml:id="kzz7yh-a93632-d1e1167">
             <lb ed="#V" n="66"/>¶ Respondeo quod deus non produxit nec producem po¬ fnane. 
@@ -646,25 +646,25 @@
             non<lb ed="#V" n="74" break="no"/>distinguit inter ea quae sunt realiter vnum: sed intellectus distinguit 
             <lb ed="#V" n="75"/>inter ea eo quod contingit ea quae sunt realiter vnum esse secundum rationem differentia: ergo 
             <lb ed="#V" n="76"/>divinarum perfectionum communicatio cum reali differentia non potuit esse nisi per 
-            <lb ed="#V" n="77"/>potentiam directam ab intellectu: sed poso in operando directa per 
+            <lb ed="#V" n="77"/>potentiam directam ab intellectu: sed potentia in operando directa per 
             <lb ed="#V" n="78"/>intellectum determinatur ad operandum per voluntatem: ergo videtur quod deus non 
             <lb ed="#V" n="79"/>potuit perfectionem suam communicare diuersis partibus vniuersi nisi 
             <lb ed="#V" n="80"/>per potentiam directam per intellectum ad operandum et determinatam per 
             vo<lb ed="#V" n="81" break="no"/>luntatem: ergo non potuit producem vniuersum de necessitate nature. 
           </p>
           <p xml:id="kzz7yh-a93632-d1e1209">
-            <lb ed="#V" n="82"/>¶ Presmu deus non potuit creare vniuersum nisi propter aliquem 
+            <lb ed="#V" n="82"/>¶ Praeterea deus non potuit creare vniuersum nisi propter aliquem 
             fi<lb ed="#V" n="83" break="no"/>nem qui est ipse: sed omne agens propter finem autem agit propter finem praescitum 
             <lb ed="#V" n="84"/>operi suo ab alio: sicut agunt naturalia propter finem: autem a seipso: ergo 
             <lb ed="#V" n="85"/>cum finis propter quem deus operatur: non potuerit praestitui operibus 
             <lb ed="#V" n="86"/>ab alio quam a seipso: sequitur quod ipsemet dicitur finem propter quem 
             opera<lb ed="#V" n="87" break="no"/>tur praestituit operibus suis. prestituere autem finem operi est ipsum finem 
-            <lb ed="#V" n="88"/>cognoscem: et opus suum velle in illum finem ordinari: ergo sequitur quod 
+            <lb ed="#V" n="88"/>cognoscere: et opus suum velle in illum finem ordinari: ergo sequitur quod 
             <lb ed="#V" n="89"/>deus non potuit producem vniuersum nisi cognoscendo 
             vniuer<lb ed="#V" n="90" break="no"/>sum: et se esse finem vniuersi: et videndo vniuersum ordinari in 
             <lb ed="#V" n="91"/>se vt in finem: sed sic operari non est operari de necessitate nature: ergo 
             <lb ed="#V" n="92"/>deus non potuit producere vniuersum de necessitate nature. 
-            <lb ed="#V" n="93"/>Ad princitum in opositum dicendum quod quamuis deus sit naturaliter bonus: et de necessitate 
+            <lb ed="#V" n="93"/>Ad primum in oppositum dicendum quod quamuis deus sit naturaliter bonus: et de necessitate 
             <lb ed="#V" n="94"/>et vniuersum creauerit propter suam bonitatem: non tamen propter hoc 
             <lb ed="#V" n="95"/>sequitur quod vniuersum creauerit de necessitate nature: quia habitudo 
             vni<lb ed="#V" n="96" break="no"/>uersi: vt futuri vel existentis non erat naturalis nec necessaria ad suam 
@@ -681,7 +681,7 @@
             <lb ed="#V" n="101"/>patris carnalis: neque determinantur ad sic operandum per carnalis patris 
             <lb ed="#V" n="102"/>voluntatem: non tamen generatur filius a patre de necessitate nature: pro tanto quia ex 
             <lb ed="#V" n="103"/>voluntate patris et matris dependet dare operam tali facto. 
-            Uni<lb ed="#V" n="104" break="no"/>uersum autem processit a deo per posum directam per intellectum: et 
+            Uni<lb ed="#V" n="104" break="no"/>uersum autem processit a deo per potentiam directam per intellectum: et 
             deter<lb ed="#V" n="105" break="no"/>minatam ad producendum per voluntatem: nec aliter produci potuit vt 
             <lb ed="#V" n="106"/>superius ostensum est: et ideo illa productio non fuit naturalis nec necessaria. 
             <lb ed="#V" n="107"/>nec esse potuit

--- a/kzz7yh-a93632/cod-ve07v1_kzz7yh-a93632.xml
+++ b/kzz7yh-a93632/cod-ve07v1_kzz7yh-a93632.xml
@@ -139,7 +139,7 @@
             que<lb ed="#V" n="116" break="no"/>drupliciter potest intelligi sicut et 
             ex<lb ed="#V" n="117" break="no"/>ercitum posse meliorari. Potest enim exercitus meliorari 
             vi<lb ed="#V" n="118" break="no"/>per meliorationem ducis: vel per meliorationem ordinis partium 
-            <lb ed="#V" n="119"/>inter se: vel per meliorationem ordinis exercitus ad ducem. vet 
+            <lb ed="#V" n="119"/>inter se: vel per meliorationem ordinis exercitus ad ducem. vel 
             <lb ed="#V" n="120"/>per meliorationem partium secundum se ipsas. Sic et vniuersitatem 
             <lb ed="#V" n="121"/>posse meliorari quattuor modis posset intelligi scilicet per 
             me<lb ed="#V" n="122" break="no"/>liorationem finis: vel per meliorationem ordinis creaturam 
@@ -156,12 +156,12 @@
           <p xml:id="kzz7yh-a93632-d1e273">
             ¶ Nec est secundo modo supposita eadem bonitate 
             crea<lb ed="#V" n="5" break="no"/>turarum quam habent secundum se: quia ita bene ordinate sunt inter se quod 
-            <lb ed="#V" n="6"/>nullo modo possunt melius ordinari nisi secundum se mutentur in maio 
-            <lb ed="#V" n="7"/>rem bonitatem. Nec etiam tertio modo quia vniuersitas 
-            creatura<lb ed="#V" n="8" break="no"/>rum simlus sumpta ita bene ordinata est respectu finis: quod 
+            <lb ed="#V" n="6"/>nullo modo possunt melius ordinari nisi secundum se mutentur in 
+            maio<lb ed="#V" n="7" break="no"/>rem bonitatem. Nec etiam tertio modo quia vniuersitas 
+            creatura<lb ed="#V" n="8" break="no"/>rum simul sumpta ita bene ordinata est respectu finis: quod 
             ser<lb ed="#V" n="9" break="no"/>uato eodem statu bonitatis creaturarum secundum se melius 
             ordi<lb ed="#V" n="10" break="no"/>nari non potest: nec mirum quia ad exemplar ordis pulcherimum 
-            <lb ed="#V" n="11"/>ipsum vninersum est ordinatum quantum ad ordinem partium 
+            <lb ed="#V" n="11"/>ipsum vniuersum est ordinatum quantum ad ordinem partium 
             in<lb ed="#V" n="12" break="no"/>ter se: et vniuersi respectu finis. Est enim ordinatum ad 
             exemplar<lb ed="#V" n="13" break="no"/>mondi intelligibilis qui est ratio sempiterna et 
             incommutabi<lb ed="#V" n="14" break="no"/>lis in mente divina. vnde. Augustinus id est libo retracta. c. 3 loquens de 
@@ -187,7 +187,7 @@
             <lb ed="#V" n="34"/>mouem colorem vbicumque esset: et loco huius albismo ponere 
             frequen<lb ed="#V" n="35" break="no"/>ter deturparetur pictura. vnde Augu. xi. de ciui. dei. c. 22. 
             Si<lb ed="#V" n="36" break="no"/>cut pictura cum colore nigro et loco suo posita: ita 
-            vniuer<lb ed="#V" n="37" break="no"/>sitas rerum siquis posset intueri est cum pecccoribus pulchra est: 
+            vniuer<lb ed="#V" n="37" break="no"/>sitas rerum siquis posset intueri est cum peccoribus pulchra est: 
             quam<lb ed="#V" n="38" break="no"/>uis per seipsos consideratos sua deformitas turpet.
           </p>
           <p xml:id="kzz7yh-a93632-d1e349">
@@ -196,7 +196,7 @@
             me<lb ed="#V" n="40" break="no"/>lius: quia aut nulla substantia manens eadem in numero potest recipe 
             <lb ed="#V" n="41"/>meliorationem substantialem: aut saltem de multis substantiis hoc 
             <lb ed="#V" n="42"/>est verum: et ita aut non remanerent alique substantie create de 
-            <lb ed="#V" n="43"/>his que modo sunt: et sic nullomo remanet hoc idem 
+            <lb ed="#V" n="43"/>his que modo sunt: et sic nullo modo remanet hoc idem 
             vniuer<lb ed="#V" n="44" break="no"/>sum in numero: aut si alique remanerent: et aliqua 
             mutaren<lb ed="#V" n="45" break="no"/>tur in alias adhuc non remaneret idem vniuersum in 
             nu<lb ed="#V" n="46" break="no"/>mero secundum se totum: sed secundum partes.
@@ -210,7 +210,7 @@
             diuer<lb ed="#V" n="51" break="no"/>sa numero simpliciter tamen non sunt simpliciter idem numero: sed 
             <lb ed="#V" n="52"/>partim idem: partim diuersa secundum quod videtur innuere philosophus ids 
             phy<lb ed="#V" n="53" break="no"/>sico. quamuis expresse non determinet: et Commentator super eum 
-            <lb ed="#V" n="54"/>dem locum dicit quod vna queque paertium dicitur esse aliud 
+            <lb ed="#V" n="54"/>dem locum dicit quod vna queque partium dicitur esse aliud 
             a<lb ed="#V" n="55" break="no"/>toto: sed omnes insimul non possunt dici simul esse aliud a 
             to<lb ed="#V" n="56" break="no"/>to.
           </p>
@@ -226,8 +226,8 @@
             huma<lb ed="#V" n="64" break="no"/>ne Iesu christi non peiorabit ordinem aliarum partium ad 
             <lb ed="#V" n="65"/>naturam humanam Iesu christi quia bonitas sua ita proportionaliter 
             <lb ed="#V" n="66"/>excedit bonitatem aliarum creaturarum maxime inquantum est 
-            <lb ed="#V" n="67"/>vnita persone filii dei. In vnitate persone quod quanto alie creatu 
-            <lb ed="#V" n="68"/>re sient meliores tanto decentius ordinabuntur ad ipsam. 
+            <lb ed="#V" n="67"/>vnita persone filii dei. In vnitate persone quod quanto alie 
+            creatu<lb ed="#V" n="68" break="no"/>re sient meliores tanto decentius ordinabuntur ad ipsam. 
           </p>
           <p xml:id="kzz7yh-a93632-d1e423">
             <!--00286.xml-->
@@ -257,7 +257,7 @@
         <div xml:id="kzz7yh-a93632-Dd1e470">
           <head xml:id="kzz7yh-a93632-Hd1e472">Quaestio 2</head>
           <p xml:id="kzz7yh-a93632-d1e474">
-            <lb ed="#V" n="86"/>Ecundo querendum esset vtrum deus potest 
+            <lb ed="#V" n="86"/>Secundo querendum esset vtrum deus potest 
             iudi<lb ed="#V" n="87" break="no"/>cium posset aliquid addere ad 
             bo<lb ed="#V" n="88" break="no"/>nitatem vniuersi.
           </p>
@@ -306,12 +306,12 @@
             <lb ed="#V" n="115"/>fuit prima praesupponit deum facere mobile antequam fecerit: quia 
             <lb ed="#V" n="116"/>mutatio praesupponit mutabile: ergo a primo deum facere 
             mu<lb ed="#V" n="117" break="no"/>dum antequam fecerit praesupponit deum potuisse facere mundum 
-            <lb ed="#V" n="118"/>antequam fecerit: quod contratradictionem includit: quia idem 
+            <lb ed="#V" n="118"/>antequam fecerit: quod contradictionem includit: quia idem 
             praesup<lb ed="#V" n="119" break="no"/>ponere seipsum includit idem seipso esse prius et non prius 
             <lb ed="#V" n="120"/>et posterius et non posterius. 
           </p>
           <p xml:id="kzz7yh-a93632-d1e571">
-            <lb ed="#V" n="121"/>Contra Deus potuit facere mindum tardius quam 
+            <lb ed="#V" n="121"/>Contra Deus potuit facere mundum tardius quam 
             fece<lb ed="#V" n="122" break="no"/>rit: ergo a simili potuit citius fieri quam 
             faci<lb ed="#V" n="123" break="no"/>fuit.
           </p>
@@ -327,9 +327,9 @@
             po<lb ed="#V" n="129" break="no"/>tuit fieri antequam factus est: quia ante instans in quo factus fuit 
             <lb ed="#V" n="130"/>non fuit aliqua mensura prior in qua esset prius et posterius 
             <lb ed="#V" n="131"/>quia ante illud instans non fuit nisi soilna eternitas: in qua 
-            mun<lb ed="#V" n="132" break="no"/>dus fieri nullomon potuit: vel faciendo aliquam partem temporis 
+            mun<lb ed="#V" n="132" break="no"/>dus fieri nullo modo potuit: vel faciendo aliquam partem temporis 
             <lb ed="#V" n="133"/>ante illud instans in quo mundus fuit creatus: cuius partis 
-            <lb ed="#V" n="134"/>temporis illud instans esset terminus: et sic dico quod deus potutt 
+            <lb ed="#V" n="134"/>temporis illud instans esset terminus: et sic dico quod deus potuit 
             <lb ed="#V" n="135"/>mundum faceret antequam fecit per mille annos ante: et adhuc 
             <lb ed="#V" n="136"/>per mille et sic deinceps: nec tamen ex hoc sequitur quod possibile suerit 
             <!--00287.xml-->
@@ -350,14 +350,14 @@
           <p xml:id="kzz7yh-a93632-d1e642">
             ¶ Ad 
             <lb ed="#V" n="10"/>3m dicendum quod ad liberalem pertinet facem curialitatem quando melius est 
-            <lb ed="#V" n="11"/>causa fieri: sed melius fuit mundum creari in illo instanti cum quuao 
+            <lb ed="#V" n="11"/>causa fieri: sed melius fuit mundum creari in illo instanti cum quo 
             <lb ed="#V" n="12"/>creatus fuit quam ante et ideo divine liberalitati fuit concordans 
             <lb ed="#V" n="13"/>vt tunc crearetur et non ante. Unde verbum Aui. allegatum 
-            si<lb ed="#V" n="14" break="no"/>cut falsum et erraitioneum est reprobandum.
+            si<lb ed="#V" n="14" break="no"/>cut falsum et erroneam est reprobandum.
           </p>
           <p xml:id="kzz7yh-a93632-d1e655">
             ¶ Ad 4m dicendum 
-            <lb ed="#V" n="15"/>quod deum potuisse facere mudum antequam fecerit quamuis 
+            <lb ed="#V" n="15"/>quod deum potuisse facere mundum antequam fecerit quamuis 
             inclu<lb ed="#V" n="16" break="no"/>dat deum potuisse facere instans ante illud quod fuit principium: non 
             <lb ed="#V" n="17"/>tamen hoc praesupponit: quia sicut prius ordine nature fuit 
             mun<lb ed="#V" n="18" break="no"/>dus quam principium temporis instans: sic dico quod si fecisset mundum antequam 
@@ -367,7 +367,7 @@
             eternita<lb ed="#V" n="22" break="no"/>te fuerit factus: nec ab eterno: quamuis eius errationem non 
             praeces<lb ed="#V" n="23" break="no"/>serit nisi eternitas: quamuis enim ordine nature creatio mundi 
             <lb ed="#V" n="24"/>praecessisset illud instans cum quo fuisset: prius tamen fluxisset tempus 
-            <lb ed="#V" n="25"/>inter illud instans et illud quod fuit principium quam creatio mundi. Iilud 
+            <lb ed="#V" n="25"/>inter illud instans et illud quod fuit principium quam creatio mundi. Illud 
             <lb ed="#V" n="26"/>instans quod fuit principium duratione peraecessisset. Quod autem dixi in 
             eternita<lb ed="#V" n="27" break="no"/>te vel ab eterno hoc ideo dixi: quia si possibile fuisset mundum 
             produ<lb ed="#V" n="28" break="no"/>ci ab eterno: vt falso imaginantur aliqui: non tamen possibile fuisset ipsum 
@@ -401,7 +401,7 @@
           <head xml:id="kzz7yh-a93632-Hd1e741">Quaestio 4</head>
           <p xml:id="kzz7yh-a93632-d1e743">
             <lb ed="#V" n="50"/>¶ Questio. IIII. 
-            <lb ed="#V" n="51"/>Uarto queritur vtrum deus posset facere aliu 
+            <lb ed="#V" n="51"/>Quarto queritur vtrum deus posset facere aliu 
             <lb ed="#V" n="52"/>vniuersum: et videtur quod non per philosophum. 
             <lb ed="#V" n="53"/>cei et mundi: qui dicit quod tunc ista terra simul 
             moue<lb ed="#V" n="54" break="no"/>retur ad centrum istius mundi: et ad centrum 
@@ -409,32 +409,32 @@
           </p>
           <p xml:id="kzz7yh-a93632-d1e759">
             ¶ Item plato in 
-            <lb ed="#V" n="56"/>Timeo. Unum mundum dicimus: quoniam iuxta vnum exeplar 
+            <lb ed="#V" n="56"/>Timeo. Unum mundum dicimus: quoniam iuxta vnum exemplar 
             for<lb ed="#V" n="57" break="no"/>matus est: ergo videtur intentio sua fuisse quod propter 
             illi<lb ed="#V" n="58" break="no"/>us exemplaris vnitatem et perfectionem: ita perfectam 
-            <lb ed="#V" n="59"/>secit vniuersitatem: quod cum illa aliam non potuisset 
+            <lb ed="#V" n="59"/>fecit vniuersitatem: quod cum illa aliam non potuisset 
             fecis<lb ed="#V" n="60" break="no"/>se.
           </p>
           <p xml:id="kzz7yh-a93632-d1e772">
             ¶ Item quia pater generando se perfectissime expressit in vno 
             <lb ed="#V" n="61"/>filio ideo non potest alium filium generare ergo a simili cum 
             <lb ed="#V" n="62"/>deus creando: se ita expressit in vnomouso: sicut per creaturam possit 
-            <lb ed="#V" n="63"/>exprimi: ideo non potest alium mundum creare: qua propter etia 
+            <lb ed="#V" n="63"/>exprimi: ideo non potest alium mundum creare: qua propter etiam 
             <lb ed="#V" n="64"/>Trimegistus de divinitate ad Asclepium mundum dicit esse 
             <lb ed="#V" n="65"/>imaginem dei: videtur quod cum ista vniuersitate aliam non 
             <lb ed="#V" n="66"/>potest facere nec potuit. 
           </p>
           <p xml:id="kzz7yh-a93632-d1e788">
             <lb ed="#V" n="67"/>Contra Infinita potentia non finitur ad aliquem suum 
-            <lb ed="#V" n="68"/>veffectum: ergo cum hoc vniuerso deus potest 
+            <lb ed="#V" n="68"/>effectum: ergo cum hoc vniuerso deus potest 
             <!--00287.xml-->
             <cb ed="#P" n="b"/>
             <lb ed="#V" n="69"/>creare aliud vniuersum.
           </p>
           <p xml:id="kzz7yh-a93632-d1e802">
             ¶ Item deo non fuit difficilius 
-            <lb ed="#V" n="70"/>facere mundum quam vnam mudi creaturam. Sed deus cum 
-            <lb ed="#V" n="71"/>vna creatura potuit creare aliam: ergo simliter cum hoc 
+            <lb ed="#V" n="70"/>facere mundum quam vnam mundi creaturam. Sed deus cum 
+            <lb ed="#V" n="71"/>vna creatura potuit creare aliam: ergo similiter cum hoc 
             vni<lb ed="#V" n="72" break="no"/>uerso adhuc posset creare aliud. 
           </p>
           <p xml:id="kzz7yh-a93632-d1e811">
@@ -459,12 +459,12 @@
             vni<lb ed="#V" n="88" break="no"/>uersi: quia sicut terra istius vniuersi naturaliter quiesceret in 
             cen<lb ed="#V" n="89" break="no"/>tro huius vniuersi: et ita terra alterius vniuersi 
             naturali<lb ed="#V" n="90" break="no"/>ter quiescent in centro alterius vniuersi: et si terra illius 
-            vniuersi<lb ed="#V" n="91" break="no"/>poneretur in centro huius vninersi naturaliter ibi quiescent: et terra 
+            vniuersi<lb ed="#V" n="91" break="no"/>poneretur in centro huius vniuersi naturaliter ibi quiescent: et terra 
             hu<lb ed="#V" n="92" break="no"/>ius vniuersi si a deo poneretur in centro alterius 
-            vniuer<lb ed="#V" n="93" break="no"/>si naturaliter etiam ibi quiesceret: quia si duoloca alicui creature 
+            vniuer<lb ed="#V" n="93" break="no"/>si naturaliter etiam ibi quiesceret: quia si duo loca alicui creature 
             <lb ed="#V" n="94"/>naturaliter operanti essent penitus in differentia in quocumque illorum 
             <lb ed="#V" n="95"/>primo collocaretur ibi quiesceret: nec ad alium tenderet: et per hanc 
-            <lb ed="#V" n="96"/>opinionem est sententia domini Stephani episcoi Parin. et sacre 
+            <lb ed="#V" n="96"/>opinionem est sententia domini Stephani episcopi Parin. et sacre 
             theolo<lb ed="#V" n="97" break="no"/>gie doctoris: qui excommunicauit dogmatizantes quod deus non 
             <lb ed="#V" n="98"/>posset facere plures mundos. 
           </p>
@@ -507,7 +507,7 @@
           </p>
           <p xml:id="kzz7yh-a93632-d1e941">
             ¶ Item secundum Ansel. in 
-            <lb ed="#V" n="123"/>lib. de casu diaboli. c. 12 non taummodo est potentia praecedens 
+            <lb ed="#V" n="123"/>lib. de casu diaboli. c. 12 non tantummodo est potentia praecedens 
             <lb ed="#V" n="124"/>actum: sed est potentia coniuncta actui: que est cum effectu: ergo 
             <lb ed="#V" n="125"/>quamuis non possit facere easdem partes vniuersi potentia 
             praeceden<lb ed="#V" n="126" break="no"/>te actum potest tamen eas facere potentia coniuncta actui.
@@ -545,22 +545,22 @@
             conce<lb ed="#V" n="7" break="no"/>dendum est deum posse adhuc facem easdem partes vniuersi in 
             nu<lb ed="#V" n="8" break="no"/>mero: quia deus posset subtrahem influentiam suam quae partes vniuersi 
             com<lb ed="#V" n="9" break="no"/>seruat in esse: quae subtracta destruentur: et destructas deus posset eatur 
-            <lb ed="#V" n="10"/>dem in numero reperare vt ostendetur in quarto.
+            <lb ed="#V" n="10"/>dem in numero reparare vt ostendetur in quarto.
           </p>
           <p xml:id="kzz7yh-a93632-d1e1015">
             ¶ 2o autem modo dicendum 
             <lb ed="#V" n="11"/>non posse adhuc facere easdem partes vniuersi in numero: non 
             <lb ed="#V" n="12"/>ideo quia deus minorem hebeat poteonm quam solebat: quia eius potentia nec 
             <lb ed="#V" n="13"/>augeri potest: nec minui: sed quia iste partes vniuersi antequam essent 
-            <lb ed="#V" n="14"/>facte hebant rationem factibilis modo non habent eo quod facte sunt 
+            <lb ed="#V" n="14"/>facte habebant rationem factibilis modo non habent eo quod facte sunt 
             <lb ed="#V" n="15"/>quia creaturam fieri est ipsam de non esse in esse produci. 
           </p>
           <p xml:id="kzz7yh-a93632-d1e1028">
-            <lb ed="#V" n="16"/>Ad prinitum dicendum quod sic deus scientia simplicit intelligentie scit quicquid 
+            <lb ed="#V" n="16"/>Ad primum dicendum quod sic deus scientia simplicis intelligentie scit quicquid 
             sci<lb ed="#V" n="17" break="no"/>uit: ita dico quod habet positeom super omnem rem super quam vnquam potest 
             <lb ed="#V" n="18"/>hunit: quia super illam rem super quam huit poiteom causa faciendi antequaem 
             <lb ed="#V" n="19"/>scta esset: ita postque facta est: habet super illam positionm eam conseruandi et 
-            <lb ed="#V" n="20"/>destruendi et reperandi destructam: et sic deus nescit esse verum quicquid 
+            <lb ed="#V" n="20"/>destruendi et reparandi destructam: et sic deus nescit esse verum quicquid 
             <lb ed="#V" n="21"/>sciuit esse verum non propter mutationem factam ex parte scientie dei: sed ex parte 
             <lb ed="#V" n="22"/>rei: ita deus non potest facere quicquid aliquando facem potuit non propter 
             di<lb ed="#V" n="23" break="no"/>ne poster mutabilitatem: sed propter mutationem rei a futurione in 
@@ -573,7 +573,7 @@
           <p xml:id="kzz7yh-a93632-d1e1056">
             ¶ Ad 3m dicendum 
             <lb ed="#V" n="26"/>quod non est idem rem a deo creari et conseruari. Quod patet quia 
-            <lb ed="#V" n="27"/>terminus creationis esse est vel res inquantum ens: obitcium vero 
+            <lb ed="#V" n="27"/>terminus creationis esse est vel res inquantum ens: obiectum vero 
             conser<lb ed="#V" n="28" break="no"/>uationis fuit deus et permanentia creature in actuali existentia. 
             <lb ed="#V" n="29"/>Existentia vero: et permanentia illius existentie non sunt idem: nec ex hoc 
             <lb ed="#V" n="30"/>quod creatum possit permanere sine manutenentia creator 
@@ -608,12 +608,12 @@
             sun<lb ed="#V" n="45" break="no"/>mund illud bonum solem superans non secus obtusam imaginem 
             pri<lb ed="#V" n="46" break="no"/>mitiua excellenter fora ipsa sua substantia omnibus que sunt 
             pro<lb ed="#V" n="47" break="no"/>captu cuiusque totius bonitatis emittit radios. Uidetur 
-            <lb ed="#V" n="48"/>ergo velle quod sicut sol illuinat de necessitate nature ita deus 
+            <lb ed="#V" n="48"/>ergo velle quod sicut sol illuminat de necessitate nature ita deus 
             boni<lb ed="#V" n="49" break="no"/>tatem suam communicauit in creatione vniuersi de necessitate nature. 
           </p>
           <p xml:id="kzz7yh-a93632-d1e1127">
             <lb ed="#V" n="50"/>Contra omne agens de necessitate nature dat deus quancitius potest 
-            <lb ed="#V" n="51"/>effctui omnem perfectionem quam sibi dare potest 
+            <lb ed="#V" n="51"/>effectui omnem perfectionem quam sibi dare potest 
             intensi<lb ed="#V" n="52" break="no"/>ue et extensiue: quia agit secundum conatum virtutis sue. Sed deus non 
             de<lb ed="#V" n="53" break="no"/>dit vniuerso ita cito sicut potuisset dare si voluisset omnem 
             per<lb ed="#V" n="54" break="no"/>fectionem extensiue et intensiue quam sibi dare poterat: ergo non 
@@ -622,14 +622,14 @@
           <p xml:id="kzz7yh-a93632-d1e1143">
             ¶ Item quod non potuerit: videtur 
             <lb ed="#V" n="56"/>quod omnis substantia habens intellectum et voluntate potens producem exteriorem 
-            <lb ed="#V" n="57"/>effanctum: cuius productioni non potest praeuenire voluntas imperfecta: 
-            si<lb ed="#V" n="58" break="no"/>talem effectum potest producem non directa per intellectum: nec deterinata 
+            <lb ed="#V" n="57"/>effectum: cuius productioni non potest praeuenire voluntas imperfecta: 
+            si<lb ed="#V" n="58" break="no"/>talem effectum potest producem non directa per intellectum: nec determinata 
             <lb ed="#V" n="59"/>ad producendum per voluntarem: quia ex imperfectione est quod natura possit 
             <lb ed="#V" n="60"/>exire in actum praeter regitram et imperium poser superioris. Sed deus est . 
             <lb ed="#V" n="61"/>substantia habens intellectum: et voluntatem et est summe perfecta: ergo natura in 
             deo<lb ed="#V" n="62" break="no"/>quamuis non sit inferior intellectu et voluntate eo quod sunt realiter idem 
             <lb ed="#V" n="63"/>non potest exire in aliquem actum exteriorem nisi directe per 
-            intelle<lb ed="#V" n="64" break="no"/>ctum et deterinata per voluntatem: sed sic producem non est 
+            intelle<lb ed="#V" n="64" break="no"/>ctum et determinata per voluntatem: sed sic producem non est 
             producen<lb ed="#V" n="65" break="no"/>necessitate nature: ergo deus non posuit producem vniuersum de necestate 
           </p>
           <p xml:id="kzz7yh-a93632-d1e1167">
@@ -640,22 +640,22 @@
             <cb ed="#P" n="b"/>
             <lb ed="#V" n="69"/>uersis partibus vniuersi realiter sunt differentes in ipsis. In deo autem: 
             <lb ed="#V" n="70"/>sunt sublimiori modo et realiter vnum. vnde Aui. 8. Meta. c. vltimo 
-            <lb ed="#V" n="71"/>dicit quod necesse esse multitudo perfectionis et plurchritudis et 
+            <lb ed="#V" n="71"/>dicit quod necesse esse multitudo perfectionis et pulchritudinis et 
             de<lb ed="#V" n="72" break="no"/>coris: et quod intelligit se in tali vltimo perfectionis et 
             pulchritudi<lb ed="#V" n="73" break="no"/>nis et decoris: et quod vnum sunt certissime. Nam autem inquantum natura 
             non<lb ed="#V" n="74" break="no"/>distinguit inter ea quae sunt realiter vnum: sed intellectus distinguit 
             <lb ed="#V" n="75"/>inter ea eo quod contingit ea quae sunt realiter vnum esse secundum rationem differentia: ergo 
             <lb ed="#V" n="76"/>divinarum perfectionum communicatio cum reali differentia non potuit esse nisi per 
             <lb ed="#V" n="77"/>potentiam directam ab intellectu: sed poso in operando directa per 
-            <lb ed="#V" n="78"/>intellectum deteriatur adoperandum per voluntatem: ergo videtur quod deus snon 
+            <lb ed="#V" n="78"/>intellectum determinatur ad operandum per voluntatem: ergo videtur quod deus non 
             <lb ed="#V" n="79"/>potuit perfectionem suam communicare diuersis partibus vniuersi nisi 
-            <lb ed="#V" n="80"/>per potentiam directam per intellectum ad operandum et deterinatam per 
+            <lb ed="#V" n="80"/>per potentiam directam per intellectum ad operandum et determinatam per 
             vo<lb ed="#V" n="81" break="no"/>luntatem: ergo non potuit producem vniuersum de necessitate nature. 
           </p>
           <p xml:id="kzz7yh-a93632-d1e1209">
             <lb ed="#V" n="82"/>¶ Presmu deus non potuit creare vniuersum nisi propter aliquem 
             fi<lb ed="#V" n="83" break="no"/>nem qui est ipse: sed omne agens propter finem autem agit propter finem praescitum 
-            <lb ed="#V" n="84"/>operi suo ab alio: sicut agut naturalia propter finem: autem a seipso: ergo 
+            <lb ed="#V" n="84"/>operi suo ab alio: sicut agunt naturalia propter finem: autem a seipso: ergo 
             <lb ed="#V" n="85"/>cum finis propter quem deus operatur: non potuerit praestitui operibus 
             <lb ed="#V" n="86"/>ab alio quam a seipso: sequitur quod ipsemet dicitur finem propter quem 
             opera<lb ed="#V" n="87" break="no"/>tur praestituit operibus suis. prestituere autem finem operi est ipsum finem 
@@ -666,7 +666,7 @@
             <lb ed="#V" n="92"/>deus non potuit producere vniuersum de necessitate nature. 
             <lb ed="#V" n="93"/>Ad princitum in opositum dicendum quod quamuis deus sit naturaliter bonus: et de necessitate 
             <lb ed="#V" n="94"/>et vniuersum creauerit propter suam bonitatem: non tamen propter hoc 
-            <lb ed="#V" n="95"/>sequitur quod vniuersum creauerit de necessitate nature: quia hitudo 
+            <lb ed="#V" n="95"/>sequitur quod vniuersum creauerit de necessitate nature: quia habitudo 
             vni<lb ed="#V" n="96" break="no"/>uersi: vt futuri vel existentis non erat naturalis nec necessaria ad suam 
             <lb ed="#V" n="97"/>bonitatem.
           </p>
@@ -678,8 +678,8 @@
             ¶ Ad 
             <lb ed="#V" n="99"/>3m dicendum quod filius carnalis generatur a patre naturaliter pro tanto: quia virtus 
             deci<lb ed="#V" n="100" break="no"/>dens semen et virtus informans non agunt directe per intellectum 
-            <lb ed="#V" n="101"/>patris carnalis: neque deteriantur ad sic operandum per carnalis patris 
-            <lb ed="#V" n="102"/>voluntaem: non tamen generatur filius a patre de necessitate nature: pro tanto quia ex 
+            <lb ed="#V" n="101"/>patris carnalis: neque determinantur ad sic operandum per carnalis patris 
+            <lb ed="#V" n="102"/>voluntatem: non tamen generatur filius a patre de necessitate nature: pro tanto quia ex 
             <lb ed="#V" n="103"/>voluntate patris et matris dependet dare operam tali facto. 
             Uni<lb ed="#V" n="104" break="no"/>uersum autem processit a deo per posum directam per intellectum: et 
             deter<lb ed="#V" n="105" break="no"/>minatam ad producendum per voluntatem: nec aliter produci potuit vt 


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve07v1_kzz7yh-a93632.xml`.

## Applied changes

- p. 136r l. 119: vet → vel: t/l misread
- p. 136v l. 7: 'maio' + 'rem' split across line break without break="no" on lb n=7
- p. 136v l. 8: simlus → simul: transposition of l/u
- p. 136v l. 11: vninersum → vniuersum: n/u misread
- p. 136v l. 37: pecccoribus → peccoribus: triple c reduced to double
- p. 136v l. 43: nullomo → nullo modo: two words run together
- p. 136v l. 54: paertium → partium: ae/a metathesis error
- p. 136v l. 68: 'creatu' + 're' split across line break without break="no" on lb n=68
- p. 136v l. 86: Ecundo → Secundo: initial S dropped
- p. 136v l. 118: contratradictionem → contradictionem: syllable reduplication
- p. 136v l. 121: mindum → mundum: i/u misread
- p. 136v l. 132: nullomon → nullo modo: words run together with extra n
- p. 136v l. 134: potutt → potuit: final tt → it
- p. 137r l. 11: quuao → quo: garbled word
- p. 137r l. 14: erraitioneum → erroneam: garbled OCR
- p. 137r l. 15: mudum → mundum: missing n
- p. 137r l. 25: Iilud → Illud: doubled initial I
- p. 137r l. 51: Uarto → Quarto: U/Qu misread (ordinal numeral, not t/r transposition)
- p. 137r l. 56: exeplar → exemplar: missing m
- p. 137r l. 59: secit → fecit: s/f misread
- p. 137r l. 63: etia → etiam: missing final m
- p. 137r l. 68: veffectum → effectum: spurious initial v
- p. 137r l. 70: mudi → mundi: missing n
- p. 137r l. 71: simliter → similiter: missing i
- p. 137r l. 91: vninersi → vniuersi: n/u misread
- p. 137r l. 93: duoloca → duo loca: words run together
- p. 137r l. 96: episcoi → episcopi: missing p
- p. 137r l. 123: taummodo → tantummodo: garbled
- p. 137v l. 10: reperare → reparare: e/a misread
- p. 137v l. 14: hebant → habebant: missing syllable
- p. 137v l. 16: prinitum → primum, simplicit → simplicis: OCR errors
- p. 137v l. 20: reperandi → reparandi: e/a misread
- p. 137v l. 27: obitcium → obiectum: transposed letters
- p. 137v l. 48: illuinat → illuminat: missing m
- p. 137v l. 51: effctui → effectui: missing e
- p. 137v l. 57: effanctum → effectum: garbled
- p. 137v l. 58: deterinata → determinata: missing m
- p. 137v l. 64: deterinata → determinata: missing m
- p. 137v l. 71: plurchritudis → pulchritudinis: letter transposition and missing syllable
- p. 137v l. 78: deteriatur → determinatur, snon → non: OCR errors
- p. 137v l. 80: deterinatam → determinatam: missing m
- p. 137v l. 84: agut → agunt: missing n
- p. 137v l. 95: hitudo → habitudo: missing ab- prefix (not t/r); hirudo (leech) wrong
- p. 137v l. 101: deteriantur → determinantur: missing m and n
- p. 137v l. 102: voluntaem → voluntatem: missing t

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_