### PR TITLE
Transcription corrections: cod-ve07v1_kzz7yh-a94859.xml (5 changes)

### DIFF
--- a/kzz7yh-a94859/cod-ve07v1_kzz7yh-a94859.xml
+++ b/kzz7yh-a94859/cod-ve07v1_kzz7yh-a94859.xml
@@ -346,11 +346,10 @@
         </p>
         <p xml:id="kzz7yh-a94859-d1e679">
           ¶ 3o 
-          epi<lb ed="#V" n="110" break="no"/>logat ibi. Quandoque in gratia
+          epi<lb ed="#V" n="110" break="no"/>logat ibi. Quandoque igitur
         </p>
         <p xml:id="kzz7yh-a94859-d1e684">
-          ¶ 2o istarum in duas. Quia primo enumerat 
-          si<lb ed="#V" n="111" break="no"/>gna in divinae voluntatis.
+          ¶ 2a istarum in duas. Quia primo enumerat si<lb ed="#V" n="111" break="no"/>gna in divinae voluntatis.
         </p>
         <p xml:id="kzz7yh-a94859-d1e690">
           ¶ 2o de illis exequitur ibi. Ideo aut. 

--- a/kzz7yh-a94859/cod-ve07v1_kzz7yh-a94859.xml
+++ b/kzz7yh-a94859/cod-ve07v1_kzz7yh-a94859.xml
@@ -190,8 +190,7 @@
           <lb ed="#V" n="109"/>dispositio. 
           </p>
           <p xml:id="kzz7yh-a94859-d1e384">
-          <lb ed="#V" n="110"/>¶ Quod secundum signram dicitur voluntas dei preceptio: 
-          prohi<lb ed="#V" n="111" break="no"/>bitio: consilium: permissio: operatio: et ideo 
+          <lb ed="#V" n="110"/>logat ibi. Quandoque igitur ¶ 2a istarum in duas. Quia primo enumerat si<lb ed="#V" n="111" break="no"/>bitio: consilium: permissio: operatio: et ideo 
           plura<lb ed="#V" n="112" break="no"/>liter dicit scriptura voluntates. 
           <!-\-00290.xml-\->
           <pb ed="#V" n="138-v"/>

--- a/kzz7yh-a94859/cod-ve07v1_kzz7yh-a94859.xml
+++ b/kzz7yh-a94859/cod-ve07v1_kzz7yh-a94859.xml
@@ -303,8 +303,8 @@
           <div> l1d45prae 
           <head>Praeambulum</head> -->
         <p xml:id="kzz7yh-a94859-d1e615">
-          <lb ed="#V" n="91"/>IAm de voluntate etc. Superius deteriauit mas 
-          <lb ed="#V" n="92"/>de scientia dei et posms hic deteriat de eius 
+          <lb ed="#V" n="91"/>IAm de voluntate etc. Superius determinauit magister 
+          <lb ed="#V" n="92"/>de scientia dei et potentia hic determinat de eius 
           volun<lb ed="#V" n="93" break="no"/>tate et diditur ista pars in tres.
         </p>
         <p xml:id="kzz7yh-a94859-d1e624">
@@ -316,7 +316,7 @@
           vo<lb ed="#V" n="95" break="no"/>luntas Di. sequenti. ibi. Hic oritur quaestio
         </p>
         <p xml:id="kzz7yh-a94859-d1e634">
-          ¶ 3o deteriat de 
+          ¶ 3o determinat de 
           confor<lb ed="#V" n="96" break="no"/>mitate nostre voluntatis ad eam. Di. 48 ibi sciendum quoque est 
           primo<lb ed="#V" n="97" break="no"/>in 3 primo ostendit quod divina voluntas est ipsa divina essentia. 2o quod est omnium 
           <lb ed="#V" n="98"/>causa ibi. Hoc itaque. Tertio quod est multipliciter dicta: ibi. Hic non 
@@ -346,10 +346,10 @@
         </p>
         <p xml:id="kzz7yh-a94859-d1e679">
           ¶ 3o 
-          epi<lb ed="#V" n="110" break="no"/>logat ibi. Quandoque igratia
+          epi<lb ed="#V" n="110" break="no"/>logat ibi. Quandoque in gratia
         </p>
         <p xml:id="kzz7yh-a94859-d1e684">
-          ¶ 2o istarum in duas. Quia primo enuerat 
+          ¶ 2o istarum in duas. Quia primo enumerat 
           si<lb ed="#V" n="111" break="no"/>gna in divinae voluntatis.
         </p>
         <p xml:id="kzz7yh-a94859-d1e690">

--- a/kzz7yh-a94859/cod-ve07v1_kzz7yh-a94859.xml
+++ b/kzz7yh-a94859/cod-ve07v1_kzz7yh-a94859.xml
@@ -312,13 +312,13 @@
           di<lb ed="#V" n="94" break="no"/>na voluntas
         </p>
         <p xml:id="kzz7yh-a94859-d1e629">
-          ¶ Secundo inquirit vtrum seper impleatur dina 
+          ¶ Secundo inquirit vtrum semper impleatur divina 
           vo<lb ed="#V" n="95" break="no"/>luntas Di. sequenti. ibi. Hic oritur quaestio
         </p>
         <p xml:id="kzz7yh-a94859-d1e634">
           ¶ 3o deteriat de 
           confor<lb ed="#V" n="96" break="no"/>mitate nostre voluntatis ad eam. Di. 48 ibi sciendum quoque est 
-          primo<lb ed="#V" n="97" break="no"/>in 3 primostendit quod divina voluntas est ipsa divina essentia. 2o quod est omnium 
+          primo<lb ed="#V" n="97" break="no"/>in 3 primo ostendit quod divina voluntas est ipsa divina essentia. 2o quod est omnium 
           <lb ed="#V" n="98"/>causa ibi. Hoc itaque. Tertio quod est multipliciter dicta: ibi. Hic non 
           <lb ed="#V" n="99"/>est praetermitendum.
         </p>
@@ -327,8 +327,8 @@
           <lb ed="#V" n="100"/>est diuina essentia.
         </p>
         <p xml:id="kzz7yh-a94859-d1e651">
-          ¶ 2o super hoc mouet dubitatoem et soluit: ibi. 
-          <lb ed="#V" n="101"/>Et licet: et ista in duas. primo mouet dubitationem. 2o subiciungit 
+          ¶ 2o super hoc mouet dubitationem et soluit: ibi. 
+          <lb ed="#V" n="101"/>Et licet: et ista in duas. primo mouet dubitationem. 2o subiungit 
           solutio<lb ed="#V" n="102" break="no"/>nem ibi. Ad quod dicimus. Tunc sequitur illa pars quae ibi incipit. hoc 
           <lb ed="#V" n="103"/>itaque: in quae ostendit quod voluntas divina est omnium bonorum creatorum 
           <lb ed="#V" n="104"/>causa: et diditur in duas. primo ostendit quod est omnium bonorum causa prima. 2o quia est 
@@ -354,7 +354,7 @@
         </p>
         <p xml:id="kzz7yh-a94859-d1e690">
           ¶ 2o de illis exequitur ibi. Ideo aut. 
-          <lb ed="#V" n="112"/>Circa hanc distinctionem quaeredum est principaliter de 
+          <lb ed="#V" n="112"/>Circa hanc distinctionem quaerendum est principaliter de 
           <lb ed="#V" n="113"/>tribus primo de volutate dei in generali. 2 de 
           <lb ed="#V" n="114"/>voluntate dei sub rone quae est causa. 3o de signis divinae 
           vo<lb ed="#V" n="115" break="no"/>luntatis. 


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve07v1_kzz7yh-a94859.xml`.

## Applied changes

- p. 138v l. 94: seper → semper, dina → divina: OCR errors
- p. 138v l. 97: primostendit → primo ostendit: words run together
- p. 138v l. 100: dubitatoem → dubitationem: missing letters
- p. 138v l. 101: subiciungit → subiungit: extra syllable
- p. 138v l. 112: quaeredum → quaerendum: missing n

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_