### PR TITLE
Transcription corrections: cod-ve07v1_kzz7yh-a96144.xml (27 changes)

### DIFF
--- a/kzz7yh-a96144/cod-ve07v1_kzz7yh-a96144.xml
+++ b/kzz7yh-a96144/cod-ve07v1_kzz7yh-a96144.xml
@@ -80,13 +80,13 @@
             <lb ed="#V" n="103"/>Rimo ostendo quod voluntas dei non est 
             omniumbo<lb ed="#V" n="104" break="no"/>norum creatorum primo causa: quia ad causalitatem 
             <lb ed="#V" n="105"/>bonorum creatorum concurrunt scientia: poso et voluntas: sed vel 
-            <lb ed="#V" n="106"/>le secundum rationem intelligendi pesupponit scire: ergo scientia magt debet 
+            <lb ed="#V" n="106"/>le secundum rationem intelligendi praesupponit scire: ergo scientia magis debet 
             di<lb ed="#V" n="107" break="no"/>ci bonorum creatorum primo causa quam voluntas.
           </p>
           <p xml:id="kzz7yh-a96144-d1e145">
             ¶ Item deus non producit 
             <lb ed="#V" n="108"/>bona creata nisi operando: sed operatio non est actus nisi poses: 
-            <lb ed="#V" n="109"/>ergo videtur quod voluntas non sit causa rerum nec primanec 2o
+            <lb ed="#V" n="109"/>ergo videtur quod voluntas non sit causa rerum nec prima nec 2o
           </p>
           <p xml:id="kzz7yh-a96144-d1e152">
             ¶ Item causa 
@@ -94,10 +94,10 @@
             <lb ed="#V" n="111"/>magistum in praesenti di. c. 2. ergo voluntas dei non est bonorum creatorum causa. 
           </p>
           <p xml:id="kzz7yh-a96144-d1e159">
-            <lb ed="#V" n="112"/>Contra. Augu. 3. de tri. c. 4. Uoluntas dei est pima: et summa 
+            <lb ed="#V" n="112"/>Contra. Augu. 3. de tri. c. 4. Uoluntas dei est prima: et summa 
             <lb ed="#V" n="113"/>casa omnium corporalium specierum atque motionum. Nihil 
-            <lb ed="#V" n="114"/>enm sit visibiliter atque intelligibliter quod non de interiori 
-            inuisibili<lb ed="#V" n="115" break="no"/>atque intelligibili aula summi imparatoris aut iubeatur: aut permit. 
+            <lb ed="#V" n="114"/>enim sit visibiliter atque intelligibiliter quod non de interiori 
+            inuisibili<lb ed="#V" n="115" break="no"/>atque intelligibili aula summi imperatoris aut iubeatur: aut permit. 
             <lb ed="#V" n="116"/>tatur.
           </p>
           <p xml:id="kzz7yh-a96144-d1e173">
@@ -106,33 +106,33 @@
             <lb ed="#V" n="118"/>rerum: ergo cum ipse sit omnium bonorum creatorum prima causa 
             sequi<lb ed="#V" n="119" break="no"/>tur quod eius voluntas est omnium bonorum creatorum prima causa. 
             <lb ed="#V" n="120"/>Rndeo quod deus est omnium bonorum creatorum caus prim per suam 
-            <lb ed="#V" n="121"/>sapientiam dirigentem et voluntatem imperantem: et poitesm 
-            <lb ed="#V" n="122"/>exequaentem: quia sicut dicit Hug. i. li.o de sac. per. 2. c. 6. Cum sint 3m 
+            <lb ed="#V" n="121"/>sapientiam dirigentem et voluntatem imperantem: et potestatem 
+            <lb ed="#V" n="122"/>exequentem: quia sicut dicit Hug. i. li.o de sac. per. 2. c. 6. Cum sint 3m 
             <lb ed="#V" n="123"/>in deo sapientia voluntas posios. Primordiales causae a voluntate quidem 
             <lb ed="#V" n="124"/>divina quasi proficiscuntur: per sapientiam diriguntur: per positiom producuntur. 
             Uo<lb ed="#V" n="125" break="no"/>luntas enim mouet: sapientia disponit: potestas explicat. Hec sunt 
-            <lb ed="#V" n="126"/>eterna fundamta cauarum omnium et principium principium: quia tamen scientia et pos se 
+            <lb ed="#V" n="126"/>eterna fundamenta cauarum omnium et principium principium: quia tamen scientia et pos se 
             <lb ed="#V" n="127"/>habent indeterminate ad multa: et voluntas est quae determinat potest 
-            <lb ed="#V" n="128"/>ad exequaendum determinate hoc vel illud. Idon actualis productio 
-            crea<lb ed="#V" n="129" break="no"/>ture magit attribuitur voluntati sicut causae quam scientie vel poses. Et 
+            <lb ed="#V" n="128"/>ad exequendum determinate hoc vel illud. Ideo actualis productio 
+            crea<lb ed="#V" n="129" break="no"/>ture magis attribuitur voluntati sicut causae quam scientie vel poses. Et 
             <lb ed="#V" n="130"/>sic concedendum est quod dei voluntas est primo causa bonorum omnium creatorum 
-            <lb ed="#V" n="131"/>Ad pricitum in oppositum dicendum quod quamuis scientia prior sit secundum nastram rationem 
+            <lb ed="#V" n="131"/>Ad primum in oppositum dicendum quod quamuis scientia prior sit secundum nostram rationem 
             <lb ed="#V" n="132"/>intelligendi quam volutas: tamen quia deterinatio postrad 
-            operan<lb ed="#V" n="133" break="no"/>dum non sic est per scientiam: sicut per voluntantem: ideo magis 
+            operan<lb ed="#V" n="133" break="no"/>dum non sic est per scientiam: sicut per voluntatem: ideo magis 
             attri<lb ed="#V" n="134" break="no"/>buimus voluntati rationem causalitatem quam scientie
           </p>
           <p xml:id="kzz7yh-a96144-d1e215">
             ¶ Ad 2m dicendum 
-            <lb ed="#V" n="135"/>quod quia pos non ponit effctum nisi inquantum deteriatur ad operandum per 
-            <lb ed="#V" n="136"/>voluntatem: ideo magit et per prim ratiom causalitati attribuimus voluntati¬ 
+            <lb ed="#V" n="135"/>quod quia pos non ponit effectum nisi inquantum determinatur ad operandum per 
+            <lb ed="#V" n="136"/>voluntatem: ideo magis et per primam rationem causalitati attribuimus voluntati 
             <!--00293.xml-->
             <pb ed="#V" n="140-r"/>
             <cb ed="#P" n="a"/>
             <lb ed="#V" n="1"/>quam potentie
           </p>
           <p xml:id="kzz7yh-a96144-d1e231">
-            ¶ Ad 3m cum dicitur quod causa relatiue se habet ad causa 
-            <lb ed="#V" n="2"/>tum: dico quod verum est secundum esse: vel secundum dici: quamuis autem 
+            ¶ Ad 3m cum dicitur quod relatiue se habet ad causa 
+            causa<lb ed="#V" n="2" break="no"/>tum: dico quod verum est secundum esse: vel secundum dici: quamuis autem 
             volun<lb ed="#V" n="3" break="no"/>tatis diuine non sit aliqua relatio realis ad suos effectus 
             <lb ed="#V" n="4"/>sed ecsnous. Est tamen in ea sub ratione qua est causa relatio secundum ratio 
             <lb ed="#V" n="5"/>nem vel secundum dici ad suos effectus. Quod ergo in praesenti Di. 
@@ -227,13 +227,13 @@
             eli<lb ed="#V" n="63" break="no"/>ciente: et immediate a deo non sicut eliciente: sed sicut per 
             vo<lb ed="#V" n="64" break="no"/>luntatem imperante sine cuius imperio causa secunda non 
             <lb ed="#V" n="65"/>posset suum effectum producere. 
-            <lb ed="#V" n="66"/>Alis non vildetur inte modus ponedi suticies 
+            <lb ed="#V" n="66"/>Alis non videtur iste modus ponendi sufficiens 
             <lb ed="#V" n="67"/>quod voluntas per suum imperium nihil producit 
-            <lb ed="#V" n="68"/>extra voluntatem nisi per aliquam pos mimperium exequaentem. Si ergo deus tantum 
+            <lb ed="#V" n="68"/>extra voluntatem nisi per aliquam pos imperium exequaentem. Si ergo deus tantum 
             <!--00293.xml-->
             <cb ed="#P" n="b"/>
             <lb ed="#V" n="69"/>imperaret operationem cause nihil cooperando per aliquam potentiam 
-            <lb ed="#V" n="70"/>imperium exequaentem: tunc causa secunda supposmuo quod conseruetur in esse non pluls 
+            <lb ed="#V" n="70"/>imperium exequentem: tunc causa secunda supposito quod conseruetur in esse non plus 
             <lb ed="#V" n="71"/>posset effectu suum producem per imperiu volutatis divinae quam sine eius 
             <lb ed="#V" n="72"/>imperio: quod suum est.
           </p>
@@ -252,7 +252,7 @@
             <lb ed="#V" n="81"/>quia quamuis hanc rem intellectum possit intelligem sub ratione 
             <lb ed="#V" n="82"/>entis non intelligendo eam sub ratione huius entis: eo quod secundum rationem 
             <lb ed="#V" n="83"/>differnt tamen pomso exequaens quaecumque sit illa non potest discernem vnum ab 
-            <lb ed="#V" n="84"/>alio. deus enim nen posset creare ens nisi creando hoc ens: nec econcluso: 
+            <lb ed="#V" n="84"/>alio. deus enim non posset creare ens nisi creando hoc ens: nec econverso: 
             <lb ed="#V" n="85"/>et ideo dicunt se non bene intelligem quomodo hec res sit immediate a deo 
             <lb ed="#V" n="86"/>inquantum ens: et non inquantum hoc ens: nec quomodo sit a causa 2o imquantum hoc 
             <lb ed="#V" n="87"/>ens: et non imquantum ens. Idon videtur istis dicendum quod effectus causae 
@@ -269,8 +269,8 @@
             <lb ed="#V" n="98"/>actio cause prime et cause secunde.
           </p>
           <p xml:id="kzz7yh-a96144-d1e487">
-            <lb ed="#V" n="99"/>Ad pricitum in opositum cum dicitur quod causa quanto est prior tanto mediatior etc. 
-            <lb ed="#V" n="100"/>dico quod verum est: sed non opetet semper quod illa mediatio excldat 
+            <lb ed="#V" n="99"/>Ad primum in oppositum cum dicitur quod causa quanto est prior tanto mediatior etc. 
+            <lb ed="#V" n="100"/>dico quod verum est: sed non oportet semper quod illa mediatio excludat 
             <lb ed="#V" n="101"/>immediationem: vt in quaestine visum est.
           </p>
           <p xml:id="kzz7yh-a96144-d1e496">
@@ -353,7 +353,7 @@
           </p>
           <p xml:id="kzz7yh-a96144-d1e634">
             ¶ Item habitudo 
-            scito<lb ed="#V" n="12" break="no"/>rum ad dei scientiam est necessaria: ergo a simili hitudo volitorum 
+            scito<lb ed="#V" n="12" break="no"/>rum ad dei scientiam est necessaria: ergo a simili habitudo volitorum 
             <lb ed="#V" n="13"/>ad dei velle est necessaria: cum ergo bona creata sint a 
             deo<lb ed="#V" n="14" break="no"/>volita: videtur quod deus per voluntate de necessitate causa est 
             <lb ed="#V" n="15"/>bonorum creatorum.
@@ -381,7 +381,7 @@
           <p xml:id="kzz7yh-a96144-d1e679">
             ¶ Item si voluntas esset causa necessaria rerum: 
             seque<lb ed="#V" n="28" break="no"/>retur quod deus de necessitate produxit res creatas quod falsum 
-            <lb ed="#V" n="29"/>est. vnde reuerendus pater episcotus Parisiensis dominus Stephanus 
+            <lb ed="#V" n="29"/>est. vnde reuerendus pater episcopus Parisiensis dominus Stephanus 
             <lb ed="#V" n="30"/>excommunicauit istum articulum quod deum necesse est facere quod 
             <lb ed="#V" n="31"/>quid immediate sit ab eo: et dicit quod est error siue intelligatur de 
             <lb ed="#V" n="32"/>necessitate coactionis: quia tollit libertatem arbitrii: siue de 
@@ -405,7 +405,7 @@
             pro<lb ed="#V" n="46" break="no"/>ductionis bonorum creatorum ad ipsum velle divinum est 
             contin<lb ed="#V" n="47" break="no"/>gens: quamuis enim deus de necessitate velit suam bonitatem. et 
             vo<lb ed="#V" n="48" break="no"/>lendo eam vult alia quecumque vult: tamen quia alia non habent 
-            essen<lb ed="#V" n="49" break="no"/>tialiter ordinationem ad suam bonitatem: ideo non opetet 
+            essen<lb ed="#V" n="49" break="no"/>tialiter ordinationem ad suam bonitatem: ideo non oportet 
             vi<lb ed="#V" n="50" break="no"/>dendo suam bonitatem velit alia.
           </p>
           <p xml:id="kzz7yh-a96144-d1e737">
@@ -457,7 +457,7 @@
             <lb ed="#V" n="85"/>filius non possunt non velle perfectionem bonitatis sue: ita non 
             <lb ed="#V" n="86"/>possunt non velle emanationem spiritus sancti: sed 
             emanatio<lb ed="#V" n="87" break="no"/>creaturarum non compehenditur infra perfectionem divinae boni 
-            <lb ed="#V" n="88"/>tatis: nec ad deum habet essentialiter hitudinem: et ideo deus 
+            <lb ed="#V" n="88"/>tatis: nec ad deum habet essentialiter habitudinem: et ideo deus 
             <lb ed="#V" n="89"/>potuit non velle emanationem creature.
           </p>
           <p xml:id="kzz7yh-a96144-d1e838">
@@ -470,8 +470,8 @@
             <lb ed="#V" n="95"/>ideas suorum oppositorum: et ideo deus non potest non scire 
             <lb ed="#V" n="96"/>omnia scibilia: deus autem volendo suam bonitatem vult 
             crea<lb ed="#V" n="97" break="no"/>turas omnes inquantum est ab eis imitabilis quasdam inquantum 
-            <lb ed="#V" n="98"/>est ab eis imitata vel imitanda: quamuis autem habitudo creatu 
-            <lb ed="#V" n="99"/>re ad divinam bonitatem inquantum est ab ea imitabilis sit 
+            <lb ed="#V" n="98"/>est ab eis imitata vel imitanda: quamuis autem habitudo 
+            creatu<lb ed="#V" n="99" break="no"/>re ad divinam bonitatem inquantum est ab ea imitabilis sit 
             ne<lb ed="#V" n="100" break="no"/>cessaria: non tamen inquantum est ab ea imitanda.
           </p>
           <p xml:id="kzz7yh-a96144-d1e864">
@@ -513,7 +513,7 @@
             <lb ed="#V" n="123"/>causa querenda. 
           </p>
           <p xml:id="kzz7yh-a96144-d1e933">
-            <lb ed="#V" n="124"/>Respondeo quod ipsitus dini velle nulla est ratio 
+            <lb ed="#V" n="124"/>Respondeo quod ipsius divini velle nulla est ratio 
             mo<lb ed="#V" n="125" break="no"/>tiua cum ipsum divinum velle rea 
             <lb ed="#V" n="126"/>liter idem sit quod deus: tamen ordinationis que est inter divinum 
             <lb ed="#V" n="127"/>velle et ipsum volitum: bene est ratio aliqua respectu 

--- a/kzz7yh-a96144/cod-ve07v1_kzz7yh-a96144.xml
+++ b/kzz7yh-a96144/cod-ve07v1_kzz7yh-a96144.xml
@@ -134,7 +134,7 @@
             ¶ Ad 3m cum dicitur quod relatiue se habet ad causa 
             causa<lb ed="#V" n="2" break="no"/>tum: dico quod verum est secundum esse: vel secundum dici: quamuis autem 
             volun<lb ed="#V" n="3" break="no"/>tatis diuine non sit aliqua relatio realis ad suos effectus 
-            <lb ed="#V" n="4"/>sed ecsnous. Est tamen in ea sub ne qua est causa relatio secundum ratio 
+            <lb ed="#V" n="4"/>sed ecsnous. Est tamen in ea sub ratione qua est causa relatio secundum
             ratio<lb ed="#V" n="5" break="no"/>nem vel secundum dici ad suos effectus. Quod ergo in praesenti Di. 
             ne<lb ed="#V" n="6" break="no"/>gatur voluntatem relatiue dici intelligendum est de relatione secundum 
             <lb ed="#V" n="7"/>rem: quia realiter non refertur: nec ad intrinsecum: nec ad 

--- a/kzz7yh-a96144/cod-ve07v1_kzz7yh-a96144.xml
+++ b/kzz7yh-a96144/cod-ve07v1_kzz7yh-a96144.xml
@@ -85,13 +85,13 @@
           </p>
           <p xml:id="kzz7yh-a96144-d1e145">
             ¶ Item deus non producit 
-            <lb ed="#V" n="108"/>bona creata nisi operando: sed operatio non est actus nisi poses: 
+            <lb ed="#V" n="108"/>bona creata nisi operando: sed operatio non est actus nisi potentiae: 
             <lb ed="#V" n="109"/>ergo videtur quod voluntas non sit causa rerum nec prima nec 2o
           </p>
           <p xml:id="kzz7yh-a96144-d1e152">
             ¶ Item causa 
             re<lb ed="#V" n="110" break="no"/>latiue se habet ad causatum: sed voluntas dei relatiue numquam dicitur secundum 
-            <lb ed="#V" n="111"/>magistum in praesenti di. c. 2. ergo voluntas dei non est bonorum creatorum causa. 
+            <lb ed="#V" n="111"/>magistrum in praesenti di. c. 2. ergo voluntas dei non est bonorum creatorum causa. 
           </p>
           <p xml:id="kzz7yh-a96144-d1e159">
             <lb ed="#V" n="112"/>Contra. Augu. 3. de tri. c. 4. Uoluntas dei est prima: et summa 
@@ -105,11 +105,11 @@
             <lb ed="#V" n="117"/>dicitur illo volente dicitur: in quo sati exprimit quod per suam voluntatem est causa 
             <lb ed="#V" n="118"/>rerum: ergo cum ipse sit omnium bonorum creatorum prima causa 
             sequi<lb ed="#V" n="119" break="no"/>tur quod eius voluntas est omnium bonorum creatorum prima causa. 
-            <lb ed="#V" n="120"/>Rndeo quod deus est omnium bonorum creatorum caus prim per suam 
+            <lb ed="#V" n="120"/>Respondeo quod deus est omnium bonorum creatorum causa prima per suam 
             <lb ed="#V" n="121"/>sapientiam dirigentem et voluntatem imperantem: et potestatem 
             <lb ed="#V" n="122"/>exequentem: quia sicut dicit Hug. i. li.o de sac. per. 2. c. 6. Cum sint 3m 
             <lb ed="#V" n="123"/>in deo sapientia voluntas posios. Primordiales causae a voluntate quidem 
-            <lb ed="#V" n="124"/>divina quasi proficiscuntur: per sapientiam diriguntur: per positiom producuntur. 
+            <lb ed="#V" n="124"/>divina quasi proficiscuntur: per sapientiam diriguntur: per potentiam producuntur. 
             Uo<lb ed="#V" n="125" break="no"/>luntas enim mouet: sapientia disponit: potestas explicat. Hec sunt 
             <lb ed="#V" n="126"/>eterna fundamenta cauarum omnium et principium principium: quia tamen scientia et pos se 
             <lb ed="#V" n="127"/>habent indeterminate ad multa: et voluntas est quae determinat potest 
@@ -117,7 +117,7 @@
             crea<lb ed="#V" n="129" break="no"/>ture magis attribuitur voluntati sicut causae quam scientie vel poses. Et 
             <lb ed="#V" n="130"/>sic concedendum est quod dei voluntas est primo causa bonorum omnium creatorum 
             <lb ed="#V" n="131"/>Ad primum in oppositum dicendum quod quamuis scientia prior sit secundum nostram rationem 
-            <lb ed="#V" n="132"/>intelligendi quam volutas: tamen quia deterinatio postrad 
+            <lb ed="#V" n="132"/>intelligendi quam voluntas: tamen quia determinatio potentiae 
             operan<lb ed="#V" n="133" break="no"/>dum non sic est per scientiam: sicut per voluntatem: ideo magis 
             attri<lb ed="#V" n="134" break="no"/>buimus voluntati rationem causalitatem quam scientie
           </p>
@@ -134,8 +134,8 @@
             ¶ Ad 3m cum dicitur quod relatiue se habet ad causa 
             causa<lb ed="#V" n="2" break="no"/>tum: dico quod verum est secundum esse: vel secundum dici: quamuis autem 
             volun<lb ed="#V" n="3" break="no"/>tatis diuine non sit aliqua relatio realis ad suos effectus 
-            <lb ed="#V" n="4"/>sed ecsnous. Est tamen in ea sub ratione qua est causa relatio secundum ratio 
-            <lb ed="#V" n="5"/>nem vel secundum dici ad suos effectus. Quod ergo in praesenti Di. 
+            <lb ed="#V" n="4"/>sed ecsnous. Est tamen in ea sub ne qua est causa relatio secundum ratio 
+            ratio<lb ed="#V" n="5" break="no"/>nem vel secundum dici ad suos effectus. Quod ergo in praesenti Di. 
             ne<lb ed="#V" n="6" break="no"/>gatur voluntatem relatiue dici intelligendum est de relatione secundum 
             <lb ed="#V" n="7"/>rem: quia realiter non refertur: nec ad intrinsecum: nec ad 
             extrin<lb ed="#V" n="8" break="no"/>secum.
@@ -181,7 +181,7 @@
             <lb ed="#V" n="31"/>suarum. Multi multa sciunt et seipsos nesciunt: alios 
             inspi<lb ed="#V" n="32" break="no"/>ciunt: et seipsos deserunt: deum querunt per ista exteriora de 
             <lb ed="#V" n="33"/>serentes sua interiora: quibus intimior est deus. Si ergo deus 
-            <lb ed="#V" n="34"/>est intimior cause scecunde quam ipsa sibi: non est ratio 
+            <lb ed="#V" n="34"/>est intimior cause <sic>scecunde</sic> quam ipsa sibi: non est ratio 
             qua<lb ed="#V" n="35" break="no"/>re effectus egrediens a causa secunda immediate 
             egredere<lb ed="#V" n="36" break="no"/>tur ab ea: et non a causa prima.
           </p>
@@ -201,7 +201,7 @@
             vehemen<lb ed="#V" n="45" break="no"/>tioris adherentie cum re quam causa propinqua: sed hoc esse non 
             <lb ed="#V" n="46"/>posset nisi causa primo cum hoc quod est prima esset rei propinquor 
             <lb ed="#V" n="47"/>quam alia causa: ergo videtur quod effectus egrediens immediate a 
-            <lb ed="#V" n="48"/>causa secunda immediatius egreditut a causa prima. 
+            <lb ed="#V" n="48"/>causa secunda immediatius <sic>egreditut</sic> a causa prima. 
           </p>
           <p xml:id="kzz7yh-a96144-d1e360">
             <lb ed="#V" n="49"/>Respondeo quod voluntas dei est bonorum 
@@ -210,7 +210,7 @@
             mediam<lb ed="#V" n="52" break="no"/>te causa secunda: sic intelligendo quod non producit ea mediante 
             ali<lb ed="#V" n="53" break="no"/>quo differente a se: quamuis enim voluntas imperet eorum productionem 
             <lb ed="#V" n="54"/>et potentia exequatur: tamen quia realiter idem sunt in deo potentia 
-            <lb ed="#V" n="55"/>et voluntas: poso deterinata est ad operandum per voluntatem: ideo 
+            <lb ed="#V" n="55"/>et voluntas: potentia determinata est ad operandum per voluntatem: ideo 
             ef<lb ed="#V" n="56" break="no"/>fectus: qui eliciuntur a dei potentia immediate tantum: dicuntur est esse a 
             vo<lb ed="#V" n="57" break="no"/>luntate divina immediate tantum: quamuis in rei veritate sint a divina 
             <lb ed="#V" n="58"/>voluntate imperante et a dei potentiaeliciente.
@@ -251,7 +251,7 @@
             <lb ed="#V" n="80"/>Alii autem hunc modum ponendi non satis clarum reputant 
             <lb ed="#V" n="81"/>quia quamuis hanc rem intellectum possit intelligem sub ratione 
             <lb ed="#V" n="82"/>entis non intelligendo eam sub ratione huius entis: eo quod secundum rationem 
-            <lb ed="#V" n="83"/>differnt tamen pomso exequaens quaecumque sit illa non potest discernem vnum ab 
+            <lb ed="#V" n="83"/>differunt tamen potentia exequens quaecumque sit illa non potest discernere vnum ab 
             <lb ed="#V" n="84"/>alio. deus enim non posset creare ens nisi creando hoc ens: nec econverso: 
             <lb ed="#V" n="85"/>et ideo dicunt se non bene intelligem quomodo hec res sit immediate a deo 
             <lb ed="#V" n="86"/>inquantum ens: et non inquantum hoc ens: nec quomodo sit a causa 2o imquantum hoc 
@@ -260,7 +260,7 @@
             to<lb ed="#V" n="89" break="no"/>tum: sed modo alio et alio: quia a causa primo elicitur per modum superiorem. et 
             <lb ed="#V" n="90"/>a causa 2o per modum inferiorem: cui sententie videtur concordare Commen. super 
             <lb ed="#V" n="91"/>primam propositionem de causis dicens. Causa primo adiuuat causam secundam super 
-            <lb ed="#V" n="92"/>operationem suam: quia omnem oponem quam 2s efficit et causa primo efficit. verum 
+            <lb ed="#V" n="92"/>operationem suam: quia omnem operationem quam 2a efficit et causa primo efficit. verum 
             <lb ed="#V" n="93"/>tamen efficit eam per modum altiorem et sublimiorem. Dicunt ergo quod quamuis 
             <lb ed="#V" n="94"/>sit impossibile eundem effectum secundum se totum esse immediate ab vna causa: et 
             <lb ed="#V" n="95"/>cum hoc ipsum secundum se totum cansa immediate ab alia causa loquendo de 
@@ -289,7 +289,7 @@
             <lb ed="#V" n="109"/>intellectus et voluntas: nec in aliqua intellectu a substantia quod ens non 
             <lb ed="#V" n="110"/>potest esse obictum nature intellectualis: nisi subn. duplici habitudinem scilicet 
             <lb ed="#V" n="111"/>inquantum nata est se illi materifestare: et imquantum nata est illam allicem 
-            <lb ed="#V" n="112"/>sed sub primo hitudine non est obiectum nisi intellectus. In 2o non est 
+            <lb ed="#V" n="112"/>sed sub prima habitudine non est obiectum nisi intellectus. In 2o non est 
             <lb ed="#V" n="113"/>obiectum nisi voluntatis. Unde deus volendo rem fieri facit ipsam non 
             <lb ed="#V" n="114"/>mediante aliqua pomo executiua.
           </p>
@@ -298,21 +298,21 @@
             trans<lb ed="#V" n="115" break="no"/>mutet illud quod attingit non indiget pos aliqua exequente. Unde 
             <lb ed="#V" n="116"/>videmus quod voluntas in nobis tramsmutat sensibilitatem. 
             <lb ed="#V" n="117"/>Sed contra hanc opionem est expresse auctoritas Hug. allegata 
-            <lb ed="#V" n="118"/>in soslbitle peraecedentis quaestionis: et est magister qui alium tractatum 
+            <lb ed="#V" n="118"/>in solutione praecedentis quaestionis: et est magister qui alium tractatum 
             <lb ed="#V" n="119"/>facit de voluntate: et alium de posio.
           </p>
           <p xml:id="kzz7yh-a96144-d1e546">
-            ¶ Preus contra illud quod dicunt 
+            ¶ Praeterea contra illud quod dicunt 
             <lb ed="#V" n="120"/>in nulla substantia intellectuali esse aliam potentiam ab intellectu et 
             <lb ed="#V" n="121"/>voluntate est excommunicatio huius articuli quod intelligentia sola 
             volun<lb ed="#V" n="122" break="no"/>tate mouet celum. Nullus enim hoc dices ab hoc intendebat ex 
             <lb ed="#V" n="123"/>cludere intellectum: nec divinam virtutem.
           </p>
           <p xml:id="kzz7yh-a96144-d1e557">
-            ¶ Prems volibile et 
+            ¶ Praeterea volibile et 
             <lb ed="#V" n="124"/>operabile secundum rationem differunt: ergo voluntas et pomo exequens eius 
             <lb ed="#V" n="125"/>imperium in deo differunt secundum rationem: et in substantia intellectuali 
-            crea<lb ed="#V" n="126" break="no"/>ta differnt eo modo quo postio distinguuntur in eis: nec cogunt rationes 
+            crea<lb ed="#V" n="126" break="no"/>ta differunt eo modo quo potentiae distinguuntur in eis: nec cogunt rationes 
             <lb ed="#V" n="127"/>pro alia opinione. Maior enim prime rationis falsa est. Ens enim 
             <lb ed="#V" n="128"/>potest esse obicium nature intellectualius sub ratione quae operabile ab ea 
             opera<lb ed="#V" n="129" break="no"/>tione: altiori et secretiori improportionaliter quam sit operatio 
@@ -320,7 +320,7 @@
           </p>
           <p xml:id="kzz7yh-a96144-d1e575">
             ¶ Secunda est ratio non cogit quia quamuis voluntas 
-            imperan<lb ed="#V" n="131" break="no"/>do aliquam immutationem faciat in voluntate in poso executiua 
+            imperan<lb ed="#V" n="131" break="no"/>do aliquam immutationem faciat in voluntate in potentia executiua 
             si<lb ed="#V" n="132" break="no"/>bi correspondente: tamen nostra voluntas nostram sensualitatem. 
             trans<lb ed="#V" n="133" break="no"/>mutat mediante potentia exequente.
           </p>
@@ -369,7 +369,7 @@
           <p xml:id="kzz7yh-a96144-d1e659">
             <lb ed="#V" n="21"/>Contra. Ansel. lib. 2. cur. deus homo. ca. 17. loquens 
             <lb ed="#V" n="22"/>de deo dicit quod ipsum aut velle aut nolle: 
-            ali<lb ed="#V" n="23" break="no"/>quid propter necessitatem aute impossibilitatem alienum 
+            ali<lb ed="#V" n="23" break="no"/>quid propter necessitatem aut impossibilitatem alienum 
             <lb ed="#V" n="24"/>est a veritate.
           </p>
           <p xml:id="kzz7yh-a96144-d1e670">


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve07v1_kzz7yh-a96144.xml`.

## Applied changes

- p. 139v l. 106: pesupponit → praesupponit, magt → magis: OCR errors
- p. 139v l. 109: primanec → prima nec: space missing
- p. 139v l. 112: pima → prima: missing r
- p. 139v l. 114: enm → enim, intelligibliter → intelligibiliter: OCR errors
- p. 139v l. 115: imparatoris → imperatoris: a/e misread
- p. 139v l. 121: poitesm → potestatem: garbled abbreviation
- p. 139v l. 122: exequaentem → exequentem: ae spurious insertion
- p. 139v l. 126: fundamta → fundamenta: missing letters
- p. 139v l. 128: exequaendum → exequendum, Idon → Ideo: OCR errors
- p. 139v l. 129: magit → magis: t/s misread
- p. 139v l. 131: pricitum → primum, nastram → nostram: OCR errors
- p. 139v l. 133: voluntantem → voluntatem: extra n
- p. 139v l. 135: effctum → effectum, deteriatur → determinatur: OCR errors
- p. 139v l. 136: magit → magis, prim → primam, ratiom → rationem: OCR errors
- p. 140r l. 2: 'causa' + 'tum' split across line break without break="no" on lb n=2
- p. 140r l. 66: vildetur → videtur, inte → iste, ponedi → ponendi, suticies → sufficiens: OCR errors
- p. 140r l. 68: mimperium → imperium: extra mi prefix
- p. 140r l. 70: exequaentem → exequentem, supposmuo → supposito, pluls → plus: OCR errors
- p. 140r l. 84: nen → non, econcluso → econverso: OCR errors
- p. 140r l. 99: pricitum → primum: garbled
- p. 140r l. 100: opetet → oportet (not operet), excldat → excludat: OCR errors
- p. 140v l. 12: hitudo → habitudo: missing ab (not t/r)
- p. 140v l. 29: episcotus → episcopus: t/p misread
- p. 140v l. 49: opetet → oportet: missing r (not operet)
- p. 140v l. 88: hitudinem → habitudinem: missing ab (not t/r)
- p. 140v l. 99: 'creatu' + 're' split across line break without break="no" on lb n=99
- p. 140v l. 124: ipsitus → ipsius, dini → divini: OCR errors

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_