### PR TITLE
Transcription corrections: cod-ve07v1_kzz7yh-a98373.xml (21 changes)

### DIFF
--- a/kzz7yh-a98373/cod-ve07v1_kzz7yh-a98373.xml
+++ b/kzz7yh-a98373/cod-ve07v1_kzz7yh-a98373.xml
@@ -75,7 +75,7 @@
         </p>
         <p xml:id="kzz7yh-a98373-d1e129">
           ¶ 
-          Sex<lb ed="#V" n="52" break="no"/>to vtrun bonum sit mala fieri.
+          Sex<lb ed="#V" n="52" break="no"/>to <sic>vtrun</sic> bonum sit mala fieri.
         </p>
         <p xml:id="kzz7yh-a98373-d1e134">
           ¶ Septimo vtrum malum 
@@ -89,7 +89,7 @@
           <head xml:id="kzz7yh-a98373-Hd1e146">Quaestio 1</head>
           <p xml:id="kzz7yh-a98373-d1e148">
             ¶ Questio I. 
-            <lb ed="#V" n="55"/>PRimo ostendo quod deus velit ostenes 
+            <lb ed="#V" n="55"/>PRimo ostendo quod deus velit omnes 
             <lb ed="#V" n="56"/>homines saluos fieri 
             <lb ed="#V" n="57"/>apostolus i. ad Thi. 2. c. dicit de deo quod omnes homines vult 
             <lb ed="#V" n="58"/>saluos fieri.
@@ -146,7 +146,7 @@
             Pec<lb ed="#V" n="88" break="no"/>cantes aut vult puniri vt iuste: et paucis interpositis subium 
             <lb ed="#V" n="89"/>git quod ista est sequens voluntas et concessio ex nostra causa. Quod 
             er<lb ed="#V" n="90" break="no"/>go dicitur in deo voluntas antes et consequens non est accipienda 
-            <lb ed="#V" n="91"/>ista aestentia et consena ex parte volentis: sed ex parte volitorum: sicut 
+            <lb ed="#V" n="91"/>ista antecedentia et consequentia ex parte volentis: sed ex parte volitorum: sicut 
             <lb ed="#V" n="92"/>diceremus quod iustus rex primo vult omnes homines regni sui 
             <lb ed="#V" n="93"/>non affligi habendo aspectum ad conformitatem nature et tamen 
             <lb ed="#V" n="94"/>ex consequenti vult aliquos puniri inquantum sunt mali. 
@@ -182,11 +182,11 @@
             ¶ Item Hug. i. libro de sacramentis per 
             <lb ed="#V" n="112"/>4. c. 12. Si dicitur deus vult malum fieri aliquibus interpositis subicium. 
             <lb ed="#V" n="113"/>gitur refutat hoc mens pia non quia quod dicitur non bene dicitur: 
-            <lb ed="#V" n="114"/>sed quia quod bedicitur non bene intelligitur: ergo bedicitur in 
+            <lb ed="#V" n="114"/>sed quia quod dicitur non bene intelligitur: ergo bedicitur in 
             <lb ed="#V" n="115"/>rei ueritate quod deus vult malum.
           </p>
           <p xml:id="kzz7yh-a98373-d1e326">
-            ¶ Item. c. sequanti dicit 
+            ¶ Item. c. sequenti dicit 
             <lb ed="#V" n="116"/>de deo quod malum esse uult: sed qui uult malum esse vult malum 
             <lb ed="#V" n="117"/>fieri: ergo deus vult malum fieri. 
           </p>
@@ -205,7 +205,7 @@
           </p>
           <p xml:id="kzz7yh-a98373-d1e359">
             <lb ed="#V" n="127"/>Ad primum in oppositum dicendum quod deum 
-            vel<lb ed="#V" n="128" break="no"/>le materim ser t um uelle mala 
+            vel<lb ed="#V" n="128" break="no"/>le materim ser tum uelle mala 
             <lb ed="#V" n="129"/>non fieri non sunt contradictoria. Utraque enim pars falsa est: sed deum 
             <lb ed="#V" n="130"/>uelle mala fieri. et deum non uelle mala fieri contradicunt: et 
             di<lb ed="#V" n="131" break="no"/>co quod ista pars vera est. Uides ergo quod non est idem uelle 
@@ -216,7 +216,7 @@
             <!--00300.xml-->
             <pb ed="#V" n="143-v"/>
             <cb ed="#P" n="a"/>
-            <lb ed="#V" n="1"/>deum velle malum benediciter etc. dico quod hoc non habet 
+            <lb ed="#V" n="1"/>deum velle malum benedicite etc. dico quod hoc non habet 
             veri<lb ed="#V" n="2" break="no"/>tem nisi intelligatur de voluntate signi que est permissio.
           </p>
           <p xml:id="kzz7yh-a98373-d1e388">
@@ -590,7 +590,7 @@
             vllum<lb ed="#V" n="120" break="no"/>non dico angelorum sed. vel hominum crearet quam malum futurum 
             <lb ed="#V" n="121"/>esse praescisset nisi pariter nosset quibus eos bonorum vsibus 
             com<lb ed="#V" n="122" break="no"/>mendaret. atque ita ordinem seculorum tanquam pulcherrimum 
-            <lb ed="#V" n="123"/>carmen etiam ex quibusdam quasi anthitetis honestaret. 
+            <lb ed="#V" n="123"/>carmen etiam ex quibusdam quasi <sic>anthitetis</sic> honestaret. 
           </p>
           <p xml:id="kzz7yh-a98373-d1e1084">
             <lb ed="#V" n="124"/>Contra. Augu. 12 de ciui. dei. c. 8. dicit. Quod malum 
@@ -627,7 +627,7 @@
             <lb ed="#V" n="6"/>deformitatis qua res formaliter dicitur mala non est ordinabile 
             <lb ed="#V" n="7"/>ordine reali per se: quia illa deformitas non est ens: sed 
             priua<lb ed="#V" n="8" break="no"/>tio entis debiti: et sic procedebat argumentum vltimum ad 
-            <lb ed="#V" n="9"/>partem secundam ordine tamen reali est ordinailile per accidens quia 
+            <lb ed="#V" n="9"/>partem secundam ordine tamen reali est <sic>ordinailile</sic> per accidens quia 
             <lb ed="#V" n="10"/>essentia in qua est illa deformitas ordinabilis est scilicet in 
             pe<lb ed="#V" n="11" break="no"/>nam propter illam deformitatem. Unde <ref xml:id="kzz7yh-a98373-Rd1e1177">Augu. xi. super Gen. 
             <lb ed="#V" n="12"/>longe post principium</ref>. Cur itaque temptari non sineret quam 
@@ -718,7 +718,7 @@
             <lb ed="#V" n="68"/>manifestatio: que est propter oppositionem mali: etiam magna bona 
             <!--00302.xml-->
             <cb ed="#P" n="b"/>
-            <lb ed="#V" n="69"/>que a deo sunt elicita ex malis: vel occasione materalorum sunt 
+            <lb ed="#V" n="69"/>que a deo sunt elicita ex malis: vel occasione malorum sunt 
             <lb ed="#V" n="70"/>de persectione vniuersi: sicut cicatrix in corpore matris 
             resur<lb ed="#V" n="71" break="no"/>gentis: et plura alia: et sic patet quod vniuersum esset perfectius sine 
             <lb ed="#V" n="72"/>illa deformitate qua res est mala considerata secundum se.

--- a/kzz7yh-a98373/cod-ve07v1_kzz7yh-a98373.xml
+++ b/kzz7yh-a98373/cod-ve07v1_kzz7yh-a98373.xml
@@ -96,8 +96,8 @@
           </p>
           <p xml:id="kzz7yh-a98373-d1e159">
             ¶ Item nullus potest saluari nisi quem 
-            <lb ed="#V" n="59"/>deus vult saliutari: ergo si deus non vult omnes homines saluo: 
-            <lb ed="#V" n="60"/>fieri non omnes hores possunt saluari quod falsum videtur. 
+            <lb ed="#V" n="59"/>deus vult saluari: ergo si deus non vult omnes homines saluo: 
+            <lb ed="#V" n="60"/>fieri non omnes homines possunt saluari quod falsum videtur. 
           </p>
           <p xml:id="kzz7yh-a98373-d1e166">
             <lb ed="#V" n="61"/>¶ Item summe liberalis vult omnibus bona sua communicari quantum 
@@ -128,10 +128,10 @@
           </p>
           <p xml:id="kzz7yh-a98373-d1e215">
             <lb ed="#V" n="75"/>¶ Aliomodo vt sit sensus. Quod velit omnes homines saluos 
-            <lb ed="#V" n="76"/>fieri anstencedenter quod est velle omnem hominem saluum fieri secundum quod 
+            <lb ed="#V" n="76"/>fieri antecedenter quod est velle omnem hominem saluum fieri secundum quod 
             <lb ed="#V" n="77"/>consideratur absolute inquantum homo est: et in isto sensu 
             ve<lb ed="#V" n="78" break="no"/>rum est. Unde Damas. 2. lib. c. penul. Oportet scire quod deus 
-            an<lb ed="#V" n="79" break="no"/>tecedenter vult dmnes saluos fieri: et regno eius potiri: 
+            an<lb ed="#V" n="79" break="no"/>tecedenter vult omnes saluos fieri: et regno eius potiri: 
             <lb ed="#V" n="80"/>et fortunari. Non enim ad puniendum plasmauit nos: sed ad 
             per<lb ed="#V" n="81" break="no"/>ticipandum bonitatem eius vt bonus.
           </p>
@@ -145,7 +145,7 @@
             mo<lb ed="#V" n="87" break="no"/>riuntur in peccato mortali. Unde Dama. 2 li. c. penul. 
             Pec<lb ed="#V" n="88" break="no"/>cantes aut vult puniri vt iuste: et paucis interpositis subium 
             <lb ed="#V" n="89"/>git quod ista est sequens voluntas et concessio ex nostra causa. Quod 
-            er<lb ed="#V" n="90" break="no"/>go dicitur in deo voluntas antes et conseqens non est accipienda 
+            er<lb ed="#V" n="90" break="no"/>go dicitur in deo voluntas antes et consequens non est accipienda 
             <lb ed="#V" n="91"/>ista aestentia et consena ex parte volentis: sed ex parte volitorum: sicut 
             <lb ed="#V" n="92"/>diceremus quod iustus rex primo vult omnes homines regni sui 
             <lb ed="#V" n="93"/>non affligi habendo aspectum ad conformitatem nature et tamen 
@@ -156,10 +156,10 @@
             ¶ Ad 2m cum dicitur. Qua 
             <lb ed="#V" n="96"/>non omnes homines possent saluari nisi deus vel 
             <lb ed="#V" n="97"/>let omnes saluos fieri etc. dico quod verum est si non vellet omnes 
-            <lb ed="#V" n="98"/>homines saluos fieri neque anstentecedenter neque consequenter. 
+            <lb ed="#V" n="98"/>homines saluos fieri neque antecedenter neque consequenter. 
           </p>
           <p xml:id="kzz7yh-a98373-d1e276">
-            <lb ed="#V" n="99"/>¶ Ad 3m cum dicitur quod summe liberalis vult omibus bona sua 
+            <lb ed="#V" n="99"/>¶ Ad 3m cum dicitur quod summe liberalis vult omnibus bona sua 
             <lb ed="#V" n="100"/>communicari quantum possibile est etc. dicendum quod uerum est si 
             pos<lb ed="#V" n="101" break="no"/>sibile est et decens simul: deum autem uelle simpliciter et absolute 
             <lb ed="#V" n="102"/>omnes homines saluos fieri omnibus particularibus conditionibus 
@@ -173,13 +173,13 @@
             <lb ed="#V" n="105"/>¶ Questio. II. 
             <lb ed="#V" n="106"/>SEcundo queritur utrum deus uelit mala 
             fieri<lb ed="#V" n="107" break="no"/>et uidetur quod sic: quia de quolibet affirm 
-            <lb ed="#V" n="108"/>tio uel negatio: hoc est princnium: quod maxime defendit 
+            <lb ed="#V" n="108"/>tio uel negatio: hoc est principium: quod maxime defendit 
             <lb ed="#V" n="109"/>philosophus. 4. Metaphy. Sed non est uerum quod deus uelit 
             <lb ed="#V" n="110"/>mala non fieri: quia nihil potest fieri contra uoluntatem suam: 
             <lb ed="#V" n="111"/>ergo deus uult mala fieri.
           </p>
           <p xml:id="kzz7yh-a98373-d1e315">
-            ¶ Item Hug. i. libro de sacramentius per 
+            ¶ Item Hug. i. libro de sacramentis per 
             <lb ed="#V" n="112"/>4. c. 12. Si dicitur deus vult malum fieri aliquibus interpositis subicium. 
             <lb ed="#V" n="113"/>gitur refutat hoc mens pia non quia quod dicitur non bene dicitur: 
             <lb ed="#V" n="114"/>sed quia quod bedicitur non bene intelligitur: ergo bedicitur in 
@@ -241,7 +241,7 @@
           </p>
           <p xml:id="kzz7yh-a98373-d1e423">
             ¶ Item dicit 
-            <lb ed="#V" n="13"/>Canon. 83. di. c. Error cum possit prohibere puersos et non 
+            <lb ed="#V" n="13"/>Canon. 83. di. c. Error cum possit prohibere peruersos et non 
             <lb ed="#V" n="14"/>facis nihil aliud est quam fouere: ergo cum deus possit 
             prohi<lb ed="#V" n="15" break="no"/>bere mala fieri sumendo ea fieri videtur malos in sua 
             ma<lb ed="#V" n="16" break="no"/>litia fouere.
@@ -428,8 +428,8 @@
           <p xml:id="kzz7yh-a98373-d1e771">
             ¶ Item Glo. super illud 
             <lb ed="#V" n="7"/>psalmi. Diminute sunt veritates a filiis hominum. Ueritas 
-            <lb ed="#V" n="8"/>dei vna est qua illustrantur animme sancte: sed in hominibus multe 
-            <lb ed="#V" n="9"/>sunt veritates: sicut ab vna facie mualte in speculis apparent 
+            <lb ed="#V" n="8"/>dei vna est qua illustrantur animae sancte: sed in hominibus multe 
+            <lb ed="#V" n="9"/>sunt veritates: sicut ab vna facie multae in speculis apparent 
             <lb ed="#V" n="10"/>imagines: ergo omne verum quod non est prima veritas est a 
             prae<lb ed="#V" n="11" break="no"/>ma veritate: sed mala fieri non est prima veritas nec a prima 
             <lb ed="#V" n="12"/>veritate: ergo mala fieri non est verum.
@@ -440,7 +440,7 @@
             <lb ed="#V" n="14"/>sed mala fieri non est rectum: ergo mala fieri non est verum 
           </p>
           <p xml:id="kzz7yh-a98373-d1e794">
-            <lb ed="#V" n="15"/>Contra. Si Ioannes praedicat Ioanem praedicare est 
+            <lb ed="#V" n="15"/>Contra. Si Ioannes praedicat Ioannem praedicare est 
             ve<lb ed="#V" n="16" break="no"/>rum: ergo a simili si malum sit malum fieri est 
             <lb ed="#V" n="17"/>verum: sed multa mala fiunt: ergo multa mala fieri est verum. 
           </p>
@@ -491,12 +491,12 @@
           <head xml:id="kzz7yh-a98373-Hd1e893">Quaestio 6</head>
           <p xml:id="kzz7yh-a98373-d1e895">
             ¶ Questio. VI 
-            <lb ed="#V" n="54"/>SExto queritur quetitur vtrum 
+            <lb ed="#V" n="54"/>SExto queritur quaeritur vtrum 
             bonum<lb ed="#V" n="55" break="no"/>sit mala fieri: et 
             vi<lb ed="#V" n="56" break="no"/>detur quod sic Hug. i. libro de sacramentius per. 4. c. 5 bonum fuit 
             <lb ed="#V" n="57"/>esse et bona et mala: et voluit vtrunque esse deus: quia 
             <lb ed="#V" n="58"/>vtrunque esse bonum fuit: sed quod est bonum esse bonum est 
-            <lb ed="#V" n="59"/>fieri: ergobonum est mala fieri. Item idem Hug. eodem libro per. 
+            <lb ed="#V" n="59"/>fieri: ergo bonum est mala fieri. Item idem Hug. eodem libro per. 
             <lb ed="#V" n="60"/>eadem. c. 13. Bonum est esse malum: sed vt prius quod bonum 
             <lb ed="#V" n="61"/>est esse bonum est fieri.
           </p>
@@ -576,7 +576,7 @@
             <lb ed="#V" n="111"/>sacramentius per. 4. c. 6. dicit de deo. Uidet mala procul quae 
             fu<lb ed="#V" n="112" break="no"/>tura erant cum bonis plusquam erant et considerauit: quia 
             <lb ed="#V" n="113"/>malis adiunctis bona commendarentur et pulchriora fierent 
-            <lb ed="#V" n="114"/>comperatione malorum: sed ea per quorum adiunctionem bona 
+            <lb ed="#V" n="114"/>comparatione malorum: sed ea per quorum adiunctionem bona 
             con<lb ed="#V" n="115" break="no"/>mendantur et pulchriora redduntur sunt ordinabilia: ergo 
             ma<lb ed="#V" n="116" break="no"/>la sunt ordinabilia.
           </p>
@@ -612,7 +612,7 @@
             <lb ed="#V" n="134"/>existentibus: ergo non est ordinabile aliquo ordine reali. 
           </p>
           <p xml:id="kzz7yh-a98373-d1e1116">
-            <lb ed="#V" n="135"/>Respondeo quod sicut sanum potest aliquid dici tripiter 
+            <lb ed="#V" n="135"/>Respondeo quod sicut sanum potest aliquid dici tripliciter 
             <lb ed="#V" n="136"/>vel sicut subiectum sanitatis: et sicut homo¬ 
             <!--00302.xml-->
             <pb ed="#V" n="144-v"/>
@@ -638,7 +638,7 @@
           </p>
           <p xml:id="kzz7yh-a98373-d1e1167">
             ¶ 
-            Secun<lb ed="#V" n="17" break="no"/>do modo dico quod ipsa desormitas ordinabilis est non 
+            Secun<lb ed="#V" n="17" break="no"/>do modo dico quod ipsa deformitas ordinabilis est non 
             ordine<lb ed="#V" n="18" break="no"/>nature sed iustitie: quia homo per illam deformitatem 
             dispo<lb ed="#V" n="19" break="no"/>nitur ad iustam penam recipiendam: et sic deus ordinat 
             <lb ed="#V" n="20"/>malas voluntates inquantum voluntatibus per malitiam 
@@ -674,7 +674,7 @@
           <head xml:id="kzz7yh-a98373-Hd1e1227">Quaestio 8</head>
           <p xml:id="kzz7yh-a98373-d1e1229">
             ¶ Quaestio VIII 
-            <lb ed="#V" n="37"/>Ctauo queritur vtrum malum sit de perfectione 
+            <lb ed="#V" n="37"/>Octauo queritur vtrum malum sit de perfectione 
             <lb ed="#V" n="38"/>vniuersi: et videtur quod sic: quia omne 
             ordi<lb ed="#V" n="39" break="no"/>dinabile est de perfectione vniuersali: sed malum est 
             <lb ed="#V" n="40"/>ordinabile vt in praecedenti quaestione visum est: ergo est 
@@ -685,7 +685,7 @@
             magne<lb ed="#V" n="42" break="no"/>perfectiones deessent vniuerso est de perfectione vniuersi: sed 
             <lb ed="#V" n="43"/>si nunquam fuisset peccatum multe et magne perfectiones deessent 
             <lb ed="#V" n="44"/>vniuerso scilicet victorie martyrum et incarnatio filii dei: vnde 
-            excla<lb ed="#V" n="45" break="no"/>mat Grego. in bendictione cerei paschalis. O felix culpa quae 
+            excla<lb ed="#V" n="45" break="no"/>mat Grego. in benedictione cerei paschalis. O felix culpa quae 
             <lb ed="#V" n="46"/>talem meruit habere redemptorem: ergo malum est de 
             perfectio<lb ed="#V" n="47" break="no"/>ne vniuersi.
           </p>
@@ -711,7 +711,7 @@
             <lb ed="#V" n="61"/>essentialem et accidentalem dico quod malum 
             ra<lb ed="#V" n="62" break="no"/>tione ipsius deforitatis non est de vniuersi perfectione essentia 
             <lb ed="#V" n="63"/>li vllo modo. Si autem loquamur de perfectione vniuersi 
-            acciden<lb ed="#V" n="64" break="no"/>tali: sic dico: quamuis malum de ratione deforitatis non sit de perfectione 
+            acciden<lb ed="#V" n="64" break="no"/>tali: sic dico: quamuis malum de ratione deformitatis non sit de perfectione 
             <lb ed="#V" n="65"/>vniuersi per se quia non est accidens bonum: tamen per accidens est de 
             perfecti<lb ed="#V" n="66" break="no"/>one tali inquantum scilicet esse sibi substrata est de perfectione 
             vniuer<lb ed="#V" n="67" break="no"/>si: et inquantum iusta pena que propter ipsam infligitur est maior bomni 

--- a/kzz7yh-a98373/cod-ve07v1_kzz7yh-a98373.xml
+++ b/kzz7yh-a98373/cod-ve07v1_kzz7yh-a98373.xml
@@ -182,7 +182,7 @@
             ¶ Item Hug. i. libro de sacramentis per 
             <lb ed="#V" n="112"/>4. c. 12. Si dicitur deus vult malum fieri aliquibus interpositis subicium. 
             <lb ed="#V" n="113"/>gitur refutat hoc mens pia non quia quod dicitur non bene dicitur: 
-            <lb ed="#V" n="114"/>sed quia quod dicitur non bene intelligitur: ergo bedicitur in 
+            <lb ed="#V" n="114"/>sed quia quod bene dicitur non bene intelligitur: ergo bedicitur in 
             <lb ed="#V" n="115"/>rei ueritate quod deus vult malum.
           </p>
           <p xml:id="kzz7yh-a98373-d1e326">
@@ -205,7 +205,7 @@
           </p>
           <p xml:id="kzz7yh-a98373-d1e359">
             <lb ed="#V" n="127"/>Ad primum in oppositum dicendum quod deum 
-            vel<lb ed="#V" n="128" break="no"/>le materim ser tum uelle mala 
+            vel<lb ed="#V" n="128" break="no"/>le mala fieri: et deum uelle mala 
             <lb ed="#V" n="129"/>non fieri non sunt contradictoria. Utraque enim pars falsa est: sed deum 
             <lb ed="#V" n="130"/>uelle mala fieri. et deum non uelle mala fieri contradicunt: et 
             di<lb ed="#V" n="131" break="no"/>co quod ista pars vera est. Uides ergo quod non est idem uelle 
@@ -216,8 +216,7 @@
             <!--00300.xml-->
             <pb ed="#V" n="143-v"/>
             <cb ed="#P" n="a"/>
-            <lb ed="#V" n="1"/>deum velle malum benedicite etc. dico quod hoc non habet 
-            veri<lb ed="#V" n="2" break="no"/>tem nisi intelligatur de voluntate signi que est permissio.
+            <lb ed="#V" n="1"/>deum velle malum bene dicitur etc. dico quod hoc non habet veri<lb ed="#V" n="2" break="no"/>tem nisi intelligatur de voluntate signi que est permissio.
           </p>
           <p xml:id="kzz7yh-a98373-d1e388">
             ¶ Ad 


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve07v1_kzz7yh-a98373.xml`.

## Applied changes

- p. 143r l. 59: saliutari → saluari: extra li
- p. 143r l. 60: hores → homines: garbled
- p. 143r l. 76: anstencedenter → antecedenter: extra nste
- p. 143r l. 79: dmnes → omnes: d/o misread
- p. 143r l. 90: conseqens → consequens: missing u
- p. 143r l. 98: anstentecedenter → antecedenter: extra letters
- p. 143r l. 99: omibus → omnibus: missing n
- p. 143r l. 108: princnium → principium: missing letters
- p. 143r l. 111: sacramentius → sacramentis: extra iu
- p. 143v l. 13: puersos → peruersos: missing letters
- p. 144r l. 8: animme → animae: doubled m, medieval ae spelling
- p. 144r l. 9: mualte → multae: transposition
- p. 144r l. 15: Ioanem → Ioannem: missing n
- p. 144r l. 54: quetitur → quaeritur: t/r and spelling
- p. 144r l. 59: ergobonum → ergo bonum: space missing
- p. 144r l. 114: comperatione → comparatione: e/a misread
- p. 144r l. 135: tripiter → tripliciter: missing letters
- p. 144v l. 17: desormitas → deformitas: sor/for misread
- p. 144v l. 37: Ctauo → Octauo: missing initial O
- p. 144v l. 45: bendictione → benedictione: missing e
- p. 144v l. 64: deforitatis → deformitatis: missing m

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_