### PR TITLE
Transcription corrections: cod-ve09v2_kzz7yh-f00235.xml (3 changes)

### DIFF
--- a/kzz7yh-f00235/cod-ve09v2_kzz7yh-f00235.xml
+++ b/kzz7yh-f00235/cod-ve09v2_kzz7yh-f00235.xml
@@ -321,7 +321,7 @@
           scri<lb ed="#V" n="85" break="no"/>ptura etc. In primo libro deterinauit 
           ma<lb ed="#V" n="86" break="no"/>gister de deo quantum ad rationem sue naturalis 
           <lb ed="#V" n="87"/>perfectionis. In hoc secundo libro deterinat 
-          <lb ed="#V" n="88"/>de ipso inquentum eius perfectio relucet in 
+          <lb ed="#V" n="88"/>de ipso in quantum eius perfectio relucet in 
           <lb ed="#V" n="89"/>operibus creationis.
         </p>
         <p xml:id="kzz7yh-f00235-d1e668">
@@ -433,7 +433,7 @@
           <!--00018.xml-->
           <pb ed="#V" n="2-v"/>
           <cb ed="#P" n="a"/>
-          <lb ed="#V" n="1"/>CIrca hanc Distinctionem querum 
+          <lb ed="#V" n="1"/>CIrca hanc Distinctionem quaerun 
           <lb ed="#V" n="2"/>tur quinque.
         </p>
         <p xml:id="kzz7yh-f00235-d1e819">

--- a/kzz7yh-f00235/cod-ve09v2_kzz7yh-f00235.xml
+++ b/kzz7yh-f00235/cod-ve09v2_kzz7yh-f00235.xml
@@ -319,7 +319,7 @@
           <lb ed="#V" n="83"/>CReationem omnium rerum 
           <lb ed="#V" n="84"/>insinuans 
           scri<lb ed="#V" n="85" break="no"/>ptura etc. In primo libro deterinauit 
-          ma<lb ed="#V" n="86" break="no"/>gister de deo quatum ad rationem sue naturalis 
+          ma<lb ed="#V" n="86" break="no"/>gister de deo quantum ad rationem sue naturalis 
           <lb ed="#V" n="87"/>perfectionis. In hoc secundo libro deterinat 
           <lb ed="#V" n="88"/>de ipso inquentum eius perfectio relucet in 
           <lb ed="#V" n="89"/>operibus creationis.
@@ -351,7 +351,7 @@
         </p>
         <p xml:id="kzz7yh-f00235-d1e700">
           ¶ In secunda quorundam 
-          <lb ed="#V" n="97"/>philosophorum scilicet Plationis et Aristote. refert opiniones continentes 
+          <lb ed="#V" n="97"/>philosophorum scilicet Platonis et Aristote. refert opiniones continentes 
           er<lb ed="#V" n="98" break="no"/>roneam vanitatem ibi. Plato namque
         </p>
         <p xml:id="kzz7yh-f00235-d1e707">
@@ -374,8 +374,8 @@
           <lb ed="#V" n="105"/>corporalis ibi. et sicut factus est homini
         </p>
         <p xml:id="kzz7yh-f00235-d1e733">
-          ¶ In tertia propter quid creatu 
-          <lb ed="#V" n="106"/>re corporali vnita est spiritualis ibi Solet estquari
+          ¶ In tertia propter quid 
+          creatu<lb ed="#V" n="106" break="no"/>re corporali vnita est spiritualis ibi Solet estquari
         </p>
         <p xml:id="kzz7yh-f00235-d1e739">
           ¶ In quarta 

--- a/kzz7yh-f00235/cod-ve09v2_kzz7yh-f00235.xml
+++ b/kzz7yh-f00235/cod-ve09v2_kzz7yh-f00235.xml
@@ -321,7 +321,7 @@
           scri<lb ed="#V" n="85" break="no"/>ptura etc. In primo libro deterinauit 
           ma<lb ed="#V" n="86" break="no"/>gister de deo quantum ad rationem sue naturalis 
           <lb ed="#V" n="87"/>perfectionis. In hoc secundo libro deterinat 
-          <lb ed="#V" n="88"/>de ipso in quantum eius perfectio relucet in 
+          <lb ed="#V" n="88"/>de ipso inquantum eius perfectio relucet in 
           <lb ed="#V" n="89"/>operibus creationis.
         </p>
         <p xml:id="kzz7yh-f00235-d1e668">
@@ -375,7 +375,7 @@
         </p>
         <p xml:id="kzz7yh-f00235-d1e733">
           ¶ In tertia propter quid 
-          creatu<lb ed="#V" n="106" break="no"/>re corporali vnita est spiritualis ibi Solet estquari
+          creatu<lb ed="#V" n="106" break="no"/>re corporali vnita est spiritualis ibi Solet etiam quaeri
         </p>
         <p xml:id="kzz7yh-f00235-d1e739">
           ¶ In quarta 
@@ -433,8 +433,8 @@
           <!--00018.xml-->
           <pb ed="#V" n="2-v"/>
           <cb ed="#P" n="a"/>
-          <lb ed="#V" n="1"/>CIrca hanc Distinctionem quaerun 
-          <lb ed="#V" n="2"/>tur quinque.
+          <lb ed="#V" n="1"/>CIrca hanc Distinctionem
+          quaerun<lb ed="#V" n="2" break="no"/>tur quinque.
         </p>
         <p xml:id="kzz7yh-f00235-d1e819">
           ¶ 


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve09v2_kzz7yh-f00235.xml`.

## Applied changes

- p. 2r l. 86: quatum → quantum: missing n (likely OCR drop)
- p. 2r l. 97: Plationis → Platonis: l/t misread
- p. 2r l. 106: 'creatu' + 're' split across line break without break="no" on lb n=106

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_