### PR TITLE
Transcription corrections: cod-ve09v2_kzz7yh-f01812.xml (12 changes)

### DIFF
--- a/kzz7yh-f01812/cod-ve09v2_kzz7yh-f01812.xml
+++ b/kzz7yh-f01812/cod-ve09v2_kzz7yh-f01812.xml
@@ -135,7 +135,7 @@
             <lb ed="#V" n="71"/>illud quod dicunt ex parte dei realiter 
             <lb ed="#V" n="72"/>idem sunt: quia vtraque est ipsa diuina actio que deus est: secundum 
             <lb ed="#V" n="73"/>tamen rationem differunt: quia alia est relatio secundum rationem ipsius 
-            <lb ed="#V" n="74"/>dei ad creaturam inquantum est creatoret alia inquantum est 
+            <lb ed="#V" n="74"/>dei ad creaturam inquantum est creator et alia inquantum est 
             <lb ed="#V" n="75"/>conseruator.
           </p>
           <p xml:id="kzz7yh-f01812-d1e245">
@@ -152,7 +152,7 @@
             de<lb ed="#V" n="85" break="no"/>aliquo siue nunc primo referri ad aliquem sub ratione qua 
             <lb ed="#V" n="86"/>dat esse non de aliquo realiter differt a conseruari. 
             <!-- TODO: add paragraph break -->
-            <lb ed="#V" n="87"/>Alii dicunt quod creari et conseruari non diffferunt secundum 
+            <lb ed="#V" n="87"/>Alii dicunt quod creari et conseruari non differunt secundum 
             <lb ed="#V" n="88"/>aliquid positiuum absolutum: quia 
             cre<lb ed="#V" n="89" break="no"/>ari est nunc primo esse ab aliquo non de aliquo. 
             Conserua<lb ed="#V" n="90" break="no"/>ri est esse ab aliquo non nunc primo nulla precedente 
@@ -247,7 +247,7 @@
             <lb ed="#V" n="24"/>sit rei conseruatio et creatio. Et videtur  
             <lb ed="#V" n="25"/>quod non. Quia ab eodem principio non est generatio et rei 
             <lb ed="#V" n="26"/>genite conseruatio: aliter enim non maneret filius 
-            <lb ed="#V" n="27"/>post patrem. Ergo a simili non opetet quod ab eodem 
+            <lb ed="#V" n="27"/>post patrem. Ergo a simili non oportet quod ab eodem 
             princi<lb ed="#V" n="28" break="no"/>pio sit rei conseruatio et creatio.
           </p>
           <p xml:id="kzz7yh-f01812-d1e461">
@@ -304,8 +304,8 @@
             ¶ Romn autem quare creatura non posset 
             <lb ed="#V" n="60"/>manere nisi a deo conseruaretur est hec. Conseruatio enim omnis 
             <lb ed="#V" n="61"/>effectus dependet ex sua causa principali: que est causa per se 
-            <lb ed="#V" n="62"/>et immediata sui esse: talis autem causa cuiuslibet creatu 
-            <lb ed="#V" n="63"/>re solus deus est. Sequatur ergo quod nisi creatura a deo 
+            <lb ed="#V" n="62"/>et immediata sui esse: talis autem causa cuiuslibet 
+            creatu<lb ed="#V" n="63" break="no"/>re solus deus est. Sequatur ergo quod nisi creatura a deo 
             con<lb ed="#V" n="64" break="no"/>seruaretur: desineret esse. secundum quod expresse vult Augustinus 4o 
             su<lb ed="#V" n="65" break="no"/>per Gensiem ante medium: et. 5olibro loge post medium et. ix. 
             <lb ed="#V" n="66"/>libro inter medium et finem vbi sic dicit. Si deus 
@@ -383,7 +383,7 @@
             <lb ed="#V" n="123"/>ficator forme domus in materia: quare manet forma 
             do<lb ed="#V" n="124" break="no"/>mus in absentia edificationis et non manet lumen in 
             me<lb ed="#V" n="125" break="no"/>dio in absentia luminaris. Dicunt quidam quod huius ratio est 
-            <lb ed="#V" n="126"/>naura effectuum: effectus enim qui possunt corrumpi aliter per 
+            <lb ed="#V" n="126"/>natura effectuum: effectus enim qui possunt corrumpi aliter per 
             na<lb ed="#V" n="127" break="no"/>turam quam per subtractionem sue cause create sunt talis 
             natu<lb ed="#V" n="128" break="no"/>re quod possunt manere in eius absentia. Sed illi qui non 
             pos<lb ed="#V" n="129" break="no"/>sent naturaliter corrumpi non corrumperentur per 
@@ -405,7 +405,7 @@
             lum<lb ed="#V" n="3" break="no"/>nis aliquod reale absolutum. Cum ergo dicitur quod res non potest 
             ma<lb ed="#V" n="4" break="no"/>nere nisi conseruata per suam efficientem causam 
             intellign<lb ed="#V" n="5" break="no"/>dum est de causa immediata sui esse et principali vel simplier 
-            <lb ed="#V" n="6"/>et absolute: qualis causa est deus respectu cuiussibet 
+            <lb ed="#V" n="6"/>et absolute: qualis causa est deus respectu cuiuslibet 
             crea<lb ed="#V" n="7" break="no"/>ture Uel principali in genere qualis causa est luminare 
             re<lb ed="#V" n="8" break="no"/>spectu luminis.
           </p>
@@ -620,7 +620,7 @@
             <!--00023.xml-->
             <pb ed="#V" n="5-r"/>
             <cb ed="#P" n="a"/>
-            <lb ed="#V" n="1"/>conseruare quam ereare per illam virtutem: per quam deus 
+            <lb ed="#V" n="1"/>conseruare quam creare per illam virtutem: per quam deus 
             po<lb ed="#V" n="2" break="no"/>test rem creare: potest eam inesse creato conseruare. Unde sicut. 
             <lb ed="#V" n="3"/>
             <lb ed="#V" n="4"/>tem que est abeo immediate tantum: creant non per aliquem 
@@ -630,10 +630,10 @@
           </p>
           <p xml:id="kzz7yh-f01812-d1e1140">
             ¶ ETreaturem autem que a deo hrocesserunt 
-            imme<lb ed="#V" n="8" break="no"/>ditate: et medante causa secundam: similiter a deo conseruantur 
-            <lb ed="#V" n="9"/>mediate: et meduante causa secunda: et quia caua secunda 
+            imme<lb ed="#V" n="8" break="no"/>ditate: et mediante causa secundam: similiter a deo conseruantur 
+            <lb ed="#V" n="9"/>mediate: et mediante causa secunda: et quia caua secunda 
             potes<lb ed="#V" n="10" break="no"/>test dici quidam influxus cause prime: et ideo creature 
-            prae<lb ed="#V" n="11" break="no"/>dicte a deo conseruantur der insiuxum: et ab eo immediate. 
+            prae<lb ed="#V" n="11" break="no"/>dicte a deo conseruantur der influxum: et ab eo immediate. 
           </p>
           <p xml:id="kzz7yh-f01812-d1e1151">
             <lb ed="#V" n="12"/>Ad primum in oppositum dicendum quod per
@@ -660,9 +660,9 @@
           <p xml:id="kzz7yh-f01812-d1e1190">
             ¶ Ad 
             <lb ed="#V" n="26"/>quartum dicendum quam minor est falsa: quamuis enim cret: et 
-            <lb ed="#V" n="27"/>creatum conseruet nullo infiuxu mediante: tamen creare 
+            <lb ed="#V" n="27"/>creatum conseruet nullo influxu mediante: tamen creare 
             <lb ed="#V" n="28"/>et conseruare diuerse sunt actiones: non secundum rem sed secundum 
-            fa<lb ed="#V" n="29" break="no"/>tionem: Unde et alia relatiorationis consequitur 
+            fa<lb ed="#V" n="29" break="no"/>tionem: Unde et alia relatio rationis consequitur 
             deum<lb ed="#V" n="30" break="no"/>sub ratione qua creator: et alia sub ratione qua 
             conserua<lb ed="#V" n="31" break="no"/>tor Sicut alia realis relatio est in resub ratione qua 
             crean<lb ed="#V" n="32" break="no"/>tio quam sit illa que est in ea sub ratione qua conseruatur. 

--- a/kzz7yh-f01812/cod-ve09v2_kzz7yh-f01812.xml
+++ b/kzz7yh-f01812/cod-ve09v2_kzz7yh-f01812.xml
@@ -602,7 +602,7 @@
           </p>
           <p xml:id="kzz7yh-f01812-d1e1091">
             ¶ Prime 
-            <lb ed="#V" n="128"/>a a deo conseruantur: non per influxum medium: sed 
+            <lb ed="#V" n="128"/>a deo conseruantur: non per influxum medium: sed 
             imme<lb ed="#V" n="129" break="no"/>diate tantum. Quod patet duplici ratione.
           </p>
           <p xml:id="kzz7yh-f01812-d1e1098">

--- a/kzz7yh-f01812/cod-ve09v2_kzz7yh-f01812.xml
+++ b/kzz7yh-f01812/cod-ve09v2_kzz7yh-f01812.xml
@@ -602,7 +602,7 @@
           </p>
           <p xml:id="kzz7yh-f01812-d1e1091">
             ¶ Prime 
-            <lb ed="#V" n="128"/>a deoconseruantur: non per influxum medium: sed 
+            <lb ed="#V" n="128"/>a a deo conseruantur: non per influxum medium: sed 
             imme<lb ed="#V" n="129" break="no"/>diate tantum. Quod patet duplici ratione.
           </p>
           <p xml:id="kzz7yh-f01812-d1e1098">
@@ -625,7 +625,7 @@
             <lb ed="#V" n="3"/>
             <lb ed="#V" n="4"/>tem que est abeo immediate tantum: creant non per aliquem 
             <lb ed="#V" n="5"/>medium influtum: ita eapotest conseruare detr se sirm 
-            <lb ed="#V" n="6"/>nulo infiuxum: mediate posnere: ergo talem insilutum effet 
+            <lb ed="#V" n="6"/>nulo infiuxum: mediate posnere: ergo talem insilutum esset 
             <lb ed="#V" n="7"/>suprsnluum
           </p>
           <p xml:id="kzz7yh-f01812-d1e1140">


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve09v2_kzz7yh-f01812.xml`.

## Applied changes

- p. 3v l. 74: creatoret → creator et: missing space
- p. 3v l. 87: diffferunt → differunt: triple f typo
- p. 4r l. 27: opetet → oportet: missing or letters
- p. 4r l. 63: 'creatu' + 're' split across line break without break="no" on lb n=63
- p. 4r l. 126: naura → natura: missing t
- p. 4v l. 6: cuiussibet → cuiuslibet: s/l misread
- p. 5r l. 1: ereare → creare: missing c
- p. 5r l. 8: medante → mediante: missing i
- p. 5r l. 9: meduante → mediante: u/i misread
- p. 5r l. 11: insiuxum → influxum: s/f misread
- p. 5r l. 27: infiuxu → influxu: i/l misread
- p. 5r l. 29: relatiorationis → relatio rationis: missing space

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_