### PR TITLE
Transcription corrections: cod-ve09v2_kzz7yh-f02923.xml (31 changes)

### DIFF
--- a/kzz7yh-f02923/cod-ve09v2_kzz7yh-f02923.xml
+++ b/kzz7yh-f02923/cod-ve09v2_kzz7yh-f02923.xml
@@ -218,7 +218,7 @@
           </p>
           <p xml:id="kzz7yh-f02923-d1e391">
             ¶ 
-            co<lb ed="#V" n="134" break="no"/>ergo ad quaestionem quam ista machina mundialis: facta est 
+            Di<lb ed="#V" n="134" break="no"/>co ergo ad quaestionem quam ista machina mundialis: facta est 
             <lb ed="#V" n="135"/>de nihilo: deus enim non tantum est causamundialis 
             ma<lb ed="#V" n="136" break="no"/>chine vel cuiuscumque alterius creature sub rationem qum 
             <lb ed="#V" n="137"/>esi haec ens: vtpote subtatione qua est huius speciei vel un¬ 

--- a/kzz7yh-f02923/cod-ve09v2_kzz7yh-f02923.xml
+++ b/kzz7yh-f02923/cod-ve09v2_kzz7yh-f02923.xml
@@ -92,7 +92,7 @@
           <p xml:id="kzz7yh-f02923-d1e157">
             <lb ed="#V" n="48"/>¶ Item phuns in celi et mundi. Omnes res generate 
             cor<lb ed="#V" n="49" break="no"/>umpiuintur et finiuntur: ergon a simili omnes res facte. Sed 
-            <lb ed="#V" n="50"/>mundialis machinam non cortumpetur. Ergo non est factam: 
+            <lb ed="#V" n="50"/>mundialis machinam non corrumpetur. Ergo non est factam: 
           </p>
           <p xml:id="kzz7yh-f02923-d1e166">
             <lb ed="#V" n="51"/>¶ Itm in omni re facta est venstigium factoris: per qun 
@@ -126,7 +126,7 @@
             <lb ed="#V" n="70"/>possibile. In primo enim libro demonstratum est: 
             impossibi<lb ed="#V" n="71" break="no"/>seesse plures deos: et deum non posse esse nisi simplicem: 
             <lb ed="#V" n="72"/>et immutabilem. Item non est possibie quod non sit ab aeterno: et 
-            <lb ed="#V" n="73"/>non sit sacta quiam quaomd est: et non fuit ab aeterno: incepit esse: et omne 
+            <lb ed="#V" n="73"/>non sit facta quiam quaomd est: et non fuit ab aeterno: incepit esse: et omne 
             <lb ed="#V" n="74"/>ens quod incepit esse: factum est. Restat ergo quam manchinam 
             mun<lb ed="#V" n="75" break="no"/>dlalis aut est ab aeterno: et est factu autem non est ab aeterno: etest 
             <lb ed="#V" n="76"/>ficta. Sed quocumquam istorum dato: habeo dropotinem in 
@@ -150,7 +150,7 @@
             au<lb ed="#V" n="89" break="no"/>tem verbum hilosophyum. intelligit de effectibus virtutis createm. 
             <lb ed="#V" n="90"/>c Ad tertium dico quam minor falsa est vnde Augu. 1 de 
             <lb ed="#V" n="91"/>ciui. capi quinto mundus ipse ordinatissima suam 
-            mutabi<lb ed="#V" n="92" break="no"/>litate est mobilitate: et visibilum omium puichertima 
+            mutabi<lb ed="#V" n="92" break="no"/>litate est mobilitate: et visibilum omnium puichertima 
             speceie<lb ed="#V" n="93" break="no"/>quodam modo tacitus et factum se esse: et non nisi a deo 
             in<lb ed="#V" n="94" break="no"/>effabiliter atquam inuisibiliter duichro: fieri potuisse 
             pro<lb ed="#V" n="95" break="no"/>ciamat.
@@ -184,7 +184,7 @@
             ¶ Item Auicen 4 metha capi. secundo. 
             <lb ed="#V" n="108"/>Sialiquid non fuerit possibile in se illud non esset vlo 
             mo<lb ed="#V" n="109" break="no"/>do: et paucis interpositis subiungit causam dicens: quia 
-            <lb ed="#V" n="110"/>ens non est potens super illud cum ipsum non fueritr 
+            <lb ed="#V" n="110"/>ens non est potens super illud cum ipsum non fuerit 
             <lb ed="#V" n="111"/>in se possibile. Sed in re qua nihil est: nonn est aliqua 
             pos<lb ed="#V" n="112" break="no"/>sibilitas ad essendum secundum Ansela de casu Dia. capsti. . 
             <lb ed="#V" n="113"/>Ergo videtur quam nulium agens aliquid de nihilo facenre potest 
@@ -196,7 +196,7 @@
           </p>
           <p xml:id="kzz7yh-f02923-d1e349">
             ¶ Item 
-            <lb ed="#V" n="117"/>phlosophus primo. celi et mundi. Omnis res non cadens sub 
+            <lb ed="#V" n="117"/>philosophus primo. celi et mundi. Omnis res non cadens sub 
             cor<lb ed="#V" n="118" break="no"/>fuptione est non generata. Sed caelum non cadit sub 
             cor<lb ed="#V" n="119" break="no"/>ruptione: ergo non est generatum. Et tamen vt ipse vuit. 2. 
             <lb ed="#V" n="120"/>mentha mdus et facriu Sed corpus naturale factum non 
@@ -212,7 +212,7 @@
             <lb ed="#V" n="128"/>magis prone principium quam medium: loquens ad deum 
             <lb ed="#V" n="129"/>sicauit. Tucras et aliud nihi. vnde fecisti celum et tertam 
             <lb ed="#V" n="130"/>duo quaedam: vnum prope te: alterum prope nihil. ibi accipiennterram 
-            <lb ed="#V" n="131"/>prmara corpalium sergo maeriam deo sacta est. Preterea 
+            <lb ed="#V" n="131"/>prmara corpalium sergo maeriam deo facta est. Preterea 
             efsen<lb ed="#V" n="132" break="no"/>tiam non est factua ab aeterno: a nulio dependes. Sed talis 
             ef<lb ed="#V" n="133" break="no"/>entia est summe ens: materia autem est insimum ens.
           </p>
@@ -431,7 +431,7 @@
             produncerei<lb ed="#V" n="6" break="no"/>hoiuiset.
           </p>
           <p xml:id="kzz7yh-f02923-d1e784">
-            ¶ Item plosbophus primo topi. dicit quod sunt 
+            ¶ Item philosophus primo topi. dicit quod sunt 
             probleu<lb ed="#V" n="7" break="no"/>mata de quibus rationem non habemus cum sint 
             magnan<lb ed="#V" n="8" break="no"/>vt vtrum mundus sit eternus vel non. Sed si non 
             fuis<lb ed="#V" n="9" break="no"/>set possibile mundum esse ab aeterno: haberemus 
@@ -451,53 +451,53 @@
             ¶ Item instans 
             <lb ed="#V" n="18"/>medium est duorum temporum: est enim ninis preteriti: 
             <lb ed="#V" n="19"/>et princibium futuri secundum phisphum 6 phu. Ergo ante omne 
-            <lb ed="#V" n="20"/>instans fuit tembus: et econuersio. rgo impossibile est 
+            <lb ed="#V" n="20"/>instans fuit tempus: et econuersio. rgo impossibile est 
             <lb ed="#V" n="21"/>dare primum insitans temporis et si sic tempus fuit 
             abe<lb ed="#V" n="22" break="no"/>ternon. Sedtempus non fuit ante mundum. Ergo 
             mun<lb ed="#V" n="23" break="no"/>qus suit ab aeterno.
           </p>
           <p xml:id="kzz7yh-f02923-d1e829">
-            ¶ Item quam modo opatur et antea 
+            ¶ Item quam modo operatur et antea 
             <lb ed="#V" n="24"/>non oprabatu: exiuit nouiter deum potentam in actum. 
             Si<lb ed="#V" n="25" break="no"/>ergo deus creasset mundum et non ab aeterno: nouitetr 
             <lb ed="#V" n="26"/>exiuisset de potentia in actum. Sed impossibile est 
-            ali<lb ed="#V" n="27" break="no"/>quam dei botentiuam esse nouiter in actum feductum. 
+            ali<lb ed="#V" n="27" break="no"/>quam dei potentiuam esse nouiter in actum feductum. 
             r<lb ed="#V" n="28" break="no"/>deus ab aeterno creauit mundum.
           </p>
           <p xml:id="kzz7yh-f02923-d1e842">
             ¶ Item si deus 
-            <lb ed="#V" n="29"/>non droduxit mundum ab eterno: et poste produtit: 
+            <lb ed="#V" n="29"/>non produxit mundum ab eterno: et poste produtit: 
             <lb ed="#V" n="30"/>videtur quod acciderit in voluntate eius quedam 
             renoua<lb ed="#V" n="31" break="no"/>tio quare tunc prduterit et anteua non producebat. Sed 
-            <lb ed="#V" n="32"/>renouationem accidere in diuma uoluntate est 
-            immposi<lb ed="#V" n="33" break="no"/>bile. Irgo cum deus mundum produterit. ab 
+            <lb ed="#V" n="32"/>renouationem accidere in diuina uoluntate est 
+            immposi<lb ed="#V" n="33" break="no"/>bile. Ergo cum deus mundum produterit. ab 
             aeter<lb ed="#V" n="34" break="no"/>no produxit. 
           </p>
           <p xml:id="kzz7yh-f02923-d1e858">
             <lb ed="#V" n="35"/>Contra si fuisset aliqu materia ab aeterno: 
             <lb ed="#V" n="36"/>de lla non potuisset 
-            mun<lb ed="#V" n="37" break="no"/>dus fieri ab eterno vt probabo. Sed ita cito potuiset 
+            mun<lb ed="#V" n="37" break="no"/>dus fieri ab eterno vt probabo. Sed ita cito potuisset 
             <lb ed="#V" n="38"/>deus mundum producere de illa materia sicut de nihilo. 
             <lb ed="#V" n="39"/>Trgo non fuit ponssibile quod deus mundum produceretur ab 
             <lb ed="#V" n="40"/>eterino. Minor plana etums. Maior probatur sic Deus 
             de<lb ed="#V" n="41" break="no"/>illa materia si mundum proqdntiset quancitius potuisset: 
-            <lb ed="#V" n="42"/>non drodutiset mundum nisi per mutationem 
+            <lb ed="#V" n="42"/>non produxisset mundum nisi per mutationem 
             insitanta<lb ed="#V" n="43" break="no"/>neam: quia redunctio materie de potentia ad actum et 
-            <lb ed="#V" n="44"/>per mutationem successiuam vel insitantaneam: et cirlus 
+            <lb ed="#V" n="44"/>per mutationem successiuam vel instantaneam: et cirlus 
             redu<lb ed="#V" n="45" break="no"/>citur der instantaneam quam per successinam.
           </p>
           <p xml:id="kzz7yh-f02923-d1e885">
             ¶ Sed 
             mu<lb ed="#V" n="46" break="no"/>tatio instantaneu non potest esse nisi in instati. ergo si 
-            de<lb ed="#V" n="47" break="no"/>us broduxisset mundum de illa materia quancitius potuis 
-            <lb ed="#V" n="48"/>seti produtisset ipsum in aliquo instanti: ante quod aliud 
+            de<lb ed="#V" n="47" break="no"/>us produxisset mundum de illa materia quancitius potuis 
+            <lb ed="#V" n="48"/>seti produxisset ipsum in aliquo instanti: ante quod aliud 
             <lb ed="#V" n="49"/>non fuisset. Ex quo sequitur quam eum ab aeterno non 
             po<lb ed="#V" n="50" break="no"/>dutisset: quiuam sua duratio aau auiud instans a parte ante 
             <lb ed="#V" n="51"/>terminata fuisset.
           </p>
           <p xml:id="kzz7yh-f02923-d1e901">
-            ¶ Item si mundus creari potursset 
-            <lb ed="#V" n="52"/>ab aeterno: potuiset deus fecisse infinitum in actu secundum 
+            ¶ Item si mundus creari potuisset 
+            <lb ed="#V" n="52"/>ab aeterno: potuisset deus fecisse infinitum in actu secundum 
             <lb ed="#V" n="53"/>multitudinem: et secundum magnitudinem: quia parirationem 
             <lb ed="#V" n="54"/>potuisset hommines ab aeterno fecisse: qui ab leterno 
             gene<lb ed="#V" n="55" break="no"/>fassent: et eorum successores usquam nunic: quo facto 
@@ -552,18 +552,18 @@
             deus<lb ed="#V" n="91" break="no"/>creasset mundum ab aeterno ex hoc secutum fuisetr 
             im<lb ed="#V" n="92" break="no"/>possibile: scilicet quod deus de necessitate mundum 
             creat<lb ed="#V" n="93" break="no"/>set hrobatum est enim in li io quod deus non potuit creatre 
-            <lb ed="#V" n="94"/>mundum de necessitate: nec de necessitate nanture: nec 
+            <lb ed="#V" n="94"/>mundum de necessitate: nec de necessitate naturae: nec 
             <lb ed="#V" n="95"/>de necessitate voluntatis. Restat ergo quam mimdum ab 
-            <lb ed="#V" n="96"/>eterno creati fuit impossibile. Quod autalem deus 
-            mun<lb ed="#V" n="97" break="no"/>dum de necessitate creasset: si ibsum ab aeterno 
-            creas<lb ed="#V" n="98" break="no"/>set: batet sic: quia non potuisset iposum non creare 
-            quan<lb ed="#V" n="99" break="no"/>duo creabat: quia secundum phiosehum i. liro derar. omne quam est: 
+            <lb ed="#V" n="96"/>eterno creati fuit impossibile. Quod autem deus 
+            mun<lb ed="#V" n="97" break="no"/>dum de necessitate creasset: si ipsum ab aeterno 
+            creas<lb ed="#V" n="98" break="no"/>set: batet sic: quia non potuisset ipsum non creare 
+            quan<lb ed="#V" n="99" break="no"/>duo creabat: quia secundum philosophum i. liro derar. omne quam est: 
             quan<lb ed="#V" n="100" break="no"/>do est: nece sse est. Nec potest dici quomd dotuisfet irosum 
             <lb ed="#V" n="101"/>non creare antequam creasset: quia antem eternt m nihil. 
-            <lb ed="#V" n="102"/>mec potuisset hosum non creusse poestquam creasset qutrma 
+            <lb ed="#V" n="102"/>nec potuisset hosum non creusse poestquam creasset qutrma 
             <lb ed="#V" n="103"/>non potest facere quam illud quod factum est non fueritu factums secundum 
             <lb ed="#V" n="104"/>Augu. 26. li.: conetra Fausium. Et ita patet quam si mundum 
-            <lb ed="#V" n="105"/>ab aeterno creasset: ipesum de necessitate creasset: quod et 
+            <lb ed="#V" n="105"/>ab aeterno creasset: ipsum de necessitate creasset: quod et 
             im<lb ed="#V" n="106" break="no"/>possibile.
           </p>
           <p xml:id="kzz7yh-f02923-d1e1037">
@@ -586,13 +586,13 @@
             <lb ed="#V" n="120"/>ese creantis. Sed accipere esse ab aliqno diuersum ab 
             <lb ed="#V" n="121"/>esse dantis: est accipere esse nonum. Trgo machiam 
             mun<lb ed="#V" n="122" break="no"/>diauis non dotuit a deo creari: nisi accipiendo ab 
-            ipso<lb ed="#V" n="123" break="no"/>essenouun Sed accipere esse nouum et ibsum 
+            ipso<lb ed="#V" n="123" break="no"/>essenouun Sed accipere esse nouum et ipsum 
             accipe<lb ed="#V" n="124" break="no"/>reab aeterno repugnancia sunt. nouitas enum repugnant 
             <lb ed="#V" n="125"/>eterne durationi: et ideo non fuit possibile machimam 
             <lb ed="#V" n="126"/>mundialem ab aeterno creari.
           </p>
           <p xml:id="kzz7yh-f02923-d1e1086">
-            ¶ Pbreterea hoc videt 
+            ¶ Praeterea hoc videt 
             in<lb ed="#V" n="127" break="no"/>ciudi in signato creationis: quimam creari est accipere esse 
             <lb ed="#V" n="128"/>non de aliquo hoc autem autur significat idem quam habere 
             <lb ed="#V" n="129"/>esse non de aliquo ab aliqus: aut nunc primo habere efse 
@@ -602,8 +602,8 @@
             ¶ Non primo modo vt videtur: 
             <lb ed="#V" n="131"/>quia cum creatura quamdium est sit ab alio: si non de aliquo 
             <lb ed="#V" n="132"/>semper crearetur quamdiu est: quom suisum est. Tunc eturim 
-            <lb ed="#V" n="133"/>nihil aliud esset ipbosum conseruari quam ipsam creatri: 
-            <lb ed="#V" n="134"/>quoqd ante improbatum est.
+            <lb ed="#V" n="133"/>nihil aliud esset ipsum conseruari quam ipsam creatri: 
+            <lb ed="#V" n="134"/>quod ante improbatum est.
           </p>
           <p xml:id="kzz7yh-f02923-d1e1108">
             ¶ Restant ergo quod 

--- a/kzz7yh-f02923/cod-ve09v2_kzz7yh-f02923.xml
+++ b/kzz7yh-f02923/cod-ve09v2_kzz7yh-f02923.xml
@@ -138,7 +138,7 @@
             <lb ed="#V" n="80"/>Ad primum in oppositum cum dicitur quod que 
             <lb ed="#V" n="81"/>sunt in mundo terminantur ine 
             mun<lb ed="#V" n="82" break="no"/>do etc. Dico quod intelligendum est de rebus quae fiunt in 
-            mun<lb ed="#V" n="83" break="no"/>do per virtutis createm operationem.
+            mun<lb ed="#V" n="83" break="no"/>do per virtutis create operationem.
           </p>
           <p xml:id="kzz7yh-f02923-d1e255">
             ¶ Ad secundum 
@@ -147,7 +147,7 @@
             man<lb ed="#V" n="86" break="no"/>tura enim creata: non sic postest dare permanentam sine 
             <lb ed="#V" n="87"/>sine: effectibus suis: sicut virtus increatra. Mundialis autem 
             <lb ed="#V" n="88"/>machina facta est per virtutem increatam. Predictum 
-            au<lb ed="#V" n="89" break="no"/>tem verbum hilosophyum. intelligit de effectibus virtutis createm. 
+            au<lb ed="#V" n="89" break="no"/>tem verbum hilosophyum. intelligit de effectibus virtutis create. 
             <lb ed="#V" n="90"/>c Ad tertium dico quam minor falsa est vnde Augu. 1 de 
             <lb ed="#V" n="91"/>ciui. capi quinto mundus ipse ordinatissima suam 
             mutabi<lb ed="#V" n="92" break="no"/>litate est mobilitate: et visibilum omnium puichertima 
@@ -218,7 +218,7 @@
           </p>
           <p xml:id="kzz7yh-f02923-d1e391">
             ¶ 
-            Ddi<lb ed="#V" n="134" break="no"/>cergo adquestionem quam ista machina mundialis: sactua est 
+            Ddi<lb ed="#V" n="134" break="no"/>ergo ad quaestionem quam ista machina mundialis: sactua est 
             <lb ed="#V" n="135"/>de nihilo: deus enim non tantum est causamundialis 
             ma<lb ed="#V" n="136" break="no"/>chine vel cuiuscumque alterius creature sub rationem qum 
             <lb ed="#V" n="137"/>esi haec ens: vtpote subtatione qua est huius speciei vel un¬ 
@@ -436,7 +436,7 @@
             magnan<lb ed="#V" n="8" break="no"/>vt vtrum mundus sit eternus vel non. Sed si non 
             fuis<lb ed="#V" n="9" break="no"/>set possibile mundum esse ab aeterno: haberemus 
             neces<lb ed="#V" n="10" break="no"/>sarium rationem ad probandum ipsum ab eterno 
-            nonn<lb ed="#V" n="11" break="no"/>fuisse. sergo fuit possibile ipsum ab aeterno creari.
+            nonn<lb ed="#V" n="11" break="no"/>fuisse. Ergo fuit possibile ipsum ab aeterno creari.
           </p>
           <p xml:id="kzz7yh-f02923-d1e797">
             ¶ Item 
@@ -444,8 +444,8 @@
             <lb ed="#V" n="13"/>potuit esse nisi ab alio: quia filius dei non potuit esse 
             ni<lb ed="#V" n="14" break="no"/>um ab alio scilicet a putre: et tamen est ab aeterno non 
             quam<lb ed="#V" n="15" break="no"/>non poterat fieri nisi de nihilo. Quia ita cito deus 
-            po<lb ed="#V" n="16" break="no"/>test operari de nihilo: sicut de aliquo. sergo nulla et 
-            rtmo<lb ed="#V" n="17" break="no"/>quarem non potuerit esse ab eterno.
+            po<lb ed="#V" n="16" break="no"/>test operari de nihilo: sicut de aliquo. Ergo nulla et 
+            ratio<lb ed="#V" n="17" break="no"/>quarem non potuerit esse ab eterno.
           </p>
           <p xml:id="kzz7yh-f02923-d1e813">
             ¶ Item instans 
@@ -488,7 +488,7 @@
           </p>
           <p xml:id="kzz7yh-f02923-d1e885">
             ¶ Sed 
-            mu<lb ed="#V" n="46" break="no"/>tatio instantaneu non potest esse nisi in instati. ergo si 
+            mu<lb ed="#V" n="46" break="no"/>tatio instantaneu non potest esse nisi in instanti. ergo si 
             de<lb ed="#V" n="47" break="no"/>us produxisset mundum de illa materia quancitius potuis 
             <lb ed="#V" n="48"/>seti produxisset ipsum in aliquo instanti: ante quod aliud 
             <lb ed="#V" n="49"/>non fuisset. Ex quo sequitur quam eum ab aeterno non 
@@ -504,7 +504,7 @@
             actu<lb ed="#V" n="56" break="no"/>essent infinite anime rationales cum sint incorruptibiles. 
           </p>
           <p xml:id="kzz7yh-f02923-d1e914">
-            <lb ed="#V" n="57"/>¶ Pari etratione potuisset caelum ab aeternom mouisse 
+            <lb ed="#V" n="57"/>¶ Pari etiam ratione potuisset caelum ab aeternom mouisse 
             <lb ed="#V" n="58"/>contimue usquam nunc et in qumalibet reuolutione vanum 
             <lb ed="#V" n="59"/>sapidem creausse: et ilios postea in vnum coniuntisse: quo 
             <lb ed="#V" n="60"/>facto esset actu infinitum im magnitudine. Sed in primo 
@@ -529,7 +529,7 @@
             <lb ed="#V" n="74"/>se tantum in accipiendo esse vel fieri: ergo similiter 
             <lb ed="#V" n="75"/>non fuit possibile quod faceret infinitos dies parteritos in 
             <lb ed="#V" n="76"/>accepto esse: sed tantummodo in accipiendo. Restatu 
-            <lb ed="#V" n="77"/>ergonm quod non fuit possibile quod mundus ab aeterno 
+            <lb ed="#V" n="77"/>ergo quod non fuit possibile quod mundus ab aeterno 
             crea<lb ed="#V" n="78" break="no"/>retur
           </p>
           <p xml:id="kzz7yh-f02923-d1e971">
@@ -551,25 +551,25 @@
             posi<lb ed="#V" n="90" break="no"/>to in effeus nulilum sequitur impossibile. Sed si 
             deus<lb ed="#V" n="91" break="no"/>creasset mundum ab aeterno ex hoc secutum fuisetr 
             im<lb ed="#V" n="92" break="no"/>possibile: scilicet quod deus de necessitate mundum 
-            creat<lb ed="#V" n="93" break="no"/>set hrobatum est enim in li io quod deus non potuit creatre 
+            creat<lb ed="#V" n="93" break="no"/>set Probatum est enim in li io quod deus non potuit creatre 
             <lb ed="#V" n="94"/>mundum de necessitate: nec de necessitate naturae: nec 
-            <lb ed="#V" n="95"/>de necessitate voluntatis. Restat ergo quam mimdum ab 
+            <lb ed="#V" n="95"/>de necessitate voluntatis. Restat ergo quam <sic>mumdum</sic> ab 
             <lb ed="#V" n="96"/>eterno creati fuit impossibile. Quod autem deus 
             mun<lb ed="#V" n="97" break="no"/>dum de necessitate creasset: si ipsum ab aeterno 
             creas<lb ed="#V" n="98" break="no"/>set: batet sic: quia non potuisset ipsum non creare 
             quan<lb ed="#V" n="99" break="no"/>duo creabat: quia secundum philosophum i. liro derar. omne quam est: 
-            quan<lb ed="#V" n="100" break="no"/>do est: nece sse est. Nec potest dici quomd dotuisfet irosum 
+            quan<lb ed="#V" n="100" break="no"/>do est: necesse est. Nec potest dici quod potuisset ipsum 
             <lb ed="#V" n="101"/>non creare antequam creasset: quia antem eternt m nihil. 
             <lb ed="#V" n="102"/>nec potuisset hosum non creusse poestquam creasset qutrma 
             <lb ed="#V" n="103"/>non potest facere quam illud quod factum est non fueritu factums secundum 
-            <lb ed="#V" n="104"/>Augu. 26. li.: conetra Fausium. Et ita patet quam si mundum 
+            <lb ed="#V" n="104"/>Augu. 26. li.: contra Faustum. Et ita patet quam si mundum 
             <lb ed="#V" n="105"/>ab aeterno creasset: ipsum de necessitate creasset: quod et 
             im<lb ed="#V" n="106" break="no"/>possibile.
           </p>
           <p xml:id="kzz7yh-f02923-d1e1037">
             ¶ Item si potuisset deus hunc mundum 
             si<lb ed="#V" n="107" break="no"/>gnatum ab aeterno creasse: pari ratione vnum equum 
-            si<lb ed="#V" n="108" break="no"/>gnatum et vnderam equam signatam potentes geerare. 
+            si<lb ed="#V" n="108" break="no"/>gnatum et vnam equam signatam potentes geerare. 
             <lb ed="#V" n="109"/>et facere quam iuia generatio ab vno in aliam conitinuata 
             <lb ed="#V" n="110"/>fuisset videotuam nunec. Et sic facere potuisset: quad inter equum 
             <lb ed="#V" n="111"/>ante quem non fuisset alius: et equum quil modo est 

--- a/kzz7yh-f02923/cod-ve09v2_kzz7yh-f02923.xml
+++ b/kzz7yh-f02923/cod-ve09v2_kzz7yh-f02923.xml
@@ -218,7 +218,7 @@
           </p>
           <p xml:id="kzz7yh-f02923-d1e391">
             ¶ 
-            Ddi<lb ed="#V" n="134" break="no"/>ergo ad quaestionem quam ista machina mundialis: sactua est 
+            co<lb ed="#V" n="134" break="no"/>ergo ad quaestionem quam ista machina mundialis: facta est 
             <lb ed="#V" n="135"/>de nihilo: deus enim non tantum est causamundialis 
             ma<lb ed="#V" n="136" break="no"/>chine vel cuiuscumque alterius creature sub rationem qum 
             <lb ed="#V" n="137"/>esi haec ens: vtpote subtatione qua est huius speciei vel un¬ 


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve09v2_kzz7yh-f02923.xml`.

## Applied changes

- p. 5r l. 50: cortumpetur → corrumpetur: t/r transposition
- p. 5r l. 73: sacta → facta: s/f misread
- p. 5r l. 92: omium → omnium: missing n
- p. 5r l. 110: fueritr → fuerit: extra r
- p. 5r l. 117: phlosophus → philosophus: l/i misread
- p. 5r l. 131: sacta → facta: s/f misread
- p. 6r l. 6: plosbophus → philosophus: garbled word
- p. 6r l. 20: tembus → tempus: b/p misread
- p. 6r l. 23: opatur → operatur: missing er
- p. 6r l. 27: botentiuam → potentiuam: b/p misread
- p. 6r l. 29: non droduxit mundum ab eterno: et poste produtit: → non produxit mundum ab eterno: et poste produtit:: d/p misread at word start
- p. 6r l. 32: diuma → diuina: missing i
- p. 6r l. 33: Irgo → Ergo: I/T misread for E at word start
- p. 6r l. 37: potuiset → potuisset: missing s
- p. 6r l. 42: drodutiset → produxisset: d/p misread at word start
- p. 6r l. 44: insitantaneam → instantaneam: spurious i
- p. 6r l. 47: us broduxisset mundum de illa materia quancitius potuis → us produxisset mundum de illa materia quancitius potuis: d/p misread at word start
- p. 6r l. 48: produtisset → produxisset: t/x misread
- p. 6r l. 51: potursset → potuisset: r/i misread
- p. 6r l. 52: potuiset → potuisset: missing s
- p. 6r l. 94: nanture → naturae: garbled word
- p. 6r l. 96: autalem → autem: garbled word
- p. 6r l. 97: ibsum → ipsum: garbled word
- p. 6r l. 98: iposum → ipsum: garbled word
- p. 6r l. 99: phiosehum → philosophum: garbled word
- p. 6r l. 102: mec → nec: m/n misread
- p. 6r l. 105: ipesum → ipsum: garbled word
- p. 6r l. 123: ibsum → ipsum: garbled word
- p. 6r l. 126: Pbreterea → Praeterea: garbled Pr-
- p. 6r l. 133: ipbosum → ipsum: garbled word
- p. 6r l. 134: quoqd → quod: spurious q

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_