### PR TITLE
Transcription corrections: cod-ve09v2_kzz7yh-f04172.xml (8 changes)

### DIFF
--- a/kzz7yh-f04172/cod-ve09v2_kzz7yh-f04172.xml
+++ b/kzz7yh-f04172/cod-ve09v2_kzz7yh-f04172.xml
@@ -127,7 +127,7 @@
             <lb ed="#V" n="123"/>potest in omnia bona. Ergo omnia bona a deo sunt. 
           </p>
           <p xml:id="kzz7yh-f04172-d1e218">
-            <lb ed="#V" n="124"/>Respondeo quoomnes creature sunt ab vno 
+            <lb ed="#V" n="124"/>Respondeo quod omnes creature sunt ab vno 
             <lb ed="#V" n="125"/>principio quod deus est: quamuis enim 
             <lb ed="#V" n="126"/>secundaria principia possint esse multa: non tamen 
             po<lb ed="#V" n="127" break="no"/>tuit esse nisi vnum principium primum. Quod sic patet. 
@@ -142,7 +142,7 @@
           <p xml:id="kzz7yh-f04172-d1e244">
             <lb ed="#V" n="135"/>Ad primum in oppositum cum dicitur. Uenit princeps mundi huius etc. 
             <lb ed="#V" n="136"/>dico quod mundus potest accipi quadrupliciter. 
-            <lb ed="#V" n="137"/>¶ino modo deninee. 
+            <lb ed="#V" n="137"/>¶ino modo denique. 
             <!--00027.xml-->
             <pb ed="#V" n="7-r"/>
             <cb ed="#P" n="a"/>
@@ -263,7 +263,7 @@
             ordina<lb ed="#V" n="66" break="no"/>biles sunt in deum ergo omnes immediate sunt a deo. 
           </p>
           <p xml:id="kzz7yh-f04172-d1e455">
-            <lb ed="#V" n="67"/>¶ Item Gnen I in principio creauit deus celum et terram: 
+            <lb ed="#V" n="67"/>¶ Item Genesim I in principio creauit deus celum et terram: 
             er<lb ed="#V" n="68" break="no"/>go immediate sunt a deo. Sed caelum et terra sunt duo. er. 
             <!--00027.xml-->
             <cb ed="#P" n="b"/>
@@ -564,7 +564,7 @@
             <lb ed="#V" n="133"/>aliquo principio possibili quod sit in sole tamen non 
             produ<lb ed="#V" n="134" break="no"/>citur de nihilo: quia per virtutem lucis existentis in 
             so<lb ed="#V" n="135" break="no"/>le educitur de potentia medii similitudo eius que est lumen 
-            <lb ed="#V" n="136"/>ita quod primo reducitur ad actum illa pars mediii quae contiguatur 
+            <lb ed="#V" n="136"/>ita quod primo reducitur ad actum illa pars <sic>mediii</sic> quae contiguatur 
             soli<lb ed="#V" n="137" break="no"/>et mediate 
             <!--00029.xml-->
             <pb ed="#V" n="8-r"/>
@@ -589,7 +589,7 @@
           </p>
           <p xml:id="kzz7yh-f04172-d1e1045">
             ¶ Dico quod 
-            intelligen<lb ed="#V" n="11" break="no"/>dum est in giniali bus et corruptibilibus. quandoque enim aliquid 
+            intelligen<lb ed="#V" n="11" break="no"/>dum est in generali bus et corruptibilibus. quandoque enim aliquid 
             per<lb ed="#V" n="12" break="no"/>fectionis est in natura inferiori: quod non est perfectionis in 
             <lb ed="#V" n="13"/>nam superiori. Sicut iracundum esse perfectionis est in cane 
             <lb ed="#V" n="14"/>non tamen in homine.

--- a/kzz7yh-f04172/cod-ve09v2_kzz7yh-f04172.xml
+++ b/kzz7yh-f04172/cod-ve09v2_kzz7yh-f04172.xml
@@ -589,7 +589,8 @@
           </p>
           <p xml:id="kzz7yh-f04172-d1e1045">
             ¶ Dico quod 
-            intelligen<lb ed="#V" n="11" break="no"/>dum est in generalibus et corruptibilibus. quandoque enim al<lb ed="#V" n="12" break="no"/>fectionis est in natura inferiori: quod non est perfectionis in 
+            intelligen<lb ed="#V" n="11" break="no"/>dum est in generalibus et corruptibilibus. quandoque enim aliquid 
+            per<lb ed="#V" n="12" break="no"/>fectionis est in natura inferiori: quod non est perfectionis in 
             <lb ed="#V" n="13"/>nam superiori. Sicut iracundum esse perfectionis est in cane 
             <lb ed="#V" n="14"/>non tamen in homine.
           </p>

--- a/kzz7yh-f04172/cod-ve09v2_kzz7yh-f04172.xml
+++ b/kzz7yh-f04172/cod-ve09v2_kzz7yh-f04172.xml
@@ -128,7 +128,7 @@
           </p>
           <p xml:id="kzz7yh-f04172-d1e218">
             <lb ed="#V" n="124"/>Respondeo quoomnes creature sunt ab vno 
-            <lb ed="#V" n="125"/>pincipio quod deus est: quamuis enim 
+            <lb ed="#V" n="125"/>principio quod deus est: quamuis enim 
             <lb ed="#V" n="126"/>secundaria principia possint esse multa: non tamen 
             po<lb ed="#V" n="127" break="no"/>tuit esse nisi vnum principium primum. Quod sic patet. 
             Si<lb ed="#V" n="128" break="no"/>essent duo principia creaturarum: quorum vnum non 
@@ -181,7 +181,7 @@
             <lb ed="#V" n="17"/>dicitur quod regnum meum non est de hoc mundo etc. Sic 
             expo<lb ed="#V" n="18" break="no"/>ni debet non sum rex eo modo quo de rege intenditis: 
             ha<lb ed="#V" n="19" break="no"/>bendo in hoc mundo possessiones temporales et honores ad 
-            va<lb ed="#V" n="20" break="no"/>nam gluriam: et homines ministros ad expugnandum 
+            va<lb ed="#V" n="20" break="no"/>nam gloriam: et homines ministros ad expugnandum 
             inimi<lb ed="#V" n="21" break="no"/>cos meos corporalibus armis. quasi non possem me 
             vin<lb ed="#V" n="22" break="no"/>dicare sine illis. Sed in hoc mundo regno per omnipotentiam: 
             <lb ed="#V" n="23"/>quam in me non aduertitis.
@@ -194,7 +194,7 @@
           <p xml:id="kzz7yh-f04172-d1e335">
             ¶ Ad tertium dicendum quod apostolus loquitur de 
             <lb ed="#V" n="26"/>deo equoce. vocans diabolum dominum huius seculi per quandam 
-            si<lb ed="#V" n="27" break="no"/>militudinem: propter boc quod magnum principatum habet super 
+            si<lb ed="#V" n="27" break="no"/>militudinem: propter hoc quod magnum principatum habet super 
             va<lb ed="#V" n="28" break="no"/>nam conuersationem peccatorum quae ibi nomine seculi designatur. 
           </p>
           <p xml:id="kzz7yh-f04172-d1e344">
@@ -209,7 +209,7 @@
             <lb ed="#V" n="35"/>¶ Ad. 4. cum dicitur nolite diligere mundum etc. dicund quod ibi: 
             <lb ed="#V" n="36"/>accipitur mundus pro conuersatione in peccatis. quie inquantum talis 
             <lb ed="#V" n="37"/>a deo non est. nec ex hoc sequitur quin omnes creature a 
-            deo<lb ed="#V" n="38" break="no"/>sint. quia vt dictum est: deformitas peccati non est ereatura 
+            deo<lb ed="#V" n="38" break="no"/>sint. quia vt dictum est: deformitas peccati non est creatura 
           </p>
           <p xml:id="kzz7yh-f04172-d1e371">
             <lb ed="#V" n="39"/>¶ Ad. 5. dicendum quod quamuis deus sit immutabilis: tamen secundum diuersum 
@@ -318,12 +318,12 @@
             <lb ed="#V" n="105"/>Si non: tunc. non est verum quod. 9. metahce. c. 4. dixit scilicet quod 
             <lb ed="#V" n="106"/>si ex intelligentia prouenit essentia multitudinis. hoc etiam 
             <lb ed="#V" n="107"/>propter multitudinem intentionum quae sunt in ea: et praeterea quae ratione: 
-            <lb ed="#V" n="108"/>maior mltitudo potest oriri ex minori multitudine. 
+            <lb ed="#V" n="108"/>maior multitudo potest oriri ex minori multitudine. 
             pari<lb ed="#V" n="109" break="no"/>ratione pauca multitudo posset immediate oriri ex vnitate. 
             <lb ed="#V" n="110"/>et sic ad hoc sequaretur quod a primo principio non 
             obstan<lb ed="#V" n="111" break="no"/>te quod sit summe vnum: potuerit aliqua plura procedere 
             immedia<lb ed="#V" n="112" break="no"/>te. Si autem dicatur quod in intelligentia quam dixit causam octaue 
-            <lb ed="#V" n="113"/>spere sit tanta mltitudo intentionum: quanta est in illa spera 
+            <lb ed="#V" n="113"/>spere sit tanta multitudo intentionum: quanta est in illa spera 
             mul<lb ed="#V" n="114" break="no"/>titudo rerum: quaro a quo est illa multitudo: in illa 
             intel<lb ed="#V" n="115" break="no"/>ligentia immediate. Si a deo plura a deo immediate 
             processe<lb ed="#V" n="116" break="no"/>runt quod ipse Auicem. negat. Si a se ipsa tunc autem est a se 
@@ -494,7 +494,7 @@
           <head xml:id="kzz7yh-f04172-Hd1e886" type="question-title">Utrum aliquid possit creari ab aliquo principio creato</head>
           <p xml:id="kzz7yh-f04172-d1e871">
             ¶ Quaestio IIII. 
-            <lb ed="#V" n="84"/>Uarto queritur vtrum aliquid possit creari ab 
+            <lb ed="#V" n="84"/>Quarto queritur vtrum aliquid possit creari ab 
             <lb ed="#V" n="85"/>aliquo principio creato. Et videtur 
             <lb ed="#V" n="86"/>quod sic. Quia lumen producitur a sole non de 
             sub<lb ed="#V" n="87" break="no"/>stantia solis nec de aliquo principio possibili quod 
@@ -550,7 +550,7 @@
             il<lb ed="#V" n="121" break="no"/>lo. supposita equali mora vtriusque operationis. Cum ergo 
             <lb ed="#V" n="122"/>non aliquid nullam penitus propinquitatem nec 
             propor<lb ed="#V" n="123" break="no"/>tionem hanc ad ens: et factio non de aliquo sicut in instanti: quia 
-            <lb ed="#V" n="124"/>nullum potest esse medium inter ens et non ens: Necenrium est 
+            <lb ed="#V" n="124"/>nullum potest esse medium inter ens et non ens: Necessarium est 
             po<lb ed="#V" n="125" break="no"/>tentiam que facit aliquid non de aliquo in infinitum excedere in 
             <lb ed="#V" n="126"/>vigorem omnem potentiam que non potest facere aliquid non de 
             ali<lb ed="#V" n="127" break="no"/>quo. Ad quod sequatur potentiam que potest facere aliquid non 

--- a/kzz7yh-f04172/cod-ve09v2_kzz7yh-f04172.xml
+++ b/kzz7yh-f04172/cod-ve09v2_kzz7yh-f04172.xml
@@ -142,7 +142,7 @@
           <p xml:id="kzz7yh-f04172-d1e244">
             <lb ed="#V" n="135"/>Ad primum in oppositum cum dicitur. Uenit princeps mundi huius etc. 
             <lb ed="#V" n="136"/>dico quod mundus potest accipi quadrupliciter. 
-            <lb ed="#V" n="137"/>¶ino modo denique. 
+            <lb ed="#V" n="137"/>¶ Uno odo pro vniuerso. 
             <!--00027.xml-->
             <pb ed="#V" n="7-r"/>
             <cb ed="#P" n="a"/>
@@ -589,8 +589,7 @@
           </p>
           <p xml:id="kzz7yh-f04172-d1e1045">
             ¶ Dico quod 
-            intelligen<lb ed="#V" n="11" break="no"/>dum est in generali bus et corruptibilibus. quandoque enim aliquid 
-            per<lb ed="#V" n="12" break="no"/>fectionis est in natura inferiori: quod non est perfectionis in 
+            intelligen<lb ed="#V" n="11" break="no"/>dum est in generalibus et corruptibilibus. quandoque enim al<lb ed="#V" n="12" break="no"/>fectionis est in natura inferiori: quod non est perfectionis in 
             <lb ed="#V" n="13"/>nam superiori. Sicut iracundum esse perfectionis est in cane 
             <lb ed="#V" n="14"/>non tamen in homine.
           </p>


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve09v2_kzz7yh-f04172.xml`.

## Applied changes

- p. 6v l. 125: pincipio → principio: missing r
- p. 7r l. 20: gluriam → gloriam: u/o misread
- p. 7r l. 27: boc → hoc: b/h misread
- p. 7r l. 38: ereatura → creatura: missing initial c
- p. 7r l. 108: mltitudo → multitudo: missing u
- p. 7r l. 113: mltitudo → multitudo: missing u
- p. 7v l. 84: Uarto → Quarto: U/Q misread at word start
- p. 7v l. 124: Necenrium → Necessarium: garbled word

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_