### PR TITLE
Transcription corrections: cod-ve09v2_kzz7yh-f06180.xml (8 changes)

### DIFF
--- a/kzz7yh-f06180/cod-ve09v2_kzz7yh-f06180.xml
+++ b/kzz7yh-f06180/cod-ve09v2_kzz7yh-f06180.xml
@@ -66,9 +66,9 @@
           nana<lb ed="#V" n="111" break="no"/>quam tria initia estimauit: deum scilicet et exemplar et materiam haec etiam 
           <lb ed="#V" n="112"/>imponit sibi apuleius in primo libro de dogmate platonis: 
           di<lb ed="#V" n="113" break="no"/>cens initia rerum terra esse: arbitratur plato: deum: et 
-          mate<lb ed="#V" n="114" break="no"/>riam rerum formas quas vdeas idem vocat. Inponendo 
+          mate<lb ed="#V" n="114" break="no"/>riam rerum formas quas ydeas idem vocat. Inponendo 
           ma<lb ed="#V" n="115" break="no"/>teriam esse principium non principatum errauit: quia creata 
-          <lb ed="#V" n="116"/>est a deo: vt superius ostensum est. In ponendo vdeas etiam 
+          <lb ed="#V" n="116"/>est a deo: vt superius ostensum est. In ponendo ydeas etiam 
           <lb ed="#V" n="117"/>errauit: si non intellexit eas esse immediate diuina 
           intrin<lb ed="#V" n="118" break="no"/>secus existentes. Ut actus proprii dici non queat: supple 
           lo<lb ed="#V" n="119" break="no"/>quendo: de actione radicata in motu. vnde statim subiugit sic 
@@ -98,7 +98,7 @@
           <cb ed="#P" n="a"/>
           <lb ed="#V" n="1"/>xit. Si autem opiniatus est mundum esse ab eterno errauit. quia 
           <lb ed="#V" n="2"/>
-          <lb ed="#V" n="3"/>bonus est deus sumus: quia licet nos secit propter suam homnitatem: 
+          <lb ed="#V" n="3"/>bonus est deus sumus: quia scilicet nos fecit propter suam bonitatem: 
           non<lb ed="#V" n="4" break="no"/>tamen ex necessitate: sed ex libera voluntatem: et quamuis fuerit 
           po<lb ed="#V" n="5" break="no"/>nus ab aeterno: non tamen praeter hoc sequtur quam nos feceritur ab aeterno 
           <lb ed="#V" n="6"/>quia et ab aeterno est pntra hramienem creatutur e: sed fecit nos quande 
@@ -110,13 +110,13 @@
           natu<lb ed="#V" n="12" break="no"/>ra iuuorum horium: quod secundum diuersa eorum merita assumunitur aud 
           <lb ed="#V" n="13"/>diuersions ordines angelorum. secundum illud <ref xml:id="kzz7yh-f06180-Rd1e219">Mat. 22</ref> erunt sicut 
           <lb ed="#V" n="14"/>angeli dei in celo. nolumus corpore expoliari. 
-          <lb ed="#V" n="15"/>ontra abouolus ditebat de te: quad eratur desiderium 
+          <lb ed="#V" n="15"/>contra apostolus ditebat de te: quad eratur desiderium 
           <lb ed="#V" n="16"/>habens difolui et eie cumn christo. 
         </p>
         <p xml:id="kzz7yh-f06180-d1e226">
           <lb ed="#V" n="17"/>Respondeo quod verbum aposioi: quaodm ub agiser 
           <lb ed="#V" n="18"/>Ilengat in litrtera: intelligitur de 
-          vo<lb ed="#V" n="19" break="no"/>luntate naturali. Sed vertrum suum ad Philip de voluntate 
+          vo<lb ed="#V" n="19" break="no"/>luntate naturali. Sed verbum suum ad Philip de voluntate 
           <lb ed="#V" n="20"/>deliberatiua: tribartite creature clice pure spriualis et pure 
           cor<lb ed="#V" n="21" break="no"/>poralis et ptim corporalis: et pnitim spbirisualis: 
         </p>

--- a/kzz7yh-f06180/cod-ve09v2_kzz7yh-f06180.xml
+++ b/kzz7yh-f06180/cod-ve09v2_kzz7yh-f06180.xml
@@ -72,27 +72,27 @@
           <lb ed="#V" n="117"/>errauit: si non intellexit eas esse immediate diuina 
           intrin<lb ed="#V" n="118" break="no"/>secus existentes. Ut actus proprii dici non queat: supple 
           lo<lb ed="#V" n="119" break="no"/>quendo: de actione radicata in motu. vnde statim subiugit sic 
-          <lb ed="#V" n="120"/>cum videliet actus omnis in motu consistat. Quod intelligendum est 
+          <lb ed="#V" n="120"/>cum videlicet actus omnis in motu consistat. Quod intelligendum est 
           <lb ed="#V" n="121"/>de actione qui est ab agente in passo sicut in subiecto. Aristo. vero 
           <lb ed="#V" n="122"/>duo principia scilicet materiam: et speciem: et tertium operatorium dictum. 
         </p>
         <p xml:id="kzz7yh-f06180-d1e149">
           <lb ed="#V" n="123"/>Contra primo philosophy. ponit tria principia scilicet materiam 
-          <lb ed="#V" n="124"/>rormam et priuationem. 
+          <lb ed="#V" n="124"/>formam et priuationem. 
         </p>
         <p xml:id="kzz7yh-f06180-d1e156">
           <lb ed="#V" n="125"/>Respondeo quod sub specie et materia intelligitur 
           ter<lb ed="#V" n="126" break="no"/>tium scilicet priuatio: quia reducitur ad materiam. 
-          <lb ed="#V" n="127"/>Unde dicit primo philosophy. quod principia quodammo sunt tria: quodam 
+          <lb ed="#V" n="127"/>Unde dicit primo philosophy. quod principia quodammodo sunt tria: quodam 
           <lb ed="#V" n="128"/>modo duo: quia priuatio vno modo numeratur contra materiam: alio modo non: 
-          <lb ed="#V" n="129"/>ethoc inferius loco suo magis explanabitur domino concedente. Sed 
+          <lb ed="#V" n="129"/>et hoc inferius loco suo magis explanabitur domino concedente. Sed 
           <lb ed="#V" n="130"/>inter illa duo principia quae sunt materia: et forma: priuatio non 
           inten<lb ed="#V" n="131" break="no"/>debat numerare efficiens primum: et si illa principia de quibus 
-          <lb ed="#V" n="132"/>ibi loqutur: intellexit non esse prima simpliciter: sed in 
-          gene<lb ed="#V" n="133" break="no"/>re: etilla esse creata a deo: bene intellexit. Si autem 
+          <lb ed="#V" n="132"/>ibi loquitur: intellexit non esse prima simpliciter: sed in 
+          gene<lb ed="#V" n="133" break="no"/>re: et illa esse creata a deo: bene intellexit. Si autem 
           contra<lb ed="#V" n="134" break="no"/>rium opinatus est: errauit Mundum quoque semper esse: et 
           fuis<lb ed="#V" n="135" break="no"/>se. si hoc dicendo intellexit. mundum fuisse a principio temporis ita 
-          <lb ed="#V" n="136"/>vt li semper non distribuat nisi produratione temporali: bene intelle¬ 
+          <lb ed="#V" n="136"/>vt li semper non distribuat nisi pro duratione temporali: bene intelle¬ 
           <!--00032.xml-->
           <pb ed="#V" n="9-v"/>
           <cb ed="#P" n="a"/>
@@ -100,7 +100,7 @@
           <lb ed="#V" n="2"/>
           <lb ed="#V" n="3"/>bonus est deus sumus: quia licet nos secit propter suam homnitatem: 
           non<lb ed="#V" n="4" break="no"/>tamen ex necessitate: sed ex libera voluntatem: et quamuis fuerit 
-          po<lb ed="#V" n="5" break="no"/>nus ab aeterno: non tamen praoster hoc sequtur quam nos feceritur ab aeterno 
+          po<lb ed="#V" n="5" break="no"/>nus ab aeterno: non tamen praeter hoc sequtur quam nos feceritur ab aeterno 
           <lb ed="#V" n="6"/>quia et ab aeterno est pntra hramienem creatutur e: sed fecit nos quande 
           vo<lb ed="#V" n="7" break="no"/>iuit. Eum queritur ad quid facta sit rationalis creatura 
           breuiffi<lb ed="#V" n="8" break="no"/>me responderi hotest: hromes dei bonitatem scilicetamquam propter vitimum fintem: 


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve09v2_kzz7yh-f06180.xml`.

## Applied changes

- p. 9r l. 120: videliet → videlicet: missing c
- p. 9r l. 124: rormam → formam: r/f misread at word start
- p. 9r l. 127: quodammo → quodammodo: missing do
- p. 9r l. 129: ethoc → et hoc: missing space
- p. 9r l. 132: loqutur → loquitur: missing i
- p. 9r l. 133: etilla → et illa: missing space
- p. 9r l. 136: produratione → pro duratione: missing space
- p. 9v l. 5: praoster → praeter: garbled word

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_