### PR TITLE
Transcription corrections: cod-ve09v2_kzz7yh-f06321.xml (1 change)

### DIFF
--- a/kzz7yh-f06321/cod-ve09v2_kzz7yh-f06321.xml
+++ b/kzz7yh-f06321/cod-ve09v2_kzz7yh-f06321.xml
@@ -336,7 +336,7 @@
           so<lb ed="#V" n="97" break="no"/>luit incidentem dubitationem. ibil hoc queri solet. 
         </p>
         <p xml:id="kzz7yh-f06321-d1e622">
-          <lb ed="#V" n="98"/>CIrca hanc distictionem queruntur tria. 
+          <lb ed="#V" n="98"/>CIrca hanc distinctionem queruntur tria. 
         </p>
         <p xml:id="kzz7yh-f06321-d1e627">
           <lb ed="#V" n="99"/>¶ Primo de mensura esse 


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve09v2_kzz7yh-f06321.xml`.

## Applied changes

- p. 10r l. 98: distictionem → distinctionem: missing n

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_