### PR TITLE
Transcription corrections: cod-ve09v2_kzz7yh-f06866.xml (41 changes)

### DIFF
--- a/kzz7yh-f06866/cod-ve09v2_kzz7yh-f06866.xml
+++ b/kzz7yh-f06866/cod-ve09v2_kzz7yh-f06866.xml
@@ -366,15 +366,15 @@
             <lb ed="#V" n="49"/>dare esse alicuius euiterni quod hebeat aliquam causalitatem respectu esse 
             <lb ed="#V" n="50"/>cuiuslibet alterius euiterni: quia esse cuiuslibet euiterni est a deo 
             crea<lb ed="#V" n="51" break="no"/>tum et conseruatum immediate tantum. Et ideo non est dare esse alicuius 
-            eui<lb ed="#V" n="52" break="no"/>terni cuius duratio ita hebeat plenam rationem mensure  esse aliorum 
-            <lb ed="#V" n="53"/>euiternorum: sicut continuatio motus primi mobilis manifeste 
+            eui<lb ed="#V" n="52" break="no"/>terni cuius duratio ita hebeat plenam rationem mensure respectu esse aliorum  
+<lb ed="#V" n="53"/>euiternorum: sicut continuatio motus primi mobilis manifeste 
             no<lb ed="#V" n="54" break="no"/>bis non respectu aliorum motuum. Quia tamen inter euiterna est vnum 
             <lb ed="#V" n="55"/>cuius naturale esse est simplicius et actualius. quam esse naturale alterius 
             <lb ed="#V" n="56"/>cuiusset euiterni. Et angeli est naturali cognitione sciunt 
             ip<lb ed="#V" n="57" break="no"/>sum tenere summum gradum. inter euiterna: et comparande suum esse 
             <lb ed="#V" n="58"/>ad illud magis cognoscit quilibet naturali cognitione quam gradum 
-            es<lb ed="#V" n="59" break="no"/>sendi quo ad naturalia hebeat inter euiterna.  duratio esse illius 
-            <lb ed="#V" n="60"/>nobilissimi euiterni ad intellectum relata. quodammodo habet 
+            es<lb ed="#V" n="59" break="no"/>sendi quo ad naturalia hebeat inter euiterna. Ideo duratio esse illius  
+<lb ed="#V" n="60"/>nobilissimi euiterni ad intellectum relata. quodammodo habet 
             ra<lb ed="#V" n="61" break="no"/>tionem mensure: quamuis non plenam respectu cuiusset actualis  
             ex<lb ed="#V" n="62" break="no"/>istentiae create vniformiter se habentis: Hec autem mensura dicitur euum 
             <lb ed="#V" n="63"/>vt in praecedenti quaestione habitum est. Et ideo dici potest quod aliquo modo est 
@@ -391,12 +391,9 @@
             <!--00035.xml-->
             <cb ed="#P" n="b"/>
             <lb ed="#V" n="69"/>ad mensuratum: non comparatur tamen nisi ad esse vnius euiterni tamquam 
-            <lb ed="#V" n="70"/> ad subiectum.
-          </p>
-          <p xml:id="kzz7yh-f06866-d1e719">
-            ¶ Ad 2m dicendum quod et si summus inter angelos 
-            <lb ed="#V" n="71"/>ceciderit secundum quod  tenetur: non est tamen inconueniens vt quidam 
-            vo<lb ed="#V" n="72" break="no"/>lunt quod omnes angeli naturali cognitione comparando suum esse naturale: ipsius 
+            <lb ed="#V" n="70"/>accidens ad subiectum. ¶ Ad 2m dicendum quod et si summus inter angelos 
+<lb ed="#V" n="71"/>ceciderit secundum quod communius tenetur: non est tamen inconueniens vt quidam vo  
+<lb ed="#V" n="72" break="no"/>lunt quod omnes angeli naturali cognitione comparando suum esse naturale: ipsius 
             ma<lb ed="#V" n="73" break="no"/>gis cognoscant quam gradu essendi quilibet eorum teneat in ordine 
             en<lb ed="#V" n="74" break="no"/>tium creatorum. Quia naturalia illius angeli per suum casum non fuerant 
             <lb ed="#V" n="75"/>ablata. secundum Dioni. de di. no. capi. 4. Unde adhuc esse 
@@ -468,8 +465,8 @@
           <p xml:id="kzz7yh-f06866-d1e844">
             ¶ Item si 
             nunquan<lb ed="#V" n="115" break="no"/>fuisset tempus: non deus potuisset vnum angelum creasse et illum 
-            de<lb ed="#V" n="116" break="no"/>struisse. Sed non potuisset  in instanti creationis: sue. Quia 
-            <lb ed="#V" n="117"/>nis sic dicit: tua et illorum eternitas tota tibi praesens 
+            de<lb ed="#V" n="116" break="no"/>struisse. Sed non potuisset destruere in instanti creationis: sue. Quia  
+<lb ed="#V" n="117"/>nis sic dicit: tua et illorum eternitas tota tibi praesens 
             <lb ed="#V" n="118"/>non potest facem contradictoria simul. Ergo in instanti alio. Ergo si numquam 
             <lb ed="#V" n="119"/>fuisset tempus ad hoc fuisset in duratione angelorum et instans. quod non esset 
             <lb ed="#V" n="120"/>verum nisi induratione ipsorum esset successio.
@@ -654,8 +651,8 @@
             ange<lb ed="#V" n="95" break="no"/>li est positiua magnitudinis spiritualis: finite tamen ita sua 
             mem<lb ed="#V" n="96" break="no"/>sura seu duratio si esset simpliciter esset positiua alicuius 
             <lb ed="#V" n="97"/>magnitudinis spiritualis finite tamen. Et ita sicut presens 
-            eter<lb ed="#V" n="98" break="no"/>nitatis propter sui in immensitatem cum simplicitate simul 
-            compre<lb ed="#V" n="99" break="no"/>hendit seu attingit omnia tempore: ita aliquo modo presens 
+            eter<lb ed="#V" n="98" break="no"/>nitatis propter sui inmensitatem cum simplicitate simul compre  
+<lb ed="#V" n="99" break="no"/>hendit seu attingit omnia tempore: ita aliquo modo presens 
             <lb ed="#V" n="100"/>eui attingeret aliqua tempore nostro presenti: nondum praesentia 
             <lb ed="#V" n="101"/>propinqua tamen: et sic angelus posset uidere presentialiter 
             <lb ed="#V" n="102"/>aliud: non presens nostro presenti: quod falsum est.

--- a/kzz7yh-f06866/cod-ve09v2_kzz7yh-f06866.xml
+++ b/kzz7yh-f06866/cod-ve09v2_kzz7yh-f06866.xml
@@ -87,15 +87,14 @@
           </p>
           <p xml:id="kzz7yh-f06866-d1e147">
             ¶ Item Dama. li. 1 capi. penul. angelus tempore 
-            <lb ed="#V" n="114"/>circuscribitur. Sed quod circunscribitur tempoe: est in tempoe quod videtur per 
-            simi<lb ed="#V" n="115" break="no"/>le: quia illud quod circumscribitur loco est in loco. Ergo angeli sunt in 
+            <lb ed="#V" n="114"/>circumscribitur. Sed quod circumscribitur tempore est in tempore quod videtur per<lb ed="#V" n="115" break="no"/>le: quia illud quod circumscribitur loco est in loco. Ergo angeli sunt in 
             <lb ed="#V" n="116"/>tempore
           </p>
           <p xml:id="kzz7yh-f06866-d1e156">
             ¶ Item creatio angelorum fuit in istanti. Sed 
             creatio<lb ed="#V" n="117" break="no"/>passiua ipsius angeli non addit vltra esse ipsius angeli nisi relationem 
             <lb ed="#V" n="118"/>ad creatorem. Ergo esse ipsius angeli est in instanti. Sed quod est in instanti: 
-            <lb ed="#V" n="119"/>magis debet dici esse in tempse quam in euo. cum instans reducatur ad 
+            <lb ed="#V" n="119"/>magis debet dici esse in tempore quam in euo. cum instans reducatur ad 
             tem<lb ed="#V" n="120" break="no"/>pus: quamuis non sit pars eius. sicut punctus ad lineam. Ert 
             <lb ed="#V" n="121"/>go angeli magis debent dici esse in tempore quam in euo. 
           </p>
@@ -105,7 +104,7 @@
             <cb ed="#P" n="a"/>
             <lb ed="#V" n="1"/>Contra in commento super secundam propositionem de causais. dicitur 
             <lb ed="#V" n="2"/>quod esse quod est cum eternitate: est intelligentia. quoniam 
-            <lb ed="#V" n="3"/>est esse secundum hitudinem vnam. Sed ibi loqutur de eternitate 
+            <lb ed="#V" n="3"/>est esse secundum habitudinem vnam. Sed ibi loquitur de eternitate 
             crea<lb ed="#V" n="4" break="no"/>ta que est euum. Ergo esse intelligentie quam ab officio vocamus 
             an<lb ed="#V" n="5" break="no"/>gelum est in euo.
           </p>
@@ -224,7 +223,7 @@
             <lb ed="#V" n="85"/>si duratio esse euiterni: esset aliquid superadditum illi esse: 
             pa<lb ed="#V" n="86" break="no"/>ri ratione cum esse eius duraret: duraret per aliam durationem 
             <lb ed="#V" n="87"/>sibi additam: et sic esset procedere in infinitum quod est 
-            inconue<lb ed="#V" n="88" break="no"/>niens. Euum autm idem est quod duratio esse euiterni.
+            inconue<lb ed="#V" n="88" break="no"/>niens. Euum aut idem est quod duratio esse euiterni.
           </p>
           <p xml:id="kzz7yh-f06866-d1e407">
             ¶ Uide. 
@@ -275,7 +274,7 @@
             <lb ed="#V" n="122"/>sunt in tempore propter motum etc. Dico quod hoc 
             intelligen<lb ed="#V" n="123" break="no"/>dum est de motu quo mobile proficit inesse substantiali 
             ac<lb ed="#V" n="124" break="no"/>tuali: aut deficit ab ipso: vel disponitur ad proficiendum: 
-            <lb ed="#V" n="125"/>vel deficiendum in praedicto esse: vel a praedicto esse. talius autem 
+            <lb ed="#V" n="125"/>vel deficiendum in praedicto esse: vel a praedicto esse. tali autem 
             <lb ed="#V" n="126"/>motu angelus non mouetur.
           </p>
           <p xml:id="kzz7yh-f06866-d1e502">
@@ -335,13 +334,13 @@
             <lb ed="#V" n="17"/>omnium euiternorum: sicut vnum tempus 
             <lb ed="#V" n="18"/>omnium temporalium: quamuis aliquo modo omnium euiternorum saltem 
             <lb ed="#V" n="19"/>spiritualium posset dici vnum euum. Quod sic patet. Ut ante 
-            <lb ed="#V" n="20"/>hintum est. tempus est continuatio motus ab anima numerata: qua 
+            <lb ed="#V" n="20"/>habitum est. tempus est continuatio motus ab anima numerata: qua 
             <lb ed="#V" n="21"/>mediante motu: cuius est passio mensurat anima durationes 
             <lb ed="#V" n="22"/>motuum aliorum. Mensurare autem durationem vnius motus per 
             <lb ed="#V" n="23"/>alium: est ex comparatione vnius motus ad alium 
             certifica<lb ed="#V" n="24" break="no"/>ri de alterius motus duratione. Sicut vides quod mensurare 
             <lb ed="#V" n="25"/>Panum per vlnam: est ex comparatione quantitates pani ad 
-            quanti<lb ed="#V" n="26" break="no"/>tatem vlne: certificari de illius paerni quantitate Maior autem 
+            quanti<lb ed="#V" n="26" break="no"/>tatem vlne: certificari de illius panni quantitate Maior autem 
             <lb ed="#V" n="27"/>certitudo habetur de re per causam quam per effectum: et per 
             sim<lb ed="#V" n="28" break="no"/>plex quam per compositum: vnde vnitas certior est mensura quam 
             <lb ed="#V" n="29"/>numerus. Certitudo etiam acquiritur de minus noto per magis 
@@ -356,47 +355,47 @@
             in<lb ed="#V" n="38" break="no"/>ipso sunt sensibilitatem: per quam ab omnibus cognoscitur 
             cerci<lb ed="#V" n="39" break="no"/>us et vniuersalius quam quicumque alius motus. Et ideo sola 
             con<lb ed="#V" n="40" break="no"/>tinuatio illius motus prout est ab anima numerata: plene hebet rationem 
-            <lb ed="#V" n="41"/>mensure ritumotuum aliorum: et ideo sola est tempus: loquendo de tempore 
+            <lb ed="#V" n="41"/>mensure respectu motuum aliorum: et ideo sola est tempus: loquendo de tempore 
             <lb ed="#V" n="42"/>secundum plenam temporis rationem. Et sic patet quod est vnum tempus omnium 
             tempora<lb ed="#V" n="43" break="no"/>lium: et quod non hebet nisi vnum motum pro subiecto: et tamen est mensura 
             <lb ed="#V" n="44"/>non tantum illius motus in quo est vt in subato: sed mediante illo. 
             <lb ed="#V" n="45"/>est est. mensura motuum aliorum. Unde sicut dicit Auicema 2 liro suo 
-            <lb ed="#V" n="46"/>phy. capi. vel. non oportet vt vnum quodque motum commitetur per se 
+            <lb ed="#V" n="46"/>phy. capi. vel. non oportet vt vnum quodque motum <sic>commitetur</sic> per se 
             <lb ed="#V" n="47"/>tempus proprium. nec vt quicquid mensurat aliquid sit accidens illi: ita vt 
             <lb ed="#V" n="48"/>omnis motus hebeat tempus proprium quod accidit illi tantum perse. Non est autem 
             <lb ed="#V" n="49"/>dare esse alicuius euiterni quod hebeat aliquam causalitatem respectu esse 
             <lb ed="#V" n="50"/>cuiuslibet alterius euiterni: quia esse cuiuslibet euiterni est a deo 
             crea<lb ed="#V" n="51" break="no"/>tum et conseruatum immediate tantum. Et ideo non est dare esse alicuius 
-            eui<lb ed="#V" n="52" break="no"/>terni cuius duratio ita hebeat plenam rationem mensure riumtl esse aliorum 
+            eui<lb ed="#V" n="52" break="no"/>terni cuius duratio ita hebeat plenam rationem mensure  esse aliorum 
             <lb ed="#V" n="53"/>euiternorum: sicut continuatio motus primi mobilis manifeste 
             no<lb ed="#V" n="54" break="no"/>bis non respectu aliorum motuum. Quia tamen inter euiterna est vnum 
             <lb ed="#V" n="55"/>cuius naturale esse est simplicius et actualius. quam esse naturale alterius 
             <lb ed="#V" n="56"/>cuiusset euiterni. Et angeli est naturali cognitione sciunt 
             ip<lb ed="#V" n="57" break="no"/>sum tenere summum gradum. inter euiterna: et comparande suum esse 
             <lb ed="#V" n="58"/>ad illud magis cognoscit quilibet naturali cognitione quam gradum 
-            es<lb ed="#V" n="59" break="no"/>sendi quo ad naturalia hebeat inter euiterna. Idon duratio esse illius 
+            es<lb ed="#V" n="59" break="no"/>sendi quo ad naturalia hebeat inter euiterna.  duratio esse illius 
             <lb ed="#V" n="60"/>nobilissimi euiterni ad intellectum relata. quodammodo habet 
-            ra<lb ed="#V" n="61" break="no"/>tionem mensuem: quamuis non plenam respectu cuiusset actualis ex 
-            <lb ed="#V" n="62"/>istentie create vniformiter se habentis: Hec autem mensura dicitur euum 
-            <lb ed="#V" n="63"/>vt in praecedenti quaestione hitum est. Et ideo dici potest quod aliquo modo est 
+            ra<lb ed="#V" n="61" break="no"/>tionem mensure: quamuis non plenam respectu cuiusset actualis ex 
+            <lb ed="#V" n="62"/>istentiae create vniformiter se habentis: Hec autem mensura dicitur euum 
+            <lb ed="#V" n="63"/>vt in praecedenti quaestione habitum est. Et ideo dici potest quod aliquo modo est 
             <lb ed="#V" n="64"/>vnum euum omnium angelorum: quamuis respectu eorum non sic hebeat 
             ple<lb ed="#V" n="65" break="no"/>nam rationem mensure. sicut tempus respectu temporalium.
           </p>
           <p xml:id="kzz7yh-f06866-d1e698">
             ¶ Ex dictis 
-            <lb ed="#V" n="66"/>patem potest aliquo modo via respondendi ad argumta vtriusque partem. 
+            <lb ed="#V" n="66"/>patere potest aliquo modo via respondendi ad argumenta vtriusque partem. 
           </p>
           <p xml:id="kzz7yh-f06866-d1e703">
-            <lb ed="#V" n="67"/>Ad primum dicendum quod euum quamuis competur adesse 
+            <lb ed="#V" n="67"/>Ad primum dicendum quod euum quamuis comparetur adesse 
             <lb ed="#V" n="68"/>cuiuslibet euiterni sicut mensura¬ 
             <!--00035.xml-->
             <cb ed="#P" n="b"/>
             <lb ed="#V" n="69"/>ad mensuratum: non comparatur tamen nisi ad esse vnius euiterni tamquam 
-            <lb ed="#V" n="70"/>acctns ad subiectum.
+            <lb ed="#V" n="70"/> ad subiectum.
           </p>
           <p xml:id="kzz7yh-f06866-d1e719">
             ¶ Ad 2m dicendum quod et si summus inter angelos 
-            <lb ed="#V" n="71"/>ceciderit secundum quod conius tenetur: non est tamen inconueniens vt quidam 
+            <lb ed="#V" n="71"/>ceciderit secundum quod  tenetur: non est tamen inconueniens vt quidam 
             vo<lb ed="#V" n="72" break="no"/>lunt quod omnes angeli naturali cognitione comparando suum esse naturale: ipsius 
             ma<lb ed="#V" n="73" break="no"/>gis cognoscant quam gradu essendi quilibet eorum teneat in ordine 
             en<lb ed="#V" n="74" break="no"/>tium creatorum. Quia naturalia illius angeli per suum casum non fuerant 
@@ -428,7 +427,7 @@
           <p xml:id="kzz7yh-f06866-d1e777">
             ¶ Ad. 2m cum dicitur 
             <lb ed="#V" n="94"/>quod si essent plures celi tamen non esset nisi vnum tempus etc. Dico 
-            <lb ed="#V" n="95"/>quod philosophus loqutur de pluribus celis ordinate se habentibus sic enim 
+            <lb ed="#V" n="95"/>quod philosophus loquitur de pluribus caelis ordinate se habentibus sic enim 
             <lb ed="#V" n="96"/>si essent plures celi ad huc non esset nisi vnum tempus quia sola 
             conti<lb ed="#V" n="97" break="no"/>nuatio motus vltimi celi plenam haberet temporis rationem. Sed 
             <lb ed="#V" n="98"/>si essent plures celi eque primi nec ad inuicem ordinati essent 
@@ -444,13 +443,13 @@
             <!-- line coord order error ? -->verbum philosophi. 20. metha. intelligatur 
             <lb ed="#V" n="101"/>Tertio queritur. vtrum in euo sit 
             suc<lb ed="#V" n="102" break="no"/>cessio. Et videtur quod 
-            <lb ed="#V" n="103"/>sic Anselie prosol. 30. capi. loquens ad deumde euiter. 
+            <lb ed="#V" n="103"/>sic Anselmus prosol. 30. capi. loquens ad deum de euiter. 
             <lb ed="#V" n="104"/>est: cum illa nondum hebeant de sua eternitate quod venturum est sicut 
             <lb ed="#V" n="105"/>iam non habent quod praeteritum etia. Sed in omni duratione in qua est 
             <lb ed="#V" n="106"/>preteritum et futurum est successio.
           </p>
           <p xml:id="kzz7yh-f06866-d1e818">
-            ¶ Item enum est duratio 
+            ¶ Item <sic>enum</sic> est duratio 
             infini<lb ed="#V" n="107" break="no"/>ta a parte post: ergo si est tota simul: infinitum est actu in creatura. 
             <lb ed="#V" n="108"/>quod falsum est.
           </p>
@@ -469,7 +468,7 @@
           <p xml:id="kzz7yh-f06866-d1e844">
             ¶ Item si 
             nunquan<lb ed="#V" n="115" break="no"/>fuisset tempus: non deus potuisset vnum angelum creasse et illum 
-            de<lb ed="#V" n="116" break="no"/>struisse. Sed non potuisset destruem in instanti creationis: sue. Quia 
+            de<lb ed="#V" n="116" break="no"/>struisse. Sed non potuisset  in instanti creationis: sue. Quia 
             <lb ed="#V" n="117"/>nis sic dicit: tua et illorum eternitas tota tibi praesens 
             <lb ed="#V" n="118"/>non potest facem contradictoria simul. Ergo in instanti alio. Ergo si numquam 
             <lb ed="#V" n="119"/>fuisset tempus ad hoc fuisset in duratione angelorum et instans. quod non esset 
@@ -482,7 +481,7 @@
             an<lb ed="#V" n="123" break="no"/>gelum non fore. quod falsum est. 
           </p>
           <p xml:id="kzz7yh-f06866-d1e869">
-            <lb ed="#V" n="124"/>Contra philosophus. 4 phy. c. de tempore vult. quod idem est istans 
+            <lb ed="#V" n="124"/>Contra philosophus. 4 phy. c. de tempore vult. quod idem est instans 
             inen<lb ed="#V" n="125" break="no"/>tia in toto tempore: quod sequitur ipsum mobile: et variatur 
             <lb ed="#V" n="126"/>secundum variationem illius: et ita videtur velle: quod si ipsum subiectum non variaretur 
             <lb ed="#V" n="127"/>secundum esse: quod instans mensurans esse illius non variaretur: secundum esse 
@@ -518,7 +517,7 @@
             <lb ed="#V" n="11"/>coexistentes ipsi euo.
           </p>
           <p xml:id="kzz7yh-f06866-d1e939">
-            ¶ Et pro hac opinione videntur esse plurles 
+            ¶ Et pro hac opinione videntur esse plures 
             <lb ed="#V" n="12"/>auctoritates.
           </p>
           <p xml:id="kzz7yh-f06866-d1e944">
@@ -581,7 +580,7 @@
             ¶ Item Augu. 12 de ci. dei 
             <lb ed="#V" n="48"/>ca. 20. immortalitas angelorum non transit in tempore nec preterita 
             <lb ed="#V" n="49"/>est: quasi iam non sit: nec futura: quasi nondum sit. tamen eorum 
-            <lb ed="#V" n="50"/>motus quibus tempera paraguntur: ex futuro in preteritum 
+            <lb ed="#V" n="50"/>motus quibus tempera <sic>paraguntur</sic>: ex futuro in preteritum 
             tran<lb ed="#V" n="51" break="no"/>seunt.
           </p>
           <p xml:id="kzz7yh-f06866-d1e1051">
@@ -609,7 +608,7 @@
             ¶ Item omnis 
             men<lb ed="#V" n="64" break="no"/>sura creata proportionatur mensurato. Sed nullum pertibile 
             <lb ed="#V" n="65"/>proportionatur intemporali proportione. Cum ergo esse 
-            sub<lb ed="#V" n="66" break="no"/>stantiale actuale ipsius angeli sit in pertibile: et mensura 
+            sub<lb ed="#V" n="66" break="no"/>stantiale actuale ipsius angeli sit in partibile: et mensura 
             suc<lb ed="#V" n="67" break="no"/>cessiua sint partibilis: non mensuratur mensura succedente. 
             In<lb ed="#V" n="68" break="no"/>suo ergo euo non est successio.
           </p>
@@ -655,7 +654,7 @@
             ange<lb ed="#V" n="95" break="no"/>li est positiua magnitudinis spiritualis: finite tamen ita sua 
             mem<lb ed="#V" n="96" break="no"/>sura seu duratio si esset simpliciter esset positiua alicuius 
             <lb ed="#V" n="97"/>magnitudinis spiritualis finite tamen. Et ita sicut presens 
-            eter<lb ed="#V" n="98" break="no"/>nitatis propter sui in mensitatem cum simplicitate simul 
+            eter<lb ed="#V" n="98" break="no"/>nitatis propter sui in immensitatem cum simplicitate simul 
             compre<lb ed="#V" n="99" break="no"/>hendit seu attingit omnia tempore: ita aliquo modo presens 
             <lb ed="#V" n="100"/>eui attingeret aliqua tempore nostro presenti: nondum praesentia 
             <lb ed="#V" n="101"/>propinqua tamen: et sic angelus posset uidere presentialiter 
@@ -706,7 +705,7 @@
             <lb ed="#V" n="130"/>cum illa infinitas vltra quicquid est positiuum in euo non 
             <lb ed="#V" n="131"/>dicat nisi negationem destructionis: deus destruendo 
             ip<lb ed="#V" n="132" break="no"/>sum faceret vt nunquam infinitum fuisset. tamen sicut ista 
-            <lb ed="#V" n="133"/>duo simul stare non possunt: quod anima antixprsti fuit 
+            <lb ed="#V" n="133"/>duo simul stare non possunt: quod anima antichristi fuit 
             futu<lb ed="#V" n="134" break="no"/>ra: et quod cum hoc nunquam creetur: ita ista duo simul stare non 
             <lb ed="#V" n="135"/>possunt quod euum istius angeli fuerit infinitum: et 
             post<lb ed="#V" n="136" break="no"/>ea destruatur.
@@ -723,7 +722,7 @@
             <lb ed="#V" n="4"/>hoc esset implicatio contradictionis. Sicut esset si nulla 
             pe<lb ed="#V" n="5" break="no"/>nitus esset corporalis dimissio: nec ymaginata: quamdiu sic esset 
             <lb ed="#V" n="6"/>non posset vere intelligi quod vnus angelus magis distaret 
-            <lb ed="#V" n="7"/>ab alio: quam alius loquendo de distantia locali. yvmmo ista 
+            <lb ed="#V" n="7"/>ab alio: quam alius loquendo de distantia locali. ymmo ista 
             <lb ed="#V" n="8"/>duo ponere simul est implicare contradictionem. Dico tamen quod 
             <lb ed="#V" n="9"/>per comparationem ad tempus: deus creare potuisset et adhuc 
             <lb ed="#V" n="10"/>posset vnum angelum post alium. sicut creat vnam 
@@ -766,8 +765,8 @@
             fuis<lb ed="#V" n="38" break="no"/>se: neque fore: sed esse tantum. quauis sibi coextiterint partes 
             <lb ed="#V" n="39"/>temporis preterite. et existent partes temporis future. 
             vn<lb ed="#V" n="40" break="no"/>de eo modo quo est ibi fuisse et fore differunt: sed ibi non 
-            <lb ed="#V" n="41"/>sunt nisi in coexistentia parcium temporis ipsi euo. quamuis 
-            <lb ed="#V" n="42"/>deus non posset facere quod coexistentia percium temporis 
+            <lb ed="#V" n="41"/>sunt nisi in coexistentia <sic>parcium</sic> temporis ipsi euo. quamuis 
+            <lb ed="#V" n="42"/>deus non posset facere quod coexistentia <sic>parcium</sic> temporis 
             prete<lb ed="#V" n="43" break="no"/>riti ipsi euo non fuerit: tamen posset facere quod nulla alia 
             <lb ed="#V" n="44"/>coexistentia partium temporis ipsi euo sit futura. 
             <lb ed="#V" n="45"/>Qui vult tenere opinionem secundam: 

--- a/kzz7yh-f06866/cod-ve09v2_kzz7yh-f06866.xml
+++ b/kzz7yh-f06866/cod-ve09v2_kzz7yh-f06866.xml
@@ -59,7 +59,7 @@
         </p>
         <p xml:id="kzz7yh-f06866-d1e105">
           ¶ Primo 
-          <lb ed="#V" n="103"/>vtrum angeli sint in tempoe vel in euo.
+          <lb ed="#V" n="103"/>vtrum angeli sint in tempore vel in euo.
         </p>
         <p xml:id="kzz7yh-f06866-d1e110">
           ¶ Secundo vtrum omnium 
@@ -88,7 +88,7 @@
           <p xml:id="kzz7yh-f06866-d1e147">
             ¶ Item Dama. li. 1 capi. penul. angelus tempore 
             <lb ed="#V" n="114"/>circuscribitur. Sed quod circunscribitur tempoe: est in tempoe quod videtur per 
-            simi<lb ed="#V" n="115" break="no"/>le: quiaillud quod circuscribitur loco est in loco. Ergo angeli sunt in 
+            simi<lb ed="#V" n="115" break="no"/>le: quia illud quod circumscribitur loco est in loco. Ergo angeli sunt in 
             <lb ed="#V" n="116"/>tempore
           </p>
           <p xml:id="kzz7yh-f06866-d1e156">
@@ -103,7 +103,7 @@
             <!--00034.xml-->
             <pb ed="#V" n="10-v"/>
             <cb ed="#P" n="a"/>
-            <lb ed="#V" n="1"/>Contra in commento super secundam propostionem de causais. dicitur 
+            <lb ed="#V" n="1"/>Contra in commento super secundam propositionem de causais. dicitur 
             <lb ed="#V" n="2"/>quod esse quod est cum eternitate: est intelligentia. quoniam 
             <lb ed="#V" n="3"/>est esse secundum hitudinem vnam. Sed ibi loqutur de eternitate 
             crea<lb ed="#V" n="4" break="no"/>ta que est euum. Ergo esse intelligentie quam ab officio vocamus 
@@ -116,7 +116,7 @@
             <lb ed="#V" n="8"/>quia eorum duratio est infinita a parte post. Ergo non sunt in tempore. 
           </p>
           <p xml:id="kzz7yh-f06866-d1e199">
-            <lb ed="#V" n="9"/>Respondeo quod esse subentiale et actuale ipsorum 
+            <lb ed="#V" n="9"/>Respondeo quod esse substantiale et actuale ipsorum 
             ange<lb ed="#V" n="10" break="no"/>lorum est in euo. Ad cuius intelligentiam. 
           </p>
           <p xml:id="kzz7yh-f06866-d1e206">
@@ -143,7 +143,7 @@
             inquan<lb ed="#V" n="21" break="no"/>tum ab anima numerantur: pro se adducentes quoddam verbum <ref xml:id="kzz7yh-f06866-Rd1e251">Augu. 5 
             su<lb ed="#V" n="22" break="no"/>per Gen. inter principium et medium</ref> vbi dicit: quod tempus est 
             creatu<lb ed="#V" n="23" break="no"/>re motus. Et quia motus primi mobilis est aliquid in re: dicunt se non 
-            <lb ed="#V" n="24"/>impingere in illum articulum excomuicatum: qui est quod euum et tempus 
+            <lb ed="#V" n="24"/>impingere in illum articulum excommunicatum: qui est quod euum et tempus 
             <lb ed="#V" n="25"/>nihil sunt in re: sed solum in apprehensione.
           </p>
           <p xml:id="kzz7yh-f06866-d1e252">
@@ -155,12 +155,12 @@
             <lb ed="#V" n="27"/>autem tempus sit continuatio motus Uidetur dicere Auicem. libro suo phy. 
             <lb ed="#V" n="28"/>libro 2. capi. vlti. Sic dicens: non est tempus aliquod cui accidit 
             conti<lb ed="#V" n="29" break="no"/>nuatio propria illi: ymmo ipsum est ipsa continuatio. Et ad hoc vt 
-            <lb ed="#V" n="30"/>hanc plenam rationem tempris: oportet vt numeretur anni apprehensiua: 
-            <lb ed="#V" n="31"/>vt sic ymaginabliter vel intelligibliter reducatur quasi ad modum 
+            <lb ed="#V" n="30"/>hanc plenam rationem temporis: oportet vt numeretur anni apprehensiua: 
+            <lb ed="#V" n="31"/>vt sic ymaginabiliter vel intelligibiliter reducatur quasi ad modum 
             <lb ed="#V" n="32"/>discreti: quia cum tempus sit mensura: et ratio mensure principaliter 
             <lb ed="#V" n="33"/>inueniatur indiscretis. Et maxime in principio discretionis quod est 
-            <lb ed="#V" n="34"/>vnitas. Secundum philosophum 10 metha. ex consequanti deriuetur ad 
-            conti<lb ed="#V" n="35" break="no"/>nua: oportet nos ymaginabliter facere aliquam discretionem in 
+            <lb ed="#V" n="34"/>vnitas. Secundum philosophum 10 metha. ex consequenti deriuetur ad 
+            conti<lb ed="#V" n="35" break="no"/>nua: oportet nos ymaginabiliter facere aliquam discretionem in 
             <lb ed="#V" n="36"/>continuatione motus quam dicimus tempus: cum per ipsam aliquid 
             mensura<lb ed="#V" n="37" break="no"/>mus. Et sic ex praedictis patet: quod esse in tempore: est mensurari a 
             tem<lb ed="#V" n="38" break="no"/>pore: et quia nihil mensuratur tempore nisi motus vel ratione motus: ideo 
@@ -170,13 +170,13 @@
           <p xml:id="kzz7yh-f06866-d1e290">
             ¶ Quantum ad secundum 
             ar<lb ed="#V" n="41" break="no"/>ticulum: sciendum quod instans est aliquid indiuisibile: habens 
-            connexi<lb ed="#V" n="42" break="no"/>onem ad tempus: non pars temporis sed initium temporis vel termius: a 
+            connexi<lb ed="#V" n="42" break="no"/>onem ad tempus: non pars temporis sed initium temporis vel terminus: a 
             <lb ed="#V" n="43"/>quo sine reali discontinuatione temporis: partes temporis ab anima 
-            nu<lb ed="#V" n="44" break="no"/>merantur. Et hoc omnia trahi possunt ex dictis phlosophi. 4. et 6 
-            phy<lb ed="#V" n="45" break="no"/>Instans autem quod est termius praeteriti: et initium futuri: non est in 
+            nu<lb ed="#V" n="44" break="no"/>merantur. Et hoc omnia trahi possunt ex dictis philosophi. 4. et 6 
+            phy<lb ed="#V" n="45" break="no"/>Instans autem quod est terminus praeteriti: et initium futuri: non est in 
             <lb ed="#V" n="46"/>tempore actualiter et realiter: quia sic tempus realiter discontinuaretur 
             <lb ed="#V" n="47"/>sed est tantum in tempore potentialiter: vel aliqua vi apprehensiua 
-            ac<lb ed="#V" n="48" break="no"/>tualiter signatum yvmagnabliter vel intelligibliter. Et quia hanc 
+            ac<lb ed="#V" n="48" break="no"/>tualiter signatum ymaginabiliter vel intelligibliter. Et quia hanc 
             <lb ed="#V" n="49"/>significationem facit anima aspiciendo ad mobile: ideo secundum 
             <lb ed="#V" n="50"/>quosdam dicit phuns. 4 phy. quod instans sequitur id quod fertur 
             <lb ed="#V" n="51"/>et quod est idem in esse in toto tempore: sicut mobile manet idem. 
@@ -190,7 +190,7 @@
             inessi<lb ed="#V" n="59" break="no"/>vel ad defectum essendi: sic mensuratur ab instanti quod realiter 
             differ<lb ed="#V" n="60" break="no"/>ret ab instanti eui. Si autem est mobile non tali motu: quo 
             di<lb ed="#V" n="61" break="no"/>sponatur ad proficiendum inesse substantiali vel ad defectum talis esse 
-            <lb ed="#V" n="62"/>sicut sunt corpora celestia et angeli: sic dico quod inquantum 
+            <lb ed="#V" n="62"/>sicut sunt corpora caelestia et angeli: sic dico quod inquantum 
             <lb ed="#V" n="63"/>mobilia sunt: esse eorum substantiale mensuratur instanti quod sola ratione 
             <lb ed="#V" n="64"/>differt ab indiuisibili eui.
           </p>
@@ -245,10 +245,10 @@
             <lb ed="#V" n="103"/>Unde prima opinio est securior.
           </p>
           <p xml:id="kzz7yh-f06866-d1e442">
-            ¶ Quarto ex premissis 
+            ¶ Quarto ex praemissis 
             <lb ed="#V" n="104"/>concludendum est propositum scilicet quod esse substantiale actuale ipsorum 
             <lb ed="#V" n="105"/>angelorum est in euo: non in tempore: nec in instanti realiter 
-            di<lb ed="#V" n="106" break="no"/>stincto ab euo. Quia predictum esse non est motus: nec 
+            di<lb ed="#V" n="106" break="no"/>stincto ab euo. Quia praedictum esse non est motus: nec 
             de<lb ed="#V" n="107" break="no"/>necessitate existens in motu: nec est quies: ergo non est in 
             tem<lb ed="#V" n="108" break="no"/>pore.
           </p>
@@ -264,7 +264,7 @@
             <lb ed="#V" n="116"/>creata mensuretur. 
           </p>
           <p xml:id="kzz7yh-f06866-d1e475">
-            <lb ed="#V" n="117"/>Ad primum in oppositum cum dicitur quod de angelorm 
+            <lb ed="#V" n="117"/>Ad primum in oppositum cum dicitur quod de angelorum 
             <lb ed="#V" n="118"/>duratione iudicamus aspiciendo ad 
             <lb ed="#V" n="119"/>tempus etc. Dico quod non est verum: loquendo de ipsorum 
             dura<lb ed="#V" n="120" break="no"/>tione absolute: sed hoc intelligendum est de durationis 
@@ -307,7 +307,7 @@
           </p>
           <p xml:id="kzz7yh-f06866-d1e545">
             ¶ Item si esset vnum euum tantum esset sicut in 
-            <lb ed="#V" n="2"/>subiento inesse nobilissimi angeli in naturalibus. Sed ille dicitur 
+            <lb ed="#V" n="2"/>subiecto inesse nobilissimi angeli in naturalibus. Sed ille dicitur 
             <lb ed="#V" n="3"/>esse lucifer. Ergo esse angelorum beatorum mensuraretur per esse 
             <lb ed="#V" n="4"/>angeli mali. quod absurdum videtur.
           </p>
@@ -319,8 +319,8 @@
           </p>
           <p xml:id="kzz7yh-f06866-d1e563">
             <lb ed="#V" n="8"/>Contra secundum philosophum. 1 metha. in vno quoque genere 
-            <lb ed="#V" n="9"/>est vnum ininimu quo mensurantur omnia que 
-            <lb ed="#V" n="10"/>sunt in illo genere. Ergo in geneter euiternorum est dare 
+            <lb ed="#V" n="9"/>est vnum minimum quo mensurantur omnia que 
+            <lb ed="#V" n="10"/>sunt in illo genere. Ergo in genere euiternorum est dare 
             ali<lb ed="#V" n="11" break="no"/>quid simplicissimum quo omnia euiterna mensurantur. Sed 
             men<lb ed="#V" n="12" break="no"/>sura euiterni est euum. ergo videtur quod omnium euiternorum sit 
             <lb ed="#V" n="13"/>vnum euum.
@@ -358,28 +358,28 @@
             con<lb ed="#V" n="40" break="no"/>tinuatio illius motus prout est ab anima numerata: plene hebet rationem 
             <lb ed="#V" n="41"/>mensure ritumotuum aliorum: et ideo sola est tempus: loquendo de tempore 
             <lb ed="#V" n="42"/>secundum plenam temporis rationem. Et sic patet quod est vnum tempus omnium 
-            tempora<lb ed="#V" n="43" break="no"/>lium: et quod non hebet nisi vnum motum pro subiento: et tamen est mensura 
+            tempora<lb ed="#V" n="43" break="no"/>lium: et quod non hebet nisi vnum motum pro subiecto: et tamen est mensura 
             <lb ed="#V" n="44"/>non tantum illius motus in quo est vt in subato: sed mediante illo. 
             <lb ed="#V" n="45"/>est est. mensura motuum aliorum. Unde sicut dicit Auicema 2 liro suo 
             <lb ed="#V" n="46"/>phy. capi. vel. non oportet vt vnum quodque motum commitetur per se 
             <lb ed="#V" n="47"/>tempus proprium. nec vt quicquid mensurat aliquid sit accidens illi: ita vt 
             <lb ed="#V" n="48"/>omnis motus hebeat tempus proprium quod accidit illi tantum perse. Non est autem 
             <lb ed="#V" n="49"/>dare esse alicuius euiterni quod hebeat aliquam causalitatem respectu esse 
-            <lb ed="#V" n="50"/>cuiuslet alterius euiterni: quia esse cuiusset euiterni est a deo 
+            <lb ed="#V" n="50"/>cuiuslibet alterius euiterni: quia esse cuiuslibet euiterni est a deo 
             crea<lb ed="#V" n="51" break="no"/>tum et conseruatum immediate tantum. Et ideo non est dare esse alicuius 
             eui<lb ed="#V" n="52" break="no"/>terni cuius duratio ita hebeat plenam rationem mensure riumtl esse aliorum 
-            <lb ed="#V" n="53"/>euiternorum: sicut continuatio motus primi mobilis maifeste 
+            <lb ed="#V" n="53"/>euiternorum: sicut continuatio motus primi mobilis manifeste 
             no<lb ed="#V" n="54" break="no"/>bis non respectu aliorum motuum. Quia tamen inter euiterna est vnum 
-            <lb ed="#V" n="55"/>cuius naturle esse est simplicius et actualius. quam esse naturale alterius 
+            <lb ed="#V" n="55"/>cuius naturale esse est simplicius et actualius. quam esse naturale alterius 
             <lb ed="#V" n="56"/>cuiusset euiterni. Et angeli est naturali cognitione sciunt 
             ip<lb ed="#V" n="57" break="no"/>sum tenere summum gradum. inter euiterna: et comparande suum esse 
             <lb ed="#V" n="58"/>ad illud magis cognoscit quilibet naturali cognitione quam gradum 
             es<lb ed="#V" n="59" break="no"/>sendi quo ad naturalia hebeat inter euiterna. Idon duratio esse illius 
-            <lb ed="#V" n="60"/>nobilissimi euiterni ad intellectum relata. quodammo hebet 
+            <lb ed="#V" n="60"/>nobilissimi euiterni ad intellectum relata. quodammodo habet 
             ra<lb ed="#V" n="61" break="no"/>tionem mensuem: quamuis non plenam respectu cuiusset actualis ex 
             <lb ed="#V" n="62"/>istentie create vniformiter se habentis: Hec autem mensura dicitur euum 
             <lb ed="#V" n="63"/>vt in praecedenti quaestione hitum est. Et ideo dici potest quod aliquo modo est 
-            <lb ed="#V" n="64"/>vnum euum omnium angelorum: quamuis respectu eorum nson sic hebeat 
+            <lb ed="#V" n="64"/>vnum euum omnium angelorum: quamuis respectu eorum non sic hebeat 
             ple<lb ed="#V" n="65" break="no"/>nam rationem mensure. sicut tempus respectu temporalium.
           </p>
           <p xml:id="kzz7yh-f06866-d1e698">
@@ -404,7 +404,7 @@
             natu<lb ed="#V" n="76" break="no"/>rale illius angeli nobilius est quam esse alicuius alterius angeli. 
             <lb ed="#V" n="77"/>Boni tamen angeli cognitione super naturali aspiciendo diuinum 
             <lb ed="#V" n="78"/>esse et suum esse in comparatione ad illud certitudinaliter 
-            cogno<lb ed="#V" n="79" break="no"/>scunt quomon que gradum hebeant in genere entium creatorum et 
+            cogno<lb ed="#V" n="79" break="no"/>scunt quomodo que gradum hebeant in genere entium creatorum et 
             <lb ed="#V" n="80"/>quantum adesse nature et quantum adesse glorie et ideo diuinum esse 
             <lb ed="#V" n="81"/>est eis certissima mensura sui esse.
           </p>
@@ -441,7 +441,7 @@
           <p xml:id="kzz7yh-f06866-d1e798">
             ¶ Questio. III. 
             <lb ed="#V" n="100"/>
-            <!-- line coord order error ? -->verbum phlosophi. 20. metha. intelligatur 
+            <!-- line coord order error ? -->verbum philosophi. 20. metha. intelligatur 
             <lb ed="#V" n="101"/>Tertio queritur. vtrum in euo sit 
             suc<lb ed="#V" n="102" break="no"/>cessio. Et videtur quod 
             <lb ed="#V" n="103"/>sic Anselie prosol. 30. capi. loquens ad deumde euiter. 
@@ -472,7 +472,7 @@
             de<lb ed="#V" n="116" break="no"/>struisse. Sed non potuisset destruem in instanti creationis: sue. Quia 
             <lb ed="#V" n="117"/>nis sic dicit: tua et illorum eternitas tota tibi praesens 
             <lb ed="#V" n="118"/>non potest facem contradictoria simul. Ergo in instanti alio. Ergo si numquam 
-            <lb ed="#V" n="119"/>fuisset tempus ad hoc fuisset induratione angelorum et instans. quod non eet 
+            <lb ed="#V" n="119"/>fuisset tempus ad hoc fuisset in duratione angelorum et instans. quod non esset 
             <lb ed="#V" n="120"/>verum nisi induratione ipsorum esset successio.
           </p>
           <p xml:id="kzz7yh-f06866-d1e860">
@@ -540,8 +540,8 @@
           <p xml:id="kzz7yh-f06866-d1e967">
             ¶ Item plato in 
             thi<lb ed="#V" n="20" break="no"/>meo parum ante medium tocius libri: sic dicit. quod fuisse et 
-            fore<lb ed="#V" n="21" break="no"/>temporis geniture sunt propria. motus enim sunt. vnus. pretereuntis 
-            <lb ed="#V" n="22"/>imminentis alter. non eui sed temporis. eui quaeppe mansio perpetua et 
+            fore<lb ed="#V" n="21" break="no"/>temporis geniture sunt propria. motus enim sunt. vnus. praetereuntis 
+            <lb ed="#V" n="22"/>imminentis alter. non eui sed temporis. eui quippe mansio perpetua et 
             <lb ed="#V" n="23"/>immutabilis. et parum post dicit: defuisse et fore: quod hoc omnia sunt 
             <lb ed="#V" n="24"/>vices temporis imitantis euum. ibi plane patet quod vult non esse 
             <lb ed="#V" n="25"/>prius et posterius: nec fuisse et fore: nisi in tempore et motu. euum 
@@ -561,12 +561,12 @@
             <lb ed="#V" n="33"/>etiam sunt auctoritates sanctorum. Augu. 12 libro confessi. longe ante 
             <lb ed="#V" n="34"/>medium loquens de creatura angelica beata ad deum sic 
             di<lb ed="#V" n="35" break="no"/>cit. Te igitur semper praesente ad quam toto affectum se tenet non 
-            <lb ed="#V" n="36"/>habens futurum quod expectet: nec inpreteritum trahiciens que 
-            <lb ed="#V" n="37"/>meninerit nulla vice variatur. Ecce quod quantum ad esse eius 
+            <lb ed="#V" n="36"/>habens futurum quod expectet: nec in praeteritum trahiciens que 
+            <lb ed="#V" n="37"/>meminerit nulla vice variatur. Ecce quod quantum ad esse eius 
             im<lb ed="#V" n="38" break="no"/>mutabile: nec quantum ad eius contemplationem: qua deum 
             im<lb ed="#V" n="39" break="no"/>mutabliter: contemplatur creatura angelica beata nullam 
             ha<lb ed="#V" n="40" break="no"/>bet in sua duratione successionem. Unde Grego. More. libro 
-            <lb ed="#V" n="41"/>1o. longe ante finem super illud Iob. 3 requeuerunt fessi 
+            <lb ed="#V" n="41"/>1o. longe ante finem super illud Iob. 3 requieuerunt fessi 
             robo<lb ed="#V" n="42" break="no"/>relquid est stantem semper in praesenti quietem querere nisi ad 
             il<lb ed="#V" n="43" break="no"/>lud cibi nihil venit: nihil praeterit gaudium eternitatis 
             ane<lb ed="#V" n="44" break="no"/>lare.
@@ -586,7 +586,7 @@
           </p>
           <p xml:id="kzz7yh-f06866-d1e1051">
             ¶ Item Dionisi. 5 capi. de diui. no. euum dicitur 
-            <lb ed="#V" n="52"/>queta et tota simul vita.
+            <lb ed="#V" n="52"/>quieta et tota simul vita.
           </p>
           <p xml:id="kzz7yh-f06866-d1e1056">
             ¶ Item infra. 10 capi. loquens de 
@@ -594,7 +594,7 @@
             immu<lb ed="#V" n="54" break="no"/>tabile et antiquum. Sed vbi est successio: ibi est aliqua 
             mu<lb ed="#V" n="55" break="no"/>tabilitas. ergo in euo non est successio. et quod ibi accipiat 
             eter<lb ed="#V" n="56" break="no"/>num: pro eternitate creata: que est euum: patet per hoc quod 
-            post<lb ed="#V" n="57" break="no"/>ea dicit. oportet itaque non simpliciter coeterna deo qui est 
+            post<lb ed="#V" n="57" break="no"/>ea dicit. oportet itaque non simpliciter coaeterna deo qui est 
             <lb ed="#V" n="58"/>ante eternum estimari: que eterna dicta sunt.
           </p>
           <p xml:id="kzz7yh-f06866-d1e1072">
@@ -652,9 +652,9 @@
             <lb ed="#V" n="92"/>hoc etiam est ratio. quia aliter angelus naturali virtute 
             <lb ed="#V" n="93"/>posset habere cognitionem aliquorum contingentium 
             futu<lb ed="#V" n="94" break="no"/>rorum de propinquo. Quia sicut simplicitas essentie 
-            ange<lb ed="#V" n="95" break="no"/>li est positiua magnitudis spiritualis: finite tamen ita sua 
+            ange<lb ed="#V" n="95" break="no"/>li est positiua magnitudinis spiritualis: finite tamen ita sua 
             mem<lb ed="#V" n="96" break="no"/>sura seu duratio si esset simpliciter esset positiua alicuius 
-            <lb ed="#V" n="97"/>magnitudis spiritualis finite tamen. Et ita sicut presens 
+            <lb ed="#V" n="97"/>magnitudinis spiritualis finite tamen. Et ita sicut presens 
             eter<lb ed="#V" n="98" break="no"/>nitatis propter sui in mensitatem cum simplicitate simul 
             compre<lb ed="#V" n="99" break="no"/>hendit seu attingit omnia tempore: ita aliquo modo presens 
             <lb ed="#V" n="100"/>eui attingeret aliqua tempore nostro presenti: nondum praesentia 
@@ -701,7 +701,7 @@
             <lb ed="#V" n="128"/>nunque destrueretur.
           </p>
           <p xml:id="kzz7yh-f06866-d1e1257">
-            ¶ Ad. 3m dicendumquod de tali 
+            ¶ Ad. 3m dicendum quod de tali 
             infini<lb ed="#V" n="129" break="no"/>to deus posset facere: vt nunquam fuisset actu infinitum. quia 
             <lb ed="#V" n="130"/>cum illa infinitas vltra quicquid est positiuum in euo non 
             <lb ed="#V" n="131"/>dicat nisi negationem destructionis: deus destruendo 
@@ -733,7 +733,7 @@
             ¶ Uel potest dici quod non est 
             intelligi<lb ed="#V" n="12" break="no"/>bile esse vnam mensuram priorem alia in quarum nulla per 
             <lb ed="#V" n="13"/>se est prius et posterius. eternitas enim in qua non est prius et 
-            <lb ed="#V" n="14"/>posterius duratione: precessit primum temporis instans: 
+            <lb ed="#V" n="14"/>posterius duratione: praecessit primum temporis instans: 
             in<lb ed="#V" n="15" break="no"/>quo instanti non fuit prius et posterius. et tamen posterius fuit 
             <lb ed="#V" n="16"/>eternitate: Unde in ipso fuit posterioritas: et in 
             eternita<lb ed="#V" n="17" break="no"/>te prioritas. I simili aliquo modo a remotis dicunt: quod 
@@ -755,7 +755,7 @@
             manen<lb ed="#V" n="30" break="no"/>tem que bis potest sumi. et etiam multociens. cuiusmodi 
             <lb ed="#V" n="31"/>mensura est euum. Unde si deus destrueret modo vnum 
             <lb ed="#V" n="32"/>angelum inferiorem: vere diceretur quod esse illius coexistit in 
-            di<lb ed="#V" n="33" break="no"/>uisibili eui superrioris angeli. Et tamen modo non 
+            di<lb ed="#V" n="33" break="no"/>uisibili eui superioris angeli. Et tamen modo non 
             coexi<lb ed="#V" n="34" break="no"/>steret ei. nec esset contradictio aliqua. Sicut non est 
             cotra<lb ed="#V" n="35" break="no"/>dictio quod pars temporis preterita per successionem ex parte 
             <lb ed="#V" n="36"/>temporis coexistit in diuisibili eui et tamen modo sibi non 

--- a/kzz7yh-f06866/cod-ve09v2_kzz7yh-f06866.xml
+++ b/kzz7yh-f06866/cod-ve09v2_kzz7yh-f06866.xml
@@ -87,7 +87,7 @@
           </p>
           <p xml:id="kzz7yh-f06866-d1e147">
             ¶ Item Dama. li. 1 capi. penul. angelus tempore 
-            <lb ed="#V" n="114"/>circumscribitur. Sed quod circumscribitur tempore est in tempore quod videtur per<lb ed="#V" n="115" break="no"/>le: quia illud quod circumscribitur loco est in loco. Ergo angeli sunt in 
+            <lb ed="#V" n="114"/>circumscribitur. Sed quod circumscribitur tempore est in tempore quod videtur per simi<lb ed="#V" n="115" break="no"/>le: quia illud quod circumscribitur loco est in loco. Ergo angeli sunt in 
             <lb ed="#V" n="116"/>tempore
           </p>
           <p xml:id="kzz7yh-f06866-d1e156">
@@ -375,8 +375,8 @@
             <lb ed="#V" n="58"/>ad illud magis cognoscit quilibet naturali cognitione quam gradum 
             es<lb ed="#V" n="59" break="no"/>sendi quo ad naturalia hebeat inter euiterna.  duratio esse illius 
             <lb ed="#V" n="60"/>nobilissimi euiterni ad intellectum relata. quodammodo habet 
-            ra<lb ed="#V" n="61" break="no"/>tionem mensure: quamuis non plenam respectu cuiusset actualis ex 
-            <lb ed="#V" n="62"/>istentiae create vniformiter se habentis: Hec autem mensura dicitur euum 
+            ra<lb ed="#V" n="61" break="no"/>tionem mensure: quamuis non plenam respectu cuiusset actualis  
+            ex<lb ed="#V" n="62" break="no"/>istentiae create vniformiter se habentis: Hec autem mensura dicitur euum 
             <lb ed="#V" n="63"/>vt in praecedenti quaestione habitum est. Et ideo dici potest quod aliquo modo est 
             <lb ed="#V" n="64"/>vnum euum omnium angelorum: quamuis respectu eorum non sic hebeat 
             ple<lb ed="#V" n="65" break="no"/>nam rationem mensure. sicut tempus respectu temporalium.
@@ -481,8 +481,8 @@
             an<lb ed="#V" n="123" break="no"/>gelum non fore. quod falsum est. 
           </p>
           <p xml:id="kzz7yh-f06866-d1e869">
-            <lb ed="#V" n="124"/>Contra philosophus. 4 phy. c. de tempore vult. quod idem est instans 
-            inen<lb ed="#V" n="125" break="no"/>tia in toto tempore: quod sequitur ipsum mobile: et variatur 
+            <lb ed="#V" n="124"/>Contra philosophus. 4 phy. c. de tempore vult. quod idem est instans in 
+            essen<lb ed="#V" n="125" break="no"/>tia in toto tempore: quod sequitur ipsum mobile: et variatur 
             <lb ed="#V" n="126"/>secundum variationem illius: et ita videtur velle: quod si ipsum subiectum non variaretur 
             <lb ed="#V" n="127"/>secundum esse: quod instans mensurans esse illius non variaretur: secundum esse 
             <lb ed="#V" n="128"/>Sed maneret idem non variatum. Ergo cum euiternum sub 


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve09v2_kzz7yh-f06866.xml`.

## Applied changes

- p. 10r l. 103: tempoe: not in Latin word list — review needed
- p. 10r l. 115: quiaillud → quia illud: merged words; circuscribitur → circumscribitur: c→cu
- p. 10v l. 1: propostionem → propositionem: not in word list (OCR transform matched)
- p. 10v l. 9: subentiale: not in Latin word list — review needed
- p. 10v l. 24: excomuicatum → excommunicatum: missing letters; euum is valid aevum
- p. 10v l. 30: tempris → temporis: missing syllable 'po'
- p. 10v l. 31: ymaginabliter → ymaginabiliter: missing 'i'; intelligibliter → intelligibiliter: missing 'i'
- p. 10v l. 34: consequanti: not in Latin word list — review needed
- p. 10v l. 35: ymaginabliter: not in Latin word list — review needed
- p. 10v l. 42: termius: not in Latin word list — review needed
- p. 10v l. 44: phlosophi: 3+ consecutive consonants — likely garbled OCR
- p. 10v l. 45: termius: not in Latin word list — review needed
- p. 10v l. 48: yvmagnabliter: not in Latin word list — review needed
- p. 10v l. 62: celestia → caelestia: not in word list (OCR transform matched)
- p. 10v l. 103: premissis → praemissis: not in word list (OCR transform matched)
- p. 10v l. 106: predictum → praedictum: not in word list (OCR transform matched)
- p. 10v l. 117: angelorm → angelorum: not in word list (OCR transform matched)
- p. 11r l. 2: subiento: not in Latin word list — review needed
- p. 11r l. 9: ininimu: not in Latin word list — review needed
- p. 11r l. 10: geneter → genere: garbled; euiternorum is valid medieval Latin
- p. 11r l. 43: subiento: not in Latin word list — review needed
- p. 11r l. 50: cuiuslet → cuiuslibet: missing syllable; cuiusset → cuiuslibet: same error
- p. 11r l. 53: maifeste → manifeste: dropped 'n'; euiternorum is valid
- p. 11r l. 55: naturle → naturale: not in word list (OCR transform matched)
- p. 11r l. 60: quodammo → quodammodo: dropped 'do'; hebet → habet: e/a misread
- p. 11r l. 64: nson → non: garbled; euum is valid; hebeat → habeat (possible error, keep)
- p. 11r l. 79: quomon: not in Latin word list — review needed
- p. 11r l. 100: phlosophi: 3+ consecutive consonants — likely garbled OCR
- p. 11r l. 119: induratione → in duratione: merged words; eet → esset: dropped 's'
- p. 11v l. 21: pretereuntis → praetereuntis: not in word list (OCR transform matched)
- p. 11v l. 22: quaeppe: not in Latin word list — review needed
- p. 11v l. 36: inpreteritum → in praeteritum: merged prefix; trahiciens: keep as-is
- p. 11v l. 37: meninerit: not in Latin word list — review needed
- p. 11v l. 41: requeuerunt → requieuerunt: not in word list (OCR transform matched)
- p. 11v l. 52: queta → quieta: not in word list (OCR transform matched)
- p. 11v l. 57: coeterna → coaeterna: not in word list (OCR transform matched)
- p. 11v l. 95: magnitudis: not in Latin word list — review needed
- p. 11v l. 97: magnitudis: not in Latin word list — review needed
- p. 11v l. 128: dicendumquod: not in Latin word list — review needed
- p. 12r l. 14: precessit → praecessit: not in word list (OCR transform matched)
- p. 12r l. 33: superrioris: not in Latin word list — review needed

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_