### PR TITLE
Transcription corrections: cod-ve09v2_kzz7yh-f08211.xml (20 changes)

### DIFF
--- a/kzz7yh-f08211/cod-ve09v2_kzz7yh-f08211.xml
+++ b/kzz7yh-f08211/cod-ve09v2_kzz7yh-f08211.xml
@@ -349,8 +349,8 @@
           </p>
           <p xml:id="kzz7yh-f08211-d1e624">
             ¶ Item quae simul creantur in eadem 
-            men<lb ed="#V" n="112" break="no"/>sura  creari. Sed celum empyreum et natura angelica: simul 
-            crea<lb ed="#V" n="113" break="no"/>ta fuerant. vt ante habitum est. ergo in eadem mensura fuerant creata. 
+            men<lb ed="#V" n="112" break="no"/>sura videntur creari. Sed celum empyreum et natura angelica: simul crea  
+<lb ed="#V" n="113" break="no"/>ta fuerant. vt ante habitum est. ergo in eadem mensura fuerant creata. 
           </p>
           <p xml:id="kzz7yh-f08211-d1e631">
             <lb ed="#V" n="114"/>Contra nullius corporis essentia hebet vnigeneam mensuram 

--- a/kzz7yh-f08211/cod-ve09v2_kzz7yh-f08211.xml
+++ b/kzz7yh-f08211/cod-ve09v2_kzz7yh-f08211.xml
@@ -107,7 +107,8 @@
             <lb ed="#V" n="93"/>¶ Essentia aut potest considerari tripliciter. Uel inquantum 
             <lb ed="#V" n="94"/>talis essentia vt essentia angelica vel humana. Uel inquantum 
             <lb ed="#V" n="95"/>habens partem extra partem sine parcium separatione vel 
-            reali<lb ed="#V" n="96" break="no"/>et actuali distinctione. Uel inquantum habens partem  
+            reali 
+            <lb ed="#V" n="96"/>et actuali distinctione. Uel inquantum habens partem extra 
             <lb ed="#V" n="97"/>partem actu realiter distinctas inter se.
           </p>
           <p xml:id="kzz7yh-f08211-d1e204">
@@ -151,7 +152,7 @@
             ¶ Esse 
             <lb ed="#V" n="123"/>primo modo dicto debetur triplex mensura: vna intrinseca 
             ex<lb ed="#V" n="124" break="no"/>istens in ipso sicut in subiecto. hoc est propria continuatio illius: que 
-            <lb ed="#V" n="125"/> nomine temporis: tempus posset vocari: quamuis in proprie: quia sic 
+            <lb ed="#V" n="125"/>excenso nomine temporis: tempus posset vocari: quamuis in proprie: quia sic 
             <lb ed="#V" n="126"/>possent dici multa tempora. eo quod numerantur secundum numerationem 
             <lb ed="#V" n="127"/>motuum. Alia extrinseca et in genere: et illa est tempus proprie 
             di<lb ed="#V" n="128" break="no"/>ctum quod idem est quod continuatio durationis motus ab anima 

--- a/kzz7yh-f08211/cod-ve09v2_kzz7yh-f08211.xml
+++ b/kzz7yh-f08211/cod-ve09v2_kzz7yh-f08211.xml
@@ -88,7 +88,7 @@
           <p xml:id="kzz7yh-f08211-d1e159">
             ¶ Item omne 
             crea<lb ed="#V" n="82" break="no"/>tum esse: aut est vniformiter se habens: aut variabile. Sed 
-            <lb ed="#V" n="83"/>esse creatum vniformiter sehabens mensuratur euo: et esse 
+            <lb ed="#V" n="83"/>esse creatum vniformiter se habens mensuratur euo: et esse 
             <lb ed="#V" n="84"/>variabile mensuratur tempore. ergo omnis mensura creata 
             <lb ed="#V" n="85"/>est euum vel tempus. 
           </p>
@@ -127,7 +127,7 @@
             inge<lb ed="#V" n="107" break="no"/>nere: et illa est locus. Quia substantia sic considerata: aut est locata: 
             <lb ed="#V" n="108"/>aut locabilis locatione circunscriptiua. Alia extrinseca et 
             ex<lb ed="#V" n="109" break="no"/>tra genus et illa est ipse deus sub ratione qua est in se 
-            ha<lb ed="#V" n="110" break="no"/>bens omnis magnitudis super excellentem perfectionem.
+            ha<lb ed="#V" n="110" break="no"/>bens omnis magnitudinis super excellentem perfectionem.
           </p>
           <p xml:id="kzz7yh-f08211-d1e238">
             ¶ 
@@ -152,7 +152,7 @@
             <lb ed="#V" n="123"/>primo modo dicto debetur triplex mensura: vna intrinseca 
             ex<lb ed="#V" n="124" break="no"/>istens in ipso sicut in subiecto. hoc est propria continuatio illius: que 
             <lb ed="#V" n="125"/>excenso nomine temporis: tempus posset vocari: quamuis in proprie: quia sic 
-            <lb ed="#V" n="126"/>possent dici multa tempora. eo quod numerantur secundum nuerationem 
+            <lb ed="#V" n="126"/>possent dici multa tempora. eo quod numerantur secundum numerationem 
             <lb ed="#V" n="127"/>motuum. Alia extrinseca et in genere: et illa est tempus proprie 
             di<lb ed="#V" n="128" break="no"/>ctum quod idem est quod continuatio durationis motus ab anima 
             numera<lb ed="#V" n="129" break="no"/>ta: qua mediante motu cuius est passio mensurat anima 
@@ -161,7 +161,7 @@
             compa<lb ed="#V" n="132" break="no"/>ratur: sicut accidens ad subiectum sed sicut mensura ad 
             men<lb ed="#V" n="133" break="no"/>suratum Unde illius solius motus in quo est sicut in subiecto: 
             <lb ed="#V" n="134"/>est mensura intrinseca: aliorum autem motuum est mensura 
-            ex<lb ed="#V" n="135" break="no"/>trinseca. Predicto etiam esse debetur mensura 
+            ex<lb ed="#V" n="135" break="no"/>trinseca. Praedicto etiam esse debetur mensura 
             extrinse<lb ed="#V" n="136" break="no"/>ca et extra genus. et illa deus est sub ratione qua est in se 
             <!--00038.xml-->
             <pb ed="#V" n="12-v"/>
@@ -202,7 +202,7 @@
             ¶ Sic ergo videre potes quod deus 
             <lb ed="#V" n="26"/>est mensura extrinseca et extra genus cuiuslibet essentie 
             <lb ed="#V" n="27"/>create: et sui esse: inquantum est in se habens non modo 
-            vni<lb ed="#V" n="28" break="no"/>uoco: sed super excellenter in infintum rationes 
+            vni<lb ed="#V" n="28" break="no"/>uoco: sed super excellenter in infinitum rationes 
             perfectiona<lb ed="#V" n="29" break="no"/>les cuiusset essentie create: et cuiuslibet esse creati.
           </p>
           <p xml:id="kzz7yh-f08211-d1e380">
@@ -232,7 +232,7 @@
             crea<lb ed="#V" n="47" break="no"/>ta que debetur creature respectu sui esse.
           </p>
           <p xml:id="kzz7yh-f08211-d1e428">
-            ¶ Argumntum ad per 
+            ¶ Argumentum ad per 
             <lb ed="#V" n="48"/>tem aliam procedit de tempore proprie dicto.
           </p>
         </div>
@@ -282,7 +282,7 @@
             <lb ed="#V" n="75"/>euum non fuerit creatum ante tempus. 
           </p>
           <p xml:id="kzz7yh-f08211-d1e516">
-            <lb ed="#V" n="76"/>Respondeo quod tempus dupliter potest acciposilicet 
+            <lb ed="#V" n="76"/>Respondeo quod tempus dupliciter potest accipi scilicet 
             comui<lb ed="#V" n="77" break="no"/>ter pro quicunque mensura esse existentis 
             in<lb ed="#V" n="78" break="no"/>variatione Et proprie scilicet secundum quod est continuatio motus ab anima 
             <lb ed="#V" n="79"/>numerata qua mediante motu cuius est passio mensurat anima 
@@ -307,7 +307,7 @@
           <p xml:id="kzz7yh-f08211-d1e556">
             <lb ed="#V" n="91"/>Ad primum dicendum quod Augu. in illa anctoritae: nomine 
             <lb ed="#V" n="92"/>celi intellexit caelum quo sunt 
-            stel<lb ed="#V" n="93" break="no"/>le quod secunda di fuit sactum. Sed ante factionem illius celi 
+            stel<lb ed="#V" n="93" break="no"/>le quod secunda di fuit factum. Sed ante factionem illius celi 
             preces<lb ed="#V" n="94" break="no"/>serat aliqua mensura esse variabilis. quia statim cum illa 
             mo<lb ed="#V" n="95" break="no"/>les fuit creata infra caelum empyreum: incepit in ea aliquis 
             <lb ed="#V" n="96"/>motus qualiscunque fuerit. saltem secundum aliquam sui partem. cuius 
@@ -341,9 +341,9 @@
           </p>
           <p xml:id="kzz7yh-f08211-d1e613">
             ¶ Item secundum philosophum. 10. 
-            <lb ed="#V" n="108"/>metha. in vno quoque generre est aliquod primum et 
+            <lb ed="#V" n="108"/>metha. in vno quoque generare est aliquod primum et 
             simplicissi<lb ed="#V" n="109" break="no"/>munm: quod est mensura omnium existentium in illo genere. et angeli et substantiae 
-            <lb ed="#V" n="110"/>coperales: sunt in genem substantiae. Ergo omnium ipsorum est vna 
+            <lb ed="#V" n="110"/>corporales: sunt in genere substantiae. Ergo omnium ipsorum est vna 
             mem<lb ed="#V" n="111" break="no"/>sura. vel saltem vnigenea.
           </p>
           <p xml:id="kzz7yh-f08211-d1e624">
@@ -357,12 +357,12 @@
             <lb ed="#V" n="116"/>corporalis cum esse ipsius angeli.
           </p>
           <p xml:id="kzz7yh-f08211-d1e641">
-            ¶ Ad hanc quaestinem videtur quibusdam esse 
+            ¶ Ad hanc quaestionem videtur quibusdam esse 
             <lb ed="#V" n="117"/>dicendum quod esse nullius corporis hebet vnigeneam mensuram cum mensura 
             <lb ed="#V" n="118"/>esse ipsius angeli. Quia in ipsis angelis aut non est materia: aute si est ibi 
             <lb ed="#V" n="119"/>materia non est vnigenea. cum materia alicuius corporis. Nec forus cum forus. et 
-            <lb ed="#V" n="120"/>ex conseqenti nec esse vnius cum esse alterius. Nec sunt in aliquo genere 
-            <lb ed="#V" n="121"/>vno: quia quae sunt vnius generris quantum ad prima principia 
+            <lb ed="#V" n="120"/>ex consequenti nec esse vnius cum esse alterius. Nec sunt in aliquo genere 
+            <lb ed="#V" n="121"/>vno: quia quae sunt vnius generaris quantum ad prima principia 
             vnige<lb ed="#V" n="122" break="no"/>nea sunt: et ideo dicunt ipsi esse spiritus: et ee corporis cuius cumque: non 
             po<lb ed="#V" n="123" break="no"/>test esse aliqua mensuam creata vna numero. nec est vnigenea. Unde 
             <lb ed="#V" n="124"/>dicunt quod euum quo mensurantur esse celi empyrei: et euum. quo 
@@ -372,17 +372,17 @@
           <p xml:id="kzz7yh-f08211-d1e665">
             ¶ Alii dicunt quod propria 
             <lb ed="#V" n="127"/>mensura intrinseca esse celi empyrei: et mensura esse angeli vnigenes 
-            <lb ed="#V" n="128"/>sunt: et quod illa que proprie dicitur euum que est inees suppremi 
+            <lb ed="#V" n="128"/>sunt: et quod illa que proprie dicitur euum que est in esse suppremi 
             angeli<lb ed="#V" n="129" break="no"/>sicut in subiecto: et ad ese omnium aliorum angelorum comparatur sicut mensuam 
             <lb ed="#V" n="130"/>extrinseca: est est mensura extrinseca esse celi empirei. Et dicunt 
-            <lb ed="#V" n="131"/>substantias corporeas saltem in corruptibiles esse in eodem genem cum 
+            <lb ed="#V" n="131"/>substantias corporeas saltem in corruptibiles esse in eodem genere cum 
             <lb ed="#V" n="132"/>subictiis spiritualibus: quamuis non eque primo. quia substantie spirituales plus 
             partici<lb ed="#V" n="133" break="no"/>pant de ratione sbe.
           </p>
           <p xml:id="kzz7yh-f08211-d1e683">
-            ¶ Qui vult tenere opinioem primam que videtur 
-            pro<lb ed="#V" n="134" break="no"/>babilior potest respondere ad argumta in opposipium per modum qui sequitur 
-            <lb ed="#V" n="135"/>Ad prmum dicendum quod quamuis esse celi empyrei mensuretur 
+            ¶ Qui vult tenere opinionem primam que videtur 
+            pro<lb ed="#V" n="134" break="no"/>babilior potest respondere ad argumenta in oppositum per modum qui sequitur 
+            <lb ed="#V" n="135"/>Ad primum dicendum quod quamuis esse celi empyrei mensuretur 
             <lb ed="#V" n="136"/>euo: tamen illud euum vnigeneu non est cum euo 
             <lb ed="#V" n="137"/>nddu. 
             <!--00039.xml-->
@@ -392,11 +392,11 @@
           </p>
           <p xml:id="kzz7yh-f08211-d1e703">
             ¶ Ad 2m cum dicitur quod angeli et substantie corporales 
-            <lb ed="#V" n="2"/>sunt ingenere substantiae etc. dico quod non est verum loquendo de substantia 
+            <lb ed="#V" n="2"/>sunt in genere substantiae etc. dico quod non est verum loquendo de substantia 
             <lb ed="#V" n="3"/>vniuoce dicta de illis. Non enim substantia vniuoce dicitur. de illis. 
             <lb ed="#V" n="4"/>nec etiam pure equoce. sed per quandam analogiam. Unde 
             Por<lb ed="#V" n="5" break="no"/>phirius et Boetius qui posuerunt substantias corporales et spirituales 
-            <lb ed="#V" n="6"/>sub eodem genere generralissimo: extenderunt nomen generis 
+            <lb ed="#V" n="6"/>sub eodem genere generalissimo: extenderunt nomen generis 
             <lb ed="#V" n="7"/>vltra illud quod proprie loquendo dicitur genus.
           </p>
           <p xml:id="kzz7yh-f08211-d1e719">

--- a/kzz7yh-f08211/cod-ve09v2_kzz7yh-f08211.xml
+++ b/kzz7yh-f08211/cod-ve09v2_kzz7yh-f08211.xml
@@ -96,7 +96,7 @@
             <lb ed="#V" n="86"/>Contra potest diem iudicii non esset tempus secundum quod 
             in<lb ed="#V" n="87" break="no"/>rauit angelus. vt habetur apocalip. 10. et tamen 
             <lb ed="#V" n="88"/>esset successio et variatio in tormentis que non mensurabitur 
-            <lb ed="#V" n="89"/>euo. Ergo oportet poitionere aliquam aliam mensuram preter euum et thristus 
+            <lb ed="#V" n="89"/>euo. Ergo oportet ponere aliquam aliam mensuram preter euum et tempus 
           </p>
           <p xml:id="kzz7yh-f08211-d1e181">
             <lb ed="#V" n="90"/>Respondeo quod praeter euum et tempus est alia 
@@ -106,8 +106,8 @@
           <p xml:id="kzz7yh-f08211-d1e191">
             <lb ed="#V" n="93"/>¶ Essentia aut potest considerari tripliciter. Uel inquantum 
             <lb ed="#V" n="94"/>talis essentia vt essentia angelica vel humana. Uel inquantum 
-            <lb ed="#V" n="95"/>habens partem extra partem sine percium separatione vel 
-            reali<lb ed="#V" n="96" break="no"/>et actuali distinctione. Uel inquantum habens partem extre 
+            <lb ed="#V" n="95"/>habens partem extra partem sine parcium separatione vel 
+            reali<lb ed="#V" n="96" break="no"/>et actuali distinctione. Uel inquantum habens partem  
             <lb ed="#V" n="97"/>partem actu realiter distinctas inter se.
           </p>
           <p xml:id="kzz7yh-f08211-d1e204">
@@ -122,7 +122,7 @@
           <p xml:id="kzz7yh-f08211-d1e220">
             ¶ Si autem 
             <lb ed="#V" n="104"/>consideretur essentia creata secundo modo: sic debetur sibi 
-            <lb ed="#V" n="105"/>triplex mensuta: vna in trinseca: existens in ea sicut in subto 
+            <lb ed="#V" n="105"/>triplex <sic>mensuta</sic>: vna intrinseca: existens in ea sicut in subiecto 
             <lb ed="#V" n="106"/>et illa est continua quantitas permanens. Alia extrinseca et 
             inge<lb ed="#V" n="107" break="no"/>nere: et illa est locus. Quia substantia sic considerata: aut est locata: 
             <lb ed="#V" n="108"/>aut locabilis locatione circunscriptiua. Alia extrinseca et 
@@ -151,7 +151,7 @@
             ¶ Esse 
             <lb ed="#V" n="123"/>primo modo dicto debetur triplex mensura: vna intrinseca 
             ex<lb ed="#V" n="124" break="no"/>istens in ipso sicut in subiecto. hoc est propria continuatio illius: que 
-            <lb ed="#V" n="125"/>excenso nomine temporis: tempus posset vocari: quamuis in proprie: quia sic 
+            <lb ed="#V" n="125"/> nomine temporis: tempus posset vocari: quamuis in proprie: quia sic 
             <lb ed="#V" n="126"/>possent dici multa tempora. eo quod numerantur secundum numerationem 
             <lb ed="#V" n="127"/>motuum. Alia extrinseca et in genere: et illa est tempus proprie 
             di<lb ed="#V" n="128" break="no"/>ctum quod idem est quod continuatio durationis motus ab anima 
@@ -208,7 +208,7 @@
           <p xml:id="kzz7yh-f08211-d1e380">
             ¶ 
             Pre<lb ed="#V" n="30" break="no"/>ter dictas autem mensuras ponit philosophus: vnam in 
-            predicamen<lb ed="#V" n="31" break="no"/>tis: quam nomininat numerum quam distinguit contra orationem: quia ibi re 
+            predicamen<lb ed="#V" n="31" break="no"/>tis: quam nominat numerum quam distinguit contra orationem: quia ibi re 
             <lb ed="#V" n="32"/>stringit ad multitudinem mensurantem res in 
             perma<lb ed="#V" n="33" break="no"/>nentia se habentes. Orationem autem multitudinem 
             men<lb ed="#V" n="34" break="no"/>surantem: dicit distinctiones in voce siue voces 
@@ -222,7 +222,7 @@
             mul<lb ed="#V" n="42" break="no"/>titudinem que est mensura discretorum quecumque sint illa. 
           </p>
           <p xml:id="kzz7yh-f08211-d1e411">
-            <lb ed="#V" n="43"/>¶ Ex predictis patet quod preter tempus et euum proprie dict 
+            <lb ed="#V" n="43"/>¶ Ex predictis patet quod preter tempus et euum proprie dicta 
             <lb ed="#V" n="44"/>est alia mensura creata: non tantum respectu essentie 
             cre<lb ed="#V" n="45" break="no"/>ture: sed etiam respectu sui esse.
           </p>
@@ -253,7 +253,7 @@
           </p>
           <p xml:id="kzz7yh-f08211-d1e461">
             <lb ed="#V" n="58"/>¶ Item Dama. libro 2. capi. 3. ego theologo Gregorio 
-            consen<lb ed="#V" n="59" break="no"/>tio. dicebat enim primum intellactualem substantiam creari et ita 
+            consen<lb ed="#V" n="59" break="no"/>tio. dicebat enim primum <sic>intellactualem</sic> substantiam creari et ita 
             sensi<lb ed="#V" n="60" break="no"/>bilem et tunc quod ex vtroque scilicet hominem Cum ergo 
             Gre<lb ed="#V" n="61" break="no"/>go. vt refert Dama. ibidem dixerit angelos creatos ante 
             <lb ed="#V" n="62"/>essentiam aliam creationem videtur quod mensura angelorum 
@@ -265,7 +265,7 @@
             <lb ed="#V" n="65"/>que vsitate proprie dicuntur tempora: manifestum est quod a 
             <lb ed="#V" n="66"/>motu siderum ceperunt. Sed creatura angelica et eius 
             <lb ed="#V" n="67"/>mensura: creata fuerant ante sidera. Quia vt habetur <ref xml:id="kzz7yh-f08211-Rd1e496">Gen.</ref> in 
-            <lb ed="#V" n="68"/>sydera<!--sidus?--> creata fuerant 4 die. Ergo euum creatum fuit ante thristus. 
+            <lb ed="#V" n="68"/>sydera creata fuerant 4 die. Ergo euum creatum fuit ante tempus. 
           </p>
           <p xml:id="kzz7yh-f08211-d1e490">
             <!--00038.xml-->
@@ -277,7 +277,7 @@
           </p>
           <p xml:id="kzz7yh-f08211-d1e507">
             ¶ Item secundum quod potest trahi <ref xml:id="kzz7yh-f08211-Rd1e528">ex glosa. Bede Gen. i.</ref> 
-            <lb ed="#V" n="73"/>simul fuerunt concreata anglis: caelum empireum: materia tempus. Cum 
+            <lb ed="#V" n="73"/>simul fuerunt concreata <sic>anglis:</sic> caelum empireum: materia tempus. Cum 
             <lb ed="#V" n="74"/>ergo euum non fuerit creatum ante naturam angelicam: videtur quod 
             <lb ed="#V" n="75"/>euum non fuerit creatum ante tempus. 
           </p>
@@ -305,7 +305,7 @@
             <lb ed="#V" n="90"/>opera. 6 dierum fuisse facta per interualla temporum. 
           </p>
           <p xml:id="kzz7yh-f08211-d1e556">
-            <lb ed="#V" n="91"/>Ad primum dicendum quod Augu. in illa anctoritae: nomine 
+            <lb ed="#V" n="91"/>Ad primum dicendum quod Augu. in illa auctoritate: nomine 
             <lb ed="#V" n="92"/>celi intellexit caelum quo sunt 
             stel<lb ed="#V" n="93" break="no"/>le quod secunda di fuit factum. Sed ante factionem illius celi 
             preces<lb ed="#V" n="94" break="no"/>serat aliqua mensura esse variabilis. quia statim cum illa 
@@ -324,7 +324,7 @@
           </p>
           <p xml:id="kzz7yh-f08211-d1e587">
             ¶ Argumenta ad partem 
-            <lb ed="#V" n="101"/>aliam procedut de tempore communiter dicto. 
+            <lb ed="#V" n="101"/>aliam procedunt de tempore communiter dicto. 
           </p>
         </div>
         <div xml:id="kzz7yh-f08211-Dd1e593">
@@ -348,8 +348,8 @@
           </p>
           <p xml:id="kzz7yh-f08211-d1e624">
             ¶ Item quae simul creantur in eadem 
-            men<lb ed="#V" n="112" break="no"/>sura vndeer creari. Sed celum empyreum et natura angelica: simul 
-            crea<lb ed="#V" n="113" break="no"/>ta fuerant. vt ante hitum estia ergo in eadem mensura fuerant creata. 
+            men<lb ed="#V" n="112" break="no"/>sura  creari. Sed celum empyreum et natura angelica: simul 
+            crea<lb ed="#V" n="113" break="no"/>ta fuerant. vt ante habitum est. ergo in eadem mensura fuerant creata. 
           </p>
           <p xml:id="kzz7yh-f08211-d1e631">
             <lb ed="#V" n="114"/>Contra nullius corporis essentia hebet vnigeneam mensuram 
@@ -359,12 +359,12 @@
           <p xml:id="kzz7yh-f08211-d1e641">
             ¶ Ad hanc quaestionem videtur quibusdam esse 
             <lb ed="#V" n="117"/>dicendum quod esse nullius corporis hebet vnigeneam mensuram cum mensura 
-            <lb ed="#V" n="118"/>esse ipsius angeli. Quia in ipsis angelis aut non est materia: aute si est ibi 
+            <lb ed="#V" n="118"/>esse ipsius angeli. Quia in ipsis angelis aut non est materia: aut si est ibi 
             <lb ed="#V" n="119"/>materia non est vnigenea. cum materia alicuius corporis. Nec forus cum forus. et 
             <lb ed="#V" n="120"/>ex consequenti nec esse vnius cum esse alterius. Nec sunt in aliquo genere 
             <lb ed="#V" n="121"/>vno: quia quae sunt vnius generaris quantum ad prima principia 
             vnige<lb ed="#V" n="122" break="no"/>nea sunt: et ideo dicunt ipsi esse spiritus: et ee corporis cuius cumque: non 
-            po<lb ed="#V" n="123" break="no"/>test esse aliqua mensuam creata vna numero. nec est vnigenea. Unde 
+            po<lb ed="#V" n="123" break="no"/>test esse aliqua mensura creata vna numero. nec est vnigenea. Unde 
             <lb ed="#V" n="124"/>dicunt quod euum quo mensurantur esse celi empyrei: et euum. quo 
             men<lb ed="#V" n="125" break="no"/>surantur esse angeli: diuersa sunt eua in nuero: nec est sunt 
             v<lb ed="#V" n="126" break="no"/>nigenea: quia non sunt generis eiusdem.
@@ -373,10 +373,10 @@
             ¶ Alii dicunt quod propria 
             <lb ed="#V" n="127"/>mensura intrinseca esse celi empyrei: et mensura esse angeli vnigenes 
             <lb ed="#V" n="128"/>sunt: et quod illa que proprie dicitur euum que est in esse suppremi 
-            angeli<lb ed="#V" n="129" break="no"/>sicut in subiecto: et ad ese omnium aliorum angelorum comparatur sicut mensuam 
+            angeli<lb ed="#V" n="129" break="no"/>sicut in subiecto: et ad ese omnium aliorum angelorum comparatur sicut mensura 
             <lb ed="#V" n="130"/>extrinseca: est est mensura extrinseca esse celi empirei. Et dicunt 
             <lb ed="#V" n="131"/>substantias corporeas saltem in corruptibiles esse in eodem genere cum 
-            <lb ed="#V" n="132"/>subictiis spiritualibus: quamuis non eque primo. quia substantie spirituales plus 
+            <lb ed="#V" n="132"/>substantiis spiritualibus: quamuis non eque primo. quia substantie spirituales plus 
             partici<lb ed="#V" n="133" break="no"/>pant de ratione sbe.
           </p>
           <p xml:id="kzz7yh-f08211-d1e683">
@@ -384,7 +384,7 @@
             pro<lb ed="#V" n="134" break="no"/>babilior potest respondere ad argumenta in oppositum per modum qui sequitur 
             <lb ed="#V" n="135"/>Ad primum dicendum quod quamuis esse celi empyrei mensuretur 
             <lb ed="#V" n="136"/>euo: tamen illud euum vnigeneu non est cum euo 
-            <lb ed="#V" n="137"/>nddu. 
+            <lb ed="#V" n="137"/>angelorum. 
             <!--00039.xml-->
             <pb ed="#V" n="13-r"/>
             <cb ed="#P" n="a"/>


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve09v2_kzz7yh-f08211.xml`.

## Applied changes

- p. 12r l. 83: sehabens → se habens: merged words; euo is valid aevum ablative
- p. 12r l. 110: magnitudis: not in Latin word list — review needed
- p. 12r l. 126: nuerationem: not in Latin word list — review needed
- p. 12r l. 135: Predicto → Praedicto: not in word list (OCR transform matched)
- p. 12v l. 28: infintum → infinitum: not in word list (OCR transform matched)
- p. 12v l. 47: Argumntum: 3+ consecutive consonants — likely garbled OCR
- p. 12v l. 76: dupliter → dupliciter: dropped syllable; acciposilicet → accipi scilicet: garbled merge
- p. 12v l. 93: sactum → factum: s/f misread at word start
- p. 12v l. 108: generre → generare: not in word list (OCR transform matched)
- p. 12v l. 110: coperales → corporales: transposed; genem → genere: garbled
- p. 12v l. 116: quaestinem → quaestionem: not in word list (OCR transform matched)
- p. 12v l. 120: conseqenti → consequenti: not in word list (OCR transform matched)
- p. 12v l. 121: generris → generaris: not in word list (OCR transform matched)
- p. 12v l. 128: inees → in esse: merged words; suppremi → supremi: doubled 'p'; euum valid
- p. 12v l. 131: genem: not in Latin word list — review needed
- p. 12v l. 133: opinioem: not in Latin word list — review needed
- p. 12v l. 134: argumta → argumenta: dropped 'en'; opposipium → oppositum: garbled
- p. 12v l. 135: prmum → primum: dropped 'i'; empyrei is valid
- p. 13r l. 2: ingenere → in genere: merged words; ingenuere suggestion was wrong
- p. 13r l. 6: generralissimo: not in Latin word list — review needed

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_