### PR TITLE
Transcription corrections: cod-ve09v2_kzz7yh-f08868.xml (31 changes)

### DIFF
--- a/kzz7yh-f08868/cod-ve09v2_kzz7yh-f08868.xml
+++ b/kzz7yh-f08868/cod-ve09v2_kzz7yh-f08868.xml
@@ -122,7 +122,7 @@
           </p>
           <p xml:id="kzz7yh-f08868-d1e217">
             <lb ed="#V" n="60"/>Ad primum in oppositum: cum dicitur quod 
-            Sra<lb ed="#V" n="61" break="no"/>bus  illud caelum esse 
+            Sra<lb ed="#V" n="61" break="no"/>bus <sic>dicic</sic> illud caelum esse 
             intellec<lb ed="#V" n="62" break="no"/>tuale etc. dico quod intellexit quod illud caelum non <sic>percipemus</sic> 
             <lb ed="#V" n="63"/>sensu sed per fidem, qua intellectus noster assentit 
             sacre<lb ed="#V" n="64" break="no"/>scripture.
@@ -246,7 +246,7 @@
             <pb ed="#V" n="13-v"/>
             <cb ed="#P" n="a"/>
             <lb ed="#V" n="1"/>esse naturali operatione. Et forte: influentia eius 
-            maxi<lb ed="#V" n="2" break="no"/>me  ad debitam proportionem dispositionis 
+            maxi<lb ed="#V" n="2" break="no"/>me cooperatur ad debitam proportionem dispositionis 
             <lb ed="#V" n="3"/>corporalis humani. cum ipsum sit nobilius inter 
             ce<lb ed="#V" n="4" break="no"/>lons et corpus humanum sit inter generabilia et 
             corrup<lb ed="#V" n="5" break="no"/>tibilia nobilissimum: et etiam nobilius celo inquantum est 
@@ -267,12 +267,10 @@
             em<lb ed="#V" n="18" break="no"/>pyrei pertingat ad h inferiora et si ad ista non pertingat 
             ei<lb ed="#V" n="19" break="no"/>sumen. ¶ Ad 2m dicendum quod motus non fuit necessarius corporibus 
             <lb ed="#V" n="20"/>celestibus per influentiarum sed propter influentiam contemperantiam. 
-            <lb ed="#V" n="21"/>vnde si sol staret: lumen et calorem influeret. Sequitur 
-            mfiu<lb ed="#V" n="22" break="no"/>entie non possent proportionari nini alternarentur: et v lesse non 
+            <lb ed="#V" n="21"/>vnde si sol staret: lumen et calorem influeret. Sed quia influ<lb ed="#V" n="22" break="no"/>entie non possent proportionari nini alternarentur: et v lesse non 
             <lb ed="#V" n="23"/>poterat: sine motum silorum corporum ideo necessarius fuit 
             <lb ed="#V" n="24"/>motus illorum corporum: ad naturale regimen istorum 
-            <lb ed="#V" n="25"/>inferiorum: quorum naturalis generatio et conservationi 
-            <lb ed="#V" n="26"/>quirit influentiarum celestium: talem proportionem que 
+            <lb ed="#V" n="25"/>inferiorum: quorum naturalis generatio et conservatio re<lb ed="#V" n="26" break="no"/>quirit influentiarum celestium: talem proportionem que 
             si<lb ed="#V" n="27" break="no"/>ne alternatione influentiarum et renouatione: non posrit. 
             <lb ed="#V" n="28"/>Et sicut omne mobile reduci <sic>opportet</sic> ad immobile. 
             Ali<lb ed="#V" n="29" break="no"/>quo modo a simili dici potest: quam forte infiuentie celorum 
@@ -281,7 +279,7 @@
             infiu<lb ed="#V" n="32" break="no"/>entiua aliternatur. ¶ Dicunt amen quidam: quod ab vna parte 
             <lb ed="#V" n="33"/>eius alia virtus influitur: quam ab alia: quia et si sit  
             vnifor<lb ed="#V" n="34" break="no"/>miter luminosum: quod conantur probare. Sic Grego 4. li. 
-            <lb ed="#V" n="35"/>Mora longe vitra medium. terra aere fecundatur:  ex 
+            <lb ed="#V" n="35"/>Mora longe vitra medium. terra aere fecundatur: aer ex 
             <lb ed="#V" n="36"/>celi qualitate disponitur: cum ergo dicunt ipsi uideamus 
             <lb ed="#V" n="37"/>terras equaliter distantes ab vtroque polo: et ita habentes 
             <lb ed="#V" n="38"/>omnem influentiam corporum caelestium mobilium: 

--- a/kzz7yh-f08868/cod-ve09v2_kzz7yh-f08868.xml
+++ b/kzz7yh-f08868/cod-ve09v2_kzz7yh-f08868.xml
@@ -98,7 +98,7 @@
             <lb ed="#V" n="40"/>non est possibile vt sit extra caelum corpus omnio. et constat per suum 
             <lb ed="#V" n="41"/>processum ibidem: quod loquebatur de illo celo: quod sacra 
             criptu<lb ed="#V" n="42" break="no"/>ra vocat firmamentum. ergo vltra illud caelum non est 
-            ali<lb ed="#V" n="43" break="no"/>ud  celu. 
+            ali<lb ed="#V" n="43" break="no"/>quod corporale celum. 
           </p>
           <p xml:id="kzz7yh-f08868-d1e176">
             <lb ed="#V" n="44"/>Contra Beda super illud Gen in terra erat inanis et 

--- a/kzz7yh-f08868/cod-ve09v2_kzz7yh-f08868.xml
+++ b/kzz7yh-f08868/cod-ve09v2_kzz7yh-f08868.xml
@@ -98,7 +98,7 @@
             <lb ed="#V" n="40"/>non est possibile vt sit extra caelum corpus omnio. et constat per suum 
             <lb ed="#V" n="41"/>processum ibidem: quod loquebatur de illo celo: quod sacra 
             criptu<lb ed="#V" n="42" break="no"/>ra vocat firmamentum. ergo vltra illud caelum non est 
-            ali<lb ed="#V" n="43" break="no"/>ud comdle celu. 
+            ali<lb ed="#V" n="43" break="no"/>ud  celu. 
           </p>
           <p xml:id="kzz7yh-f08868-d1e176">
             <lb ed="#V" n="44"/>Contra Beda super illud Gen in terra erat inanis et 
@@ -122,8 +122,8 @@
           </p>
           <p xml:id="kzz7yh-f08868-d1e217">
             <lb ed="#V" n="60"/>Ad primum in oppositum: cum dicitur quod 
-            Sra<lb ed="#V" n="61" break="no"/>bus dicic illud caelum esse 
-            intellec<lb ed="#V" n="62" break="no"/>tuale etc. dico quod intellexit quod illud caelum non percipemus 
+            Sra<lb ed="#V" n="61" break="no"/>bus  illud caelum esse 
+            intellec<lb ed="#V" n="62" break="no"/>tuale etc. dico quod intellexit quod illud caelum non <sic>percipemus</sic> 
             <lb ed="#V" n="63"/>sensu sed per fidem, qua intellectus noster assentit 
             sacre<lb ed="#V" n="64" break="no"/>scripture.
           </p>
@@ -154,16 +154,16 @@
           <p xml:id="kzz7yh-f08868-d1e267">
             ¶ Item inter 
             spe<lb ed="#V" n="74" break="no"/>ras celestes: nobis sensibiliter notas: illa est magis 
-            stellata<lb ed="#V" n="75" break="no"/>que est superior: quia in qualibet enim sperarum inferiorum non est 
+            stellata<lb ed="#V" n="75" break="no"/>que est superior: quia in qualibet enim <sic>sperarum</sic> inferiorum non est 
             <lb ed="#V" n="76"/>nisi vna stella que planeta dicitur in octaua autem spera est 
             <lb ed="#V" n="77"/>multitudo stellarum magna. Ergo videtur cum caelum 
-            <lb ed="#V" n="78"/>empyreum sit omnibus aliis speris superius quod maxime 
+            <lb ed="#V" n="78"/>empyreum sit omnibus aliis <sic>speris</sic> superius quod maxime 
             <lb ed="#V" n="79"/>debuit esse stellatum. 
           </p>
           <p xml:id="kzz7yh-f08868-d1e283">
             <lb ed="#V" n="80"/>Contra Dama. lib. 2. capi. 5. loquens de supremo 
             celo<lb ed="#V" n="81" break="no"/>dicit quod qui foris sunt sapientes siue stellis in 
-            <lb ed="#V" n="82"/>spere forma quomon ea non sunt moysi sua facientes dogmata. 
+            <lb ed="#V" n="82"/>spere forma quomodo ea non sunt moysi sua facientes dogmata. 
           </p>
           <p xml:id="kzz7yh-f08868-d1e292">
             <lb ed="#V" n="83"/>Respondeo quod illud celum non est stellatum sed 
@@ -222,7 +222,7 @@
             cor<lb ed="#V" n="119" break="no"/>porum: videmus influentias variari: ita quomodo est 
             in<lb ed="#V" n="120" break="no"/>fluentia ad generationem: modo ad corruptionem. secundum quod 
             di<lb ed="#V" n="121" break="no"/>cit philosophus. 2. de generatione. Sed caelum empyreum non 
-            mo<lb ed="#V" n="122" break="no"/>uetur vt ante hitum est Ergo in hoc inferiora non influit. 
+            mo<lb ed="#V" n="122" break="no"/>uetur vt ante habitum est Ergo in hoc inferiora non influit. 
           </p>
           <p xml:id="kzz7yh-f08868-d1e400">
             <lb ed="#V" n="123"/>Contra omnia que sunt infra hominem: propter 
@@ -246,7 +246,7 @@
             <pb ed="#V" n="13-v"/>
             <cb ed="#P" n="a"/>
             <lb ed="#V" n="1"/>esse naturali operatione. Et forte: influentia eius 
-            maxi<lb ed="#V" n="2" break="no"/>me comoperatur ad debitam proportionem dispositionis 
+            maxi<lb ed="#V" n="2" break="no"/>me  ad debitam proportionem dispositionis 
             <lb ed="#V" n="3"/>corporalis humani. cum ipsum sit nobilius inter 
             ce<lb ed="#V" n="4" break="no"/>lons et corpus humanum sit inter generabilia et 
             corrup<lb ed="#V" n="5" break="no"/>tibilia nobilissimum: et etiam nobilius celo inquantum est 
@@ -255,41 +255,41 @@
           </p>
           <p xml:id="kzz7yh-f08868-d1e458">
             <lb ed="#V" n="8"/>Ad primum in oppositum cum dicitur: quod 
-            cor<lb ed="#V" n="9" break="no"/>voram superiora inniuunt 
+            cor<lb ed="#V" n="9" break="no"/>pora superiora influunt 
             illumi<lb ed="#V" n="10" break="no"/>nando etc. dico quod bene quandocumque pertingit virtus ad 
-            <lb ed="#V" n="11"/>aliquid ilia horam qua ad illud indem non vrtingit: eorum 
+            <lb ed="#V" n="11"/>aliquid ilia horam qua ad illud idem non pertingit: eorum 
             <lb ed="#V" n="12"/>lumeni. quam patet existentiae luna enim existente sub 
             nostro<lb ed="#V" n="13" break="no"/>hemispio: per virtutem eius sit simul fluxus maris: in 
             quar<lb ed="#V" n="14" break="no"/>ta terrae que est sub nostro hemisphaerio: lune supposita: et in 
-            <lb ed="#V" n="15"/>quarta terre nostri hemispium illi quarte opponsita: cum tamen 
-            <lb ed="#V" n="16"/>tunc lumen iune non inllumietur quartum terre nontri emispi 
+            <lb ed="#V" n="15"/>quarta terre nostri hemisphaerii illi quarte opposita: cum tamen 
+            <lb ed="#V" n="16"/>tunc lumen lune non illuminet quartam terre nostri <sic>emisperii</sic> 
             in<lb ed="#V" n="17" break="no"/>quae sit fluxus per eam. Ita potest dici: quod aliqua virtus celi 
             em<lb ed="#V" n="18" break="no"/>pyrei pertingat ad h inferiora et si ad ista non pertingat 
             ei<lb ed="#V" n="19" break="no"/>sumen. ¶ Ad 2m dicendum quod motus non fuit necessarius corporibus 
-            <lb ed="#V" n="20"/>celestibus per infuenta sequa propter infiuentiatum contempantiam. 
-            <lb ed="#V" n="21"/>vnde si somi staret: lumen et cuorem influeret. Sequd dr 
+            <lb ed="#V" n="20"/>celestibus per influentiarum sed propter influentiam contemperantiam. 
+            <lb ed="#V" n="21"/>vnde si sol staret: lumen et calorem influeret. Sequitur 
             mfiu<lb ed="#V" n="22" break="no"/>entie non possent proportionari nini alternarentur: et v lesse non 
             <lb ed="#V" n="23"/>poterat: sine motum silorum corporum ideo necessarius fuit 
             <lb ed="#V" n="24"/>motus illorum corporum: ad naturale regimen istorum 
-            <lb ed="#V" n="25"/>inferiorum: quorum naturalis generatio et conseruationre 
-            <lb ed="#V" n="26"/>quirit inniuentiarum celestium: talem proportionem que 
+            <lb ed="#V" n="25"/>inferiorum: quorum naturalis generatio et conservationi 
+            <lb ed="#V" n="26"/>quirit influentiarum celestium: talem proportionem que 
             si<lb ed="#V" n="27" break="no"/>ne alternatione influentiarum et renouatione: non posrit. 
-            <lb ed="#V" n="28"/>Et sicut omne mobile reduci opportet ad immobile. 
+            <lb ed="#V" n="28"/>Et sicut omne mobile reduci <sic>opportet</sic> ad immobile. 
             Ali<lb ed="#V" n="29" break="no"/>quo modo a simili dici potest: quam forte infiuentie celorum 
             <lb ed="#V" n="30"/>mobilium que alternantur: iuuantur et contemperantur: per 
             <lb ed="#V" n="31"/>influentiam caeli empyrei: quam non mouent: nec eius 
             infiu<lb ed="#V" n="32" break="no"/>entiua aliternatur. ¶ Dicunt amen quidam: quod ab vna parte 
-            <lb ed="#V" n="33"/>eius alia virtus influitur: quam ab alia: quia et si sit vntrns 
-            or<lb ed="#V" n="34" break="no"/>miter luminosum: quod conantur probare. Sic Srego 4. li. 
-            <lb ed="#V" n="35"/>Mora longe vitra medium. terra aere fecundatur: acetr ex 
+            <lb ed="#V" n="33"/>eius alia virtus influitur: quam ab alia: quia et si sit  
+            vnifor<lb ed="#V" n="34" break="no"/>miter luminosum: quod conantur probare. Sic Grego 4. li. 
+            <lb ed="#V" n="35"/>Mora longe vitra medium. terra aere fecundatur:  ex 
             <lb ed="#V" n="36"/>celi qualitate disponitur: cum ergo dicunt ipsi uideamus 
             <lb ed="#V" n="37"/>terras equaliter distantes ab vtroque polo: et ita habentes 
             <lb ed="#V" n="38"/>omnem influentiam corporum caelestium mobilium: 
             equa<lb ed="#V" n="39" break="no"/>les hoc diuersas habere dispositiones: et corpora hominum 
-            <lb ed="#V" n="40"/>in terris illis habere diuetr sas naturales inclinationes: et 
+            <lb ed="#V" n="40"/>in terris illis habere  diuersas naturales inclinationes: et 
             <lb ed="#V" n="41"/>semper ita fuisse: ex quo inhabitari ceperunt: videtur hoc esse 
             <lb ed="#V" n="42"/>quia ille terrae diuersas influentias caeli empyrei recipiunt 
-            <lb ed="#V" n="43"/>que non alternantur mec potest dici hoc esse quia speram 
+            <lb ed="#V" n="43"/>que non alternantur. Nec potest dici hoc esse quia spara 
             oc<lb ed="#V" n="44" break="no"/>taua continue mutet polum: quia tunc ille terre non 
             sem<lb ed="#V" n="45" break="no"/>per sic fuissent in dispositionibus ita sibi repugnantibus: 
             si<lb ed="#V" n="46" break="no"/>cut fuerant. ¶ Alu autem dicunt: quam sicut illud caelum est 

--- a/kzz7yh-f08868/cod-ve09v2_kzz7yh-f08868.xml
+++ b/kzz7yh-f08868/cod-ve09v2_kzz7yh-f08868.xml
@@ -101,7 +101,7 @@
             ali<lb ed="#V" n="43" break="no"/>ud comdle celu. 
           </p>
           <p xml:id="kzz7yh-f08868-d1e176">
-            <lb ed="#V" n="44"/>Contra Geda super illud Gen in terra erat inanis et 
+            <lb ed="#V" n="44"/>Contra Beda super illud Gen in terra erat inanis et 
             <lb ed="#V" n="45"/>vacua etc. dicit quod hoc superius celum: quod a 
             volu<lb ed="#V" n="46" break="no"/>pilitate mundi secretum est mox vt creatum est: sanctis 
             an<lb ed="#V" n="47" break="no"/>gelis repletum est. Sed nulla creatura intellectualis potest 
@@ -109,10 +109,10 @@
             <lb ed="#V" n="49"/>est creatura corporalis. 
           </p>
           <p xml:id="kzz7yh-f08868-d1e193">
-            <lb ed="#V" n="50"/>Respondeo quod vitra aquas que super firmamen 
-            <lb ed="#V" n="51"/>tum: est vnum corporale caelum quod 
-            <lb ed="#V" n="52"/>vocatur caelum empyreum: quod non ab ardore: sed a splendo 
-            <lb ed="#V" n="53"/>re dictum est: quod secundum communiorem opinionem intelligitur per illud 
+            <lb ed="#V" n="50"/>Respondeo quod vitra aquas que super 
+            firmamen<lb ed="#V" n="51" break="no"/>tum: est vnum corporale caelum quod 
+            <lb ed="#V" n="52"/>vocatur caelum empyreum: quod non ab ardore: sed a 
+            splendo<lb ed="#V" n="53" break="no"/>re dictum est: quod secundum communiorem opinionem intelligitur per illud 
             ce<lb ed="#V" n="54" break="no"/>lum quod sacra scriptura dicit: deum in principio creasse caelum 
             <lb ed="#V" n="55"/>cum terra. quia firmamentum secunda die factum est: et ipsum celum 
             <lb ed="#V" n="56"/>empyreum est locus beatorum. Et ipsum celum deus voluit non 
@@ -161,7 +161,7 @@
             <lb ed="#V" n="79"/>debuit esse stellatum. 
           </p>
           <p xml:id="kzz7yh-f08868-d1e283">
-            <lb ed="#V" n="80"/>Contra Dama. lib. 2. capi. 5. loquens de suprimo 
+            <lb ed="#V" n="80"/>Contra Dama. lib. 2. capi. 5. loquens de supremo 
             celo<lb ed="#V" n="81" break="no"/>dicit quod qui foris sunt sapientes siue stellis in 
             <lb ed="#V" n="82"/>spere forma quomon ea non sunt moysi sua facientes dogmata. 
           </p>
@@ -178,7 +178,7 @@
             apprehen<lb ed="#V" n="92" break="no"/>di quia non est influentia dei ad hoc vt illud lumen 
             multi<lb ed="#V" n="93" break="no"/>plicet si sensibiliter vsquam ad nos sine qua influentia si 
             mul<lb ed="#V" n="94" break="no"/>tiplicare non potest Quo autem aque super celos sunt 
-            cu<lb ed="#V" n="95" break="no"/>sint perspicue vnde ab auctoribus dicutur celum 
+            cu<lb ed="#V" n="95" break="no"/>sint perspicue vnde ab auctoribus dicuntur celum 
             christal<lb ed="#V" n="96" break="no"/>linum possent impedire illius luminis multiplicationem 
             <lb ed="#V" n="97"/>non video: nisi adesset alia causa.
           </p>
@@ -230,15 +230,15 @@
             di<lb ed="#V" n="125" break="no"/>stinctione habitum est. Sed hoc est nobilior creatura quam celum 
             <lb ed="#V" n="126"/>empyreum. quia non est animatum: vt inferius ostendetur. 
             Er<lb ed="#V" n="127" break="no"/>go est propter obsequium hominis factum. Sed non 
-            praet<lb ed="#V" n="128" break="no"/>staret homini aliquod obsequm: vt videtur nisi in hoc 
+            praet<lb ed="#V" n="128" break="no"/>staret homini aliquod obsequium: vt videtur nisi in hoc 
             inferiora<lb ed="#V" n="129" break="no"/>influeret. Ergo influit in hec inferiora. 
           </p>
           <p xml:id="kzz7yh-f08868-d1e418">
             <lb ed="#V" n="130"/>Respondeo quod quamuis aliqui dixerunt quod celum 
             em<lb ed="#V" n="131" break="no"/>pyreum non influit in hoc inferiora: 
-            <lb ed="#V" n="132"/>et quod non est in obsequm homini quantum ad statum 
+            <lb ed="#V" n="132"/>et quod non est in obsequium homini quantum ad statum 
             presenten<lb ed="#V" n="133" break="no"/>sed tantum quantum ad statum glorie. Uidetur tamen mihi dicendum: quod non 
-            <lb ed="#V" n="134"/>tantum modo est ordinatum ad obsequm hominis quantum ad statum 
+            <lb ed="#V" n="134"/>tantum modo est ordinatum ad obsequium hominis quantum ad statum 
             <lb ed="#V" n="135"/>futurum: sed etiam quantum ad presentem in hoc inferiora influendo 
             vir<lb ed="#V" n="136" break="no"/>tutem. Quia sicut dicit Dama. libro 2. c. 23. impossibile est substantiam ex parte. 
             
@@ -247,60 +247,60 @@
             <cb ed="#P" n="a"/>
             <lb ed="#V" n="1"/>esse naturali operatione. Et forte: influentia eius 
             maxi<lb ed="#V" n="2" break="no"/>me comoperatur ad debitam proportionem dispositionis 
-            <lb ed="#V" n="3"/>comrporalis humani. cum ipboesum sit nobiltius inter 
-            ce<lb ed="#V" n="4" break="no"/>lons et corbus humanum sit inter generabilia et 
-            corrup<lb ed="#V" n="5" break="no"/>tibilia nonbilisimum: et etiam nobilius celo inquantum est 
+            <lb ed="#V" n="3"/>corporalis humani. cum ipsum sit nobilius inter 
+            ce<lb ed="#V" n="4" break="no"/>lons et corpus humanum sit inter generabilia et 
+            corrup<lb ed="#V" n="5" break="no"/>tibilia nobilissimum: et etiam nobilius celo inquantum est 
             <lb ed="#V" n="6"/>ab anima perfectum: cum celi sint inanimati. vt 
             inferi<lb ed="#V" n="7" break="no"/>us ostendetur. 
           </p>
           <p xml:id="kzz7yh-f08868-d1e458">
             <lb ed="#V" n="8"/>Ad primum in oppositum cum dicitur: quod 
             cor<lb ed="#V" n="9" break="no"/>voram superiora inniuunt 
-            illumi<lb ed="#V" n="10" break="no"/>nando etc. dico quod bene quandoequam pertingit virtus ad 
+            illumi<lb ed="#V" n="10" break="no"/>nando etc. dico quod bene quandocumque pertingit virtus ad 
             <lb ed="#V" n="11"/>aliquid ilia horam qua ad illud indem non vrtingit: eorum 
-            <lb ed="#V" n="12"/>lumeni. quam patet exhientie luna enim existente sub 
-            nostro<lb ed="#V" n="13" break="no"/>hemispio: per virtutem eius sit simul flurtus maris: in 
-            quar<lb ed="#V" n="14" break="no"/>ta terrem que est sub nostro hemispio: lune supposita: et in 
+            <lb ed="#V" n="12"/>lumeni. quam patet existentiae luna enim existente sub 
+            nostro<lb ed="#V" n="13" break="no"/>hemispio: per virtutem eius sit simul fluxus maris: in 
+            quar<lb ed="#V" n="14" break="no"/>ta terrae que est sub nostro hemisphaerio: lune supposita: et in 
             <lb ed="#V" n="15"/>quarta terre nostri hemispium illi quarte opponsita: cum tamen 
             <lb ed="#V" n="16"/>tunc lumen iune non inllumietur quartum terre nontri emispi 
-            in<lb ed="#V" n="17" break="no"/>quae sit fiutus per eam. Ita botest dici: quod aliqua virtus celi 
-            em<lb ed="#V" n="18" break="no"/>pyrei prtingat ad h inferiora et si ad ista non pertingat 
-            ei<lb ed="#V" n="19" break="no"/>sumen. ¶ Ad etum dicendum quam motus non fuit neccnius corponribus 
+            in<lb ed="#V" n="17" break="no"/>quae sit fluxus per eam. Ita potest dici: quod aliqua virtus celi 
+            em<lb ed="#V" n="18" break="no"/>pyrei pertingat ad h inferiora et si ad ista non pertingat 
+            ei<lb ed="#V" n="19" break="no"/>sumen. ¶ Ad 2m dicendum quod motus non fuit necessarius corporibus 
             <lb ed="#V" n="20"/>celestibus per infuenta sequa propter infiuentiatum contempantiam. 
             <lb ed="#V" n="21"/>vnde si somi staret: lumen et cuorem influeret. Sequd dr 
             mfiu<lb ed="#V" n="22" break="no"/>entie non possent proportionari nini alternarentur: et v lesse non 
-            <lb ed="#V" n="23"/>poterat: sine motum silorum corporum ideo necestarius fuit 
+            <lb ed="#V" n="23"/>poterat: sine motum silorum corporum ideo necessarius fuit 
             <lb ed="#V" n="24"/>motus illorum corporum: ad naturale regimen istorum 
             <lb ed="#V" n="25"/>inferiorum: quorum naturalis generatio et conseruationre 
             <lb ed="#V" n="26"/>quirit inniuentiarum celestium: talem proportionem que 
-            si<lb ed="#V" n="27" break="no"/>ne alternatione inuentiarum et renouatione: non posrit. 
+            si<lb ed="#V" n="27" break="no"/>ne alternatione influentiarum et renouatione: non posrit. 
             <lb ed="#V" n="28"/>Et sicut omne mobile reduci opportet ad immobile. 
             Ali<lb ed="#V" n="29" break="no"/>quo modo a simili dici potest: quam forte infiuentie celorum 
             <lb ed="#V" n="30"/>mobilium que alternantur: iuuantur et contemperantur: per 
-            <lb ed="#V" n="31"/>inniuentiam celiempyrei: quam non mouent: nec eius 
+            <lb ed="#V" n="31"/>influentiam caeli empyrei: quam non mouent: nec eius 
             infiu<lb ed="#V" n="32" break="no"/>entiua aliternatur. ¶ Dicunt amen quidam: quod ab vna parte 
             <lb ed="#V" n="33"/>eius alia virtus influitur: quam ab alia: quia et si sit vntrns 
             or<lb ed="#V" n="34" break="no"/>miter luminosum: quod conantur probare. Sic Srego 4. li. 
             <lb ed="#V" n="35"/>Mora longe vitra medium. terra aere fecundatur: acetr ex 
             <lb ed="#V" n="36"/>celi qualitate disponitur: cum ergo dicunt ipsi uideamus 
             <lb ed="#V" n="37"/>terras equaliter distantes ab vtroque polo: et ita habentes 
-            <lb ed="#V" n="38"/>omnem infiuentiam corporum celesuium mobilium: 
+            <lb ed="#V" n="38"/>omnem influentiam corporum caelestium mobilium: 
             equa<lb ed="#V" n="39" break="no"/>les hoc diuersas habere dispositiones: et corpora hominum 
             <lb ed="#V" n="40"/>in terris illis habere diuetr sas naturales inclinationes: et 
             <lb ed="#V" n="41"/>semper ita fuisse: ex quo inhabitari ceperunt: videtur hoc esse 
-            <lb ed="#V" n="42"/>quium ille terre diuersus infiuentias celiempyrei recipiunt 
+            <lb ed="#V" n="42"/>quia ille terrae diuersas influentias caeli empyrei recipiunt 
             <lb ed="#V" n="43"/>que non alternantur mec potest dici hoc esse quia speram 
             oc<lb ed="#V" n="44" break="no"/>taua continue mutet polum: quia tunc ille terre non 
             sem<lb ed="#V" n="45" break="no"/>per sic fuissent in dispositionibus ita sibi repugnantibus: 
             si<lb ed="#V" n="46" break="no"/>cut fuerant. ¶ Alu autem dicunt: quam sicut illud caelum est 
-            vni<lb ed="#V" n="47" break="no"/>forme in iumine ita: in virtutre: et omnes eius partes 
-            vni<lb ed="#V" n="48" break="no"/>formiter infiuunt virtutem. Et dicunt diuersitates 
-            natu<lb ed="#V" n="49" break="no"/>rales que sunt in diuersis terre partibus: nonn oportere 
-            re<lb ed="#V" n="50" break="no"/>duci in infiuentiam celi: sicut in totam causam creatam: quia 
-            <lb ed="#V" n="51"/>elementa suas brobrias infiuentias habent ex sua natura 
-            ie<lb ed="#V" n="52" break="no"/>terra in diuersis prtibus diuersam propter diuersas 
-            dispositio<lb ed="#V" n="53" break="no"/>nes: quas recepitur: in diuersis pertibus a sua conditione. Sed 
-            <lb ed="#V" n="54"/>primum opintio euidentius videtur rationi concordare. 
+            vni<lb ed="#V" n="47" break="no"/>forme in lumine ita: in virtute: et omnes eius partes 
+            vni<lb ed="#V" n="48" break="no"/>formiter influunt virtutem. Et dicunt diuersitates 
+            natu<lb ed="#V" n="49" break="no"/>rales que sunt in diuersis terre partibus: non oportere 
+            re<lb ed="#V" n="50" break="no"/>duci in influentiam celi: sicut in totam causam creatam: quia 
+            <lb ed="#V" n="51"/>elementa suas proprias influentias habent ex sua natura 
+            ie<lb ed="#V" n="52" break="no"/>terra in diuersis partibus diuersam propter diuersas 
+            dispositio<lb ed="#V" n="53" break="no"/>nes: quas recipitur: in diuersis partibus a sua conditione. Sed 
+            <lb ed="#V" n="54"/>primum opinio euidentius videtur rationi concordare. 
           </p>
         </div>
       </div>


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve09v2_kzz7yh-f08868.xml`.

## Applied changes

- p. 13r l. 44: Geda → Beda: G/B misread; Gen is valid abbreviation for Genesis
- p. 13r l. 51: 'firmamen' + 'tum' split across line break without break="no" on lb n=51
- p. 13r l. 53: 'splendo' + 're' split across line break without break="no" on lb n=53
- p. 13r l. 80: suprimo: not in Latin word list — review needed
- p. 13r l. 95: dicutur: not in Latin word list — review needed
- p. 13r l. 128: obsequm: not in Latin word list — review needed
- p. 13r l. 132: obsequm: not in Latin word list — review needed
- p. 13r l. 134: obsequm: not in Latin word list — review needed
- p. 13v l. 3: comrporalis → corporalis: transposed; ipboesum → ipsum: garbled; nobiltius → nobilius
- p. 13v l. 4: corbus: not in Latin word list — review needed
- p. 13v l. 5: nonbilisimum: not in Latin word list — review needed
- p. 13v l. 10: quandoequam: not in Latin word list — review needed
- p. 13v l. 12: exhientie: not in Latin word list — review needed
- p. 13v l. 13: flurtus: not in Latin word list — review needed
- p. 13v l. 14: terrem → terrae: garbled; hemispio → hemisphaerio: garbled
- p. 13v l. 17: fiutus → fluxus: garbled; botest → potest: b/p misread
- p. 13v l. 18: prtingat: 3+ consecutive consonants — likely garbled OCR
- p. 13v l. 19: etum → 2m (ordinal citation); quam → quod; neccnius → necessarius; corponribus → corporibus
- p. 13v l. 23: necestarius: not in Latin word list — review needed
- p. 13v l. 27: inuentiarum: not in Latin word list — review needed
- p. 13v l. 31: inniuentiam → influentiam; celiempyrei → caeli empyrei
- p. 13v l. 38: infiuentiam → influentiam; celesuium → caelestium
- p. 13v l. 42: quium → quia; infiuentias → influentias; celiempyrei → caeli empyrei
- p. 13v l. 47: iumine → lumine; virtutre → virtute
- p. 13v l. 48: infiuunt: not in Latin word list — review needed
- p. 13v l. 49: nonn: not in Latin word list — review needed
- p. 13v l. 50: infiuentiam: not in Latin word list — review needed
- p. 13v l. 51: brobrias → proprias: b/p; infiuentias → influentias
- p. 13v l. 52: prtibus: 3+ consecutive consonants — likely garbled OCR
- p. 13v l. 53: recepitur → recipitur; pertibus → partibus
- p. 13v l. 54: opintio → opinio: dropped 'n'

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_