### PR TITLE
Transcription corrections: cod-ve09v2_kzz7yh-f09382.xml (10 changes)

### DIFF
--- a/kzz7yh-f09382/cod-ve09v2_kzz7yh-f09382.xml
+++ b/kzz7yh-f09382/cod-ve09v2_kzz7yh-f09382.xml
@@ -369,8 +369,8 @@
           <lb ed="#V" n="93"/>¶ Prima in tres.
         </p>
         <p xml:id="kzz7yh-f09382-d1e743">
-          ¶ Primo narratquattuor conditiones 
-          na<lb ed="#V" n="94" break="no"/>turales quas humerunt a sua creatione.
+          ¶ Primo narrat quattuor conditiones 
+          na<lb ed="#V" n="94" break="no"/>turales quas habuerunt a sua creatione.
         </p>
         <p xml:id="kzz7yh-f09382-d1e748">
           ¶ Secundo ostendit 
@@ -388,24 +388,24 @@
         <p xml:id="kzz7yh-f09382-d1e766">
           ¶ Quia 
           <lb ed="#V" n="99"/>primo ostendit quales angeli creati sunt quantum ad conditiones 
-          <lb ed="#V" n="100"/>non naturales. que sunt super naturalis bomnitas: et malicia. 
+          <lb ed="#V" n="100"/>non naturales. que sunt super naturalis bonitas: et malicia. 
           quae<lb ed="#V" n="101" break="no"/>rum vna est supra naturam: alia contra naturam.
         </p>
         <p xml:id="kzz7yh-f09382-d1e775">
           ¶ Secundo ostendit 
           <lb ed="#V" n="102"/>quales creati sunt quantum ad conditiones non naturales que 
-          <lb ed="#V" n="103"/>sunt felicitas et miseria. di. quirta libi post hoc videndum est. 
+          <lb ed="#V" n="103"/>sunt felicitas et miseria. di. quarta libi post hoc videndum est. 
         </p>
         <p xml:id="kzz7yh-f09382-d1e782">
           <lb ed="#V" n="104"/>¶ Primo in tres.
         </p>
         <p xml:id="kzz7yh-f09382-d1e787">
-          ¶ Primo inquirit vtrum angeli habuerut 
-          <lb ed="#V" n="105"/>bominitatem moralem vel maliciam a sua creatione.
+          ¶ Primo inquirit vtrum angeli habuerunt 
+          <lb ed="#V" n="105"/>bonitatem moralem vel maliciam a sua creatione.
         </p>
         <p xml:id="kzz7yh-f09382-d1e792">
           ¶ Secundo 
-          deter<lb ed="#V" n="106" break="no"/>minat de ipsorum naturali cognitione. ibi hoc inquiri soletI 
+          deter<lb ed="#V" n="106" break="no"/>minat de ipsorum naturali cognitione. ibi hoc inquiri solet 
         </p>
         <p xml:id="kzz7yh-f09382-d1e798">
           <lb ed="#V" n="107"/>¶ Tertio de ipsorum naturali dilectione. ibi solet quaeri etiam 
@@ -419,12 +419,12 @@
           lap<lb ed="#V" n="110" break="no"/>sum
         </p>
         <p xml:id="kzz7yh-f09382-d1e815">
-          ¶ Secundo narrat quandam respensionem falsam ibi 
+          ¶ Secundo narrat quandam responsionem falsam ibi 
           putaue<lb ed="#V" n="111" break="no"/>runt enim.
         </p>
         <p xml:id="kzz7yh-f09382-d1e820">
-          ¶ Tertio narrat respensionem vnam: et ponit illius 
-          <lb ed="#V" n="112"/>confirmationem. ibi. laliis autem videtur .
+          ¶ Tertio narrat responsionem vnam: et ponit illius 
+          <lb ed="#V" n="112"/>confirmationem. ibi. aliis autem videtur .
         </p>
         <p xml:id="kzz7yh-f09382-d1e825">
           ¶ Et ista in tres.

--- a/kzz7yh-f09382/cod-ve09v2_kzz7yh-f09382.xml
+++ b/kzz7yh-f09382/cod-ve09v2_kzz7yh-f09382.xml
@@ -431,7 +431,7 @@
         </p>
         <p xml:id="kzz7yh-f09382-d1e828">
           ¶ 
-          Pri<lb ed="#V" n="113" break="no"/>mo ponit ipsam verum respensione vel opinionem.
+          Pri<lb ed="#V" n="113" break="no"/>mo ponit ipsam verum responsionem vel opinionem.
         </p>
         <p xml:id="kzz7yh-f09382-d1e833">
           ¶ Secundo 


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve09v2_kzz7yh-f09382.xml`.

## Applied changes

- p. 14v l. 93: narratquattuor: not in Latin word list — review needed
- p. 14v l. 94: humerunt: not in Latin word list — review needed
- p. 14v l. 100: bomnitas: not in Latin word list — review needed
- p. 14v l. 103: quirta → quarta: misplaced 'r'; quirita suggestion was wrong
- p. 14v l. 104: habuerut: not in Latin word list — review needed
- p. 14v l. 105: bominitatem → bonitatem: transposed; maliciam is valid Latin
- p. 14v l. 106: soletI → solet: spurious capital I appended
- p. 14v l. 110: respensionem: not in Latin word list — review needed
- p. 14v l. 111: respensionem: not in Latin word list — review needed
- p. 14v l. 112: laliis → aliis: spurious initial 'l'

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_