### PR TITLE
Transcription corrections: cod-ve09v2_kzz7yh-f102336.xml (8 changes)

### DIFF
--- a/kzz7yh-f102336/cod-ve09v2_kzz7yh-f102336.xml
+++ b/kzz7yh-f102336/cod-ve09v2_kzz7yh-f102336.xml
@@ -61,7 +61,7 @@
         </p>
         <p xml:id="kzz7yh-f102336-d1e112">
           ¶ Primo vtrum 
-          ali<lb ed="#V" n="46" break="no"/> 
+          ali<lb ed="#V" n="46" break="no"/>quod bonum nature per peccatum possit di 
           <lb ed="#V" n="47"/>minui.
         </p>
         <p xml:id="kzz7yh-f102336-d1e119">

--- a/kzz7yh-f102336/cod-ve09v2_kzz7yh-f102336.xml
+++ b/kzz7yh-f102336/cod-ve09v2_kzz7yh-f102336.xml
@@ -98,7 +98,7 @@
           </p>
           <p xml:id="kzz7yh-f102336-d1e170">
             ¶ Item per peccatum non 
-            <lb ed="#V" n="63"/>diminuitur anime substantia: nec potentie eius que 
+            <lb ed="#V" n="63"/>diminuitur anime substantia: nec potentiae eius que 
             incorruptibi<lb ed="#V" n="64" break="no"/>les sunt: nec proprie passiones essentie anime: vel potentiarum: 
             <lb ed="#V" n="65"/>quia propria passio manet integra quamdiu manet integrum 
             <lb ed="#V" n="66"/>subiectum: ergo non est aliquod bonum naturale in anima quod 
@@ -115,7 +115,7 @@
             <lb ed="#V" n="72"/>hominis aliquod bonum nature diminuitur in eo. 
           </p>
           <p xml:id="kzz7yh-f102336-d1e202">
-            <lb ed="#V" n="73"/>Contra <ref xml:id="kzz7yh-f102336-Rd1e211">Aug. enchi. 5. ca. animorum</ref> quecumque sunt 
+            <lb ed="#V" n="73"/>Contra <ref xml:id="kzz7yh-f102336-Rd1e211">Aug. Enchiridion. 5. ca. animorum</ref> quecumque sunt 
             <lb ed="#V" n="74"/>vitia naturalium sunt priuationes bonorum. 
           </p>
           <p xml:id="kzz7yh-f102336-d1e209">
@@ -201,7 +201,7 @@
             su<lb ed="#V" n="126" break="no"/>pernaturalis ad bonum que fundata est super charitatem 
             <lb ed="#V" n="127"/>potest totaliter tolli per peccatum eo quod sibi per peccatum 
             <lb ed="#V" n="128"/>contrariatur: ergo similiter cum peccatum contrarietur 
-            naturali<lb ed="#V" n="129" break="no"/>aptitudini ad virtutem: quia aliter eam non diminueret: vetur 
+            naturali<lb ed="#V" n="129" break="no"/>aptitudini ad virtutem: quia aliter eam non diminueret: videtur 
             <lb ed="#V" n="130"/>quod per peccatum totaliter possit toli.
           </p>
           <p xml:id="kzz7yh-f102336-d1e361">
@@ -213,7 +213,7 @@
             <lb ed="#V" n="135"/>predicta per peccatum totaliter est corrupta.
           </p>
           <p xml:id="kzz7yh-f102336-d1e375">
-            ¶ Item palsmus de 
+            ¶ Item psalmus de 
             <lb ed="#V" n="136"/>peccatoribus loquens ad deum dicit: Imaginem ipsorum 
             <!--00302.xml-->
             <pb ed="#V" n="144-v"/>
@@ -290,7 +290,7 @@
             ¶ Alii dicunt quod aptitudo naturalis ad virtutem semper 
             <lb ed="#V" n="47"/>scaturit a sua radice: sicut aqua a fonte: et ideo quantuncumque 
             <lb ed="#V" n="48"/>minuatur: nunquam totaliter corrumpitur: eo quod radix eius que 
-            <lb ed="#V" n="49"/>est imago dei in anima: per peccatum nec corrupitur: nec 
+            <lb ed="#V" n="49"/>est imago dei in anima: per peccatum nec corrumpitur: nec 
             <lb ed="#V" n="50"/>minuitur.
           </p>
           <p xml:id="kzz7yh-f102336-d1e520">
@@ -389,7 +389,7 @@
           </p>
           <p xml:id="kzz7yh-f102336-d1e704">
             <lb ed="#V" n="126"/>Ad primum in oppositum dicendum: quod  
-            aptitu<lb ed="#V" n="127" break="no"/>do naturalis in anima ad virtutem secd 
+            aptitu<lb ed="#V" n="127" break="no"/>do naturalis in anima ad virtutem secundum 
             <lb ed="#V" n="128"/>quod accipitur pro habitudine media inter ipsam imaginem
             <lb ed="#V" n="129"/>dei in anima et virtutem: habet infinitos gradus in potentia non 
             <lb ed="#V" n="130"/>in actu: vnde vno actu et vno gradu corrupto per 
@@ -439,7 +439,7 @@
             ima<lb ed="#V" n="23" break="no"/>ginibus que apparent in somno: eo quod sicut euigilantes nihil 
             <lb ed="#V" n="24"/>de illis imaginibus inueniunt sic anima cum euigilat per 
             egres<lb ed="#V" n="25" break="no"/>sum a corpore nihil secum portat de gloria temporali. Unde 
-            glosa<lb ed="#V" n="26" break="no"/>Imaginem ipsorum id est gloriam temporalem quam ipsi querut ad 
+            glosa<lb ed="#V" n="26" break="no"/>Imaginem ipsorum id est gloriam temporalem quam ipsi querunt ad 
             <lb ed="#V" n="27"/>nihilum rediges.
           </p>
           <p xml:id="kzz7yh-f102336-d1e807">
@@ -589,7 +589,7 @@
             diminu<lb ed="#V" n="119" break="no"/>tio boni nature 
             <lb ed="#V" n="120"/>facta in anima per peccatum hebeat rationem peccati. Et videtur 
             <lb ed="#V" n="121"/>quod non: quia omne quod habet rationem peccati macula est. Sed 
-            <lb ed="#V" n="122"/>ex consideratione cuiuscumque rei: non remanet intellus maculatus: 
+            <lb ed="#V" n="122"/>ex consideratione cuiuscumque rei: non remanet intellectus maculatus: 
             <lb ed="#V" n="123"/>ergo nec ex quocumque desiderio remanet voluntas 
             macula<lb ed="#V" n="124" break="no"/>ta: quod non esset verum si diminutio boni nature facta in anima per 
             <lb ed="#V" n="125"/>peccatum haberet rationem peccati.

--- a/kzz7yh-f102336/cod-ve09v2_kzz7yh-f102336.xml
+++ b/kzz7yh-f102336/cod-ve09v2_kzz7yh-f102336.xml
@@ -61,7 +61,7 @@
         </p>
         <p xml:id="kzz7yh-f102336-d1e112">
           ¶ Primo vtrum 
-          ali<lb ed="#V" n="46" break="no"/>rino dionum nnte der deccotum die di. 
+          ali<lb ed="#V" n="46" break="no"/> 
           <lb ed="#V" n="47"/>minui.
         </p>
         <p xml:id="kzz7yh-f102336-d1e119">
@@ -128,7 +128,7 @@
           <p xml:id="kzz7yh-f102336-d1e222">
             <lb ed="#V" n="80"/>Respondeo quod bonum nature. Uno modo potest 
             <lb ed="#V" n="81"/>accipi pro principiis 
-            componenti<lb ed="#V" n="82" break="no"/>bus substantiam: et propotentiis naturalibus: et haec bonum per 
+            componenti<lb ed="#V" n="82" break="no"/>bus substantiam: et  naturalibus: et haec bonum per 
             <lb ed="#V" n="83"/>peccatum non minuitur.
           </p>
           <p xml:id="kzz7yh-f102336-d1e233">
@@ -180,7 +180,7 @@
             natu<lb ed="#V" n="111" break="no"/>ralis in anima ad virtutem 
             <lb ed="#V" n="112"/>per peccatum totaliter possit tolli. Et videtur quod sic: 
             <lb ed="#V" n="113"/>omne finitum per subtractionem alicuius finiti ab 
-            <lb ed="#V" n="114"/>eo finicies potest totaliter corrumpi: si non sit subtractio secundum 
+            <lb ed="#V" n="114"/>eo  potest totaliter corrumpi: si non sit subtractio secundum 
             ean<lb ed="#V" n="115" break="no"/>dem proportionem. Sed aptitudo naturalis in anima ad 
             <lb ed="#V" n="116"/>virtutem finita est: quia quicquid actu est in anima finitum est. 
             <lb ed="#V" n="117"/>Cum ergo per quodlibet peccatum diminuatur praedicta 
@@ -312,7 +312,7 @@
             <lb ed="#V" n="60"/>actuale corrumpitur aliquod bonum praeexistens in anima. Inter 
             <lb ed="#V" n="61"/>enim alias differentias inter peccatum originale et 
             actua<lb ed="#V" n="62" break="no"/>le: hoc est vna: quod peccatum originale est priuatio boni 
-            debi<lb ed="#V" n="63" break="no"/>ti nunquam habiti. Sed per peccatum actule priuatur anima 
+            debi<lb ed="#V" n="63" break="no"/>ti nunquam habiti. Sed per peccatum <sic>actule</sic> priuatur anima 
             <lb ed="#V" n="64"/>aliquo bono debito prius habito.
           </p>
           <p xml:id="kzz7yh-f102336-d1e559">
@@ -320,7 +320,7 @@
             apti<lb ed="#V" n="65" break="no"/>tudo non diminuitur per subtractionem alicuius ab ea. Sed 
             <lb ed="#V" n="66"/>per hoc quod per peccatum apponitur impedimentum 
             pertingen<lb ed="#V" n="67" break="no"/>di ad terminum qui est virtus: impedimenta autem talia 
-            <lb ed="#V" n="68"/>apponi possunt sine sfine: secundum quod anima addere potest peccatum 
+            <lb ed="#V" n="68"/>apponi possunt sine fine: secundum quod anima addere potest peccatum 
             <!--00302.xml-->
             <cb ed="#P" n="b"/>
             <lb ed="#V" n="69"/>peccato sine fine: et ideo nunquam totaliter tollitur et semper 
@@ -377,9 +377,9 @@
             gra<lb ed="#V" n="114" break="no"/>tie: nec coniungi cum termino qui deus est: per gratuitam 
             <lb ed="#V" n="115"/>cognitionem et dilectionem nisi remouendo et 
             pertran<lb ed="#V" n="116" break="no"/>seundo per penitentiam carentiam emende debite pro actu 
-            <lb ed="#V" n="117"/>peccati. Unde Isa. 19. ca. Uolens signatre per peccatum poni 
+            <lb ed="#V" n="117"/>peccati. Unde Isa. 19. ca. Uolens signare per peccatum poni 
             <lb ed="#V" n="118"/>distantiam et obstaculum inter animam et deum: sic ait: 
-            iniqui<lb ed="#V" n="119" break="no"/>tates vestre diuiserunt inter vos et deum vestrum: et 
+            iniqui<lb ed="#V" n="119" break="no"/>tates  diuiserunt inter vos et deum vestrum: et 
             pecca<lb ed="#V" n="120" break="no"/>ta vestra absconderunt faciem eius a vobis ne exaudiret. 
             <lb ed="#V" n="121"/>Sequitur ergo quod per peccatum semper potest diminui 
             in<lb ed="#V" n="122" break="no"/>anima naturalis aptitudo ad virtutis susceptionem et ad 
@@ -514,8 +514,8 @@
             <lb ed="#V" n="68"/>lis aptitudo ad virtutem. Tum ergo quantum diminuitur de 
             <!--00303.xml-->
             <cb ed="#P" n="b"/>
-            <lb ed="#V" n="69"/>bonitate rei: tantum diminuatur de eius modo specientie et 
-            orden<lb ed="#V" n="70" break="no"/>ne videtur quod per peccatum diminuatur modus species 
+            <lb ed="#V" n="69"/>bonitate rei: tantum diminuatur de eius modo specie et 
+            ordi<lb ed="#V" n="70" break="no"/>ne videtur quod per peccatum diminuatur modus species 
             <lb ed="#V" n="71"/>et ordo qui sunt in naturali aptitudine ad virtutem. 
           </p>
           <p xml:id="kzz7yh-f102336-d1e935">
@@ -598,7 +598,7 @@
             ¶ Item Aug. contra faustum lib. 22 
             <lb ed="#V" n="126"/>quasi medio loco inter principium et medium dicit quod peccatum est 
             <lb ed="#V" n="127"/>falsum vel dictum vel concupitum contra eternam legem. Sed hoc 
-            <lb ed="#V" n="128"/>difffinitio non conuenit diminutioni boni facte in anima per peccatum: 
+            <lb ed="#V" n="128"/><sic>difffinitio</sic> non conuenit diminutioni boni facte in anima per peccatum: 
             <lb ed="#V" n="129"/>ergo sibi non conuenit ratio peccati.
           </p>
           <p xml:id="kzz7yh-f102336-d1e1086">
@@ -658,7 +658,7 @@
             pro<lb ed="#V" n="28" break="no"/>pinquitatis in corpore ad luminis susceptionem et obstaculum 
             <lb ed="#V" n="29"/>quo ille gradus corrumpitur. Et forte plus habet de ratione peccati 
             <lb ed="#V" n="30"/>praedicta carentia quam diminutio ipsius naturalis aptitudinis ad 
-            <lb ed="#V" n="31"/>virtutem. propinqus enim videtur se habere ad malum votuntatis actum. 
+            <lb ed="#V" n="31"/>virtutem. propinqius enim videtur se habere ad malum voluntatis actum. 
           </p>
           <p xml:id="kzz7yh-f102336-d1e1193">
             <lb ed="#V" n="32"/>Ad primum in oppositum dicendum: quod non est simile de 

--- a/kzz7yh-f102336/cod-ve09v2_kzz7yh-f102336.xml
+++ b/kzz7yh-f102336/cod-ve09v2_kzz7yh-f102336.xml
@@ -128,7 +128,7 @@
           <p xml:id="kzz7yh-f102336-d1e222">
             <lb ed="#V" n="80"/>Respondeo quod bonum nature. Uno modo potest 
             <lb ed="#V" n="81"/>accipi pro principiis 
-            componenti<lb ed="#V" n="82" break="no"/>bus substantiam: et  naturalibus: et haec bonum per 
+            componenti<lb ed="#V" n="82" break="no"/>bus substantiam: et pro potentiis naturalibus: et haec bonum per 
             <lb ed="#V" n="83"/>peccatum non minuitur.
           </p>
           <p xml:id="kzz7yh-f102336-d1e233">
@@ -180,7 +180,7 @@
             natu<lb ed="#V" n="111" break="no"/>ralis in anima ad virtutem 
             <lb ed="#V" n="112"/>per peccatum totaliter possit tolli. Et videtur quod sic: 
             <lb ed="#V" n="113"/>omne finitum per subtractionem alicuius finiti ab 
-            <lb ed="#V" n="114"/>eo  potest totaliter corrumpi: si non sit subtractio secundum 
+            <lb ed="#V" n="114"/>eo finicies potest totaliter corrumpi: si non sit subtractio secundum 
             ean<lb ed="#V" n="115" break="no"/>dem proportionem. Sed aptitudo naturalis in anima ad 
             <lb ed="#V" n="116"/>virtutem finita est: quia quicquid actu est in anima finitum est. 
             <lb ed="#V" n="117"/>Cum ergo per quodlibet peccatum diminuatur praedicta 
@@ -379,7 +379,7 @@
             pertran<lb ed="#V" n="116" break="no"/>seundo per penitentiam carentiam emende debite pro actu 
             <lb ed="#V" n="117"/>peccati. Unde Isa. 19. ca. Uolens signare per peccatum poni 
             <lb ed="#V" n="118"/>distantiam et obstaculum inter animam et deum: sic ait: 
-            iniqui<lb ed="#V" n="119" break="no"/>tates  diuiserunt inter vos et deum vestrum: et 
+            iniqui<lb ed="#V" n="119" break="no"/>tates vestre diuiserunt inter vos et deum vestrum: et 
             pecca<lb ed="#V" n="120" break="no"/>ta vestra absconderunt faciem eius a vobis ne exaudiret. 
             <lb ed="#V" n="121"/>Sequitur ergo quod per peccatum semper potest diminui 
             in<lb ed="#V" n="122" break="no"/>anima naturalis aptitudo ad virtutis susceptionem et ad 


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve09v2_kzz7yh-f102336.xml`.

## Applied changes

- p. 144r l. 63: potentie → potentiae: not in word list (OCR transform matched)
- p. 144r l. 73: enchi: 3+ consecutive consonants — likely garbled OCR
- p. 144r l. 129: vetur → videtur: dropped 'id'; vietur was incorrect
- p. 144r l. 135: palsmus: 3+ consecutive consonants — likely garbled OCR
- p. 144v l. 49: corrupitur: not in Latin word list — review needed
- p. 144v l. 127: secd: not in Latin word list — review needed
- p. 145r l. 26: querut: not in Latin word list — review needed
- p. 145r l. 122: intellus: not in Latin word list — review needed

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_