### PR TITLE
Transcription corrections: kzz7yh-f100085 (structural line-break fix)

### DIFF
--- a/kzz7yh-f100085/cod-ve09v2_kzz7yh-f100085.xml
+++ b/kzz7yh-f100085/cod-ve09v2_kzz7yh-f100085.xml
@@ -71,8 +71,8 @@
           <lb ed="#V" n="101"/>vnde oriretur vlla mali natura. hoc accipitur malum concretiue: et ideo 
           <lb ed="#V" n="102"/>vocatur hoc nomine nature propter naturam substratam 
           <lb ed="#V" n="103"/>malitie. Nisi ex angeli et hominis bona natura: hoc 
-          intelli<lb ed="#V" n="104" break="no"/>gendum est de malo culpe. Unde primitus orta est volum 
-          <lb ed="#V" n="105"/>tas mala: idest malus actus interior voluntatis. Cadit 
+          intelli<lb ed="#V" n="104" break="no"/>gendum est de malo culpe. Unde primitus orta est 
+          volun<lb ed="#V" n="105" break="no"/>tas mala: idest malus actus interior voluntatis. Cadit 
           il<lb ed="#V" n="106" break="no"/>la prophetica detestatio in eum qui dicit malum est 
           ho<lb ed="#V" n="107" break="no"/>minem: hoc intelligendum est cum reduplicatione: scilicet 
           <lb ed="#V" n="108"/>inquantum homo: sicut ostendit littera sequens.


### PR DESCRIPTION
## Summary

- p.140v l.104–105: Move `volun` stem from end of l.104 to before `<lb n="105" break="no"/>`, forming the split word `volun|tas` across the line break.

## Files changed

- `kzz7yh-f100085/cod-ve09v2_kzz7yh-f100085.xml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)