### PR TITLE
Transcription corrections: cod-ve07v1_kzz7yh-a86642.xml (16 changes)

### DIFF
--- a/kzz7yh-a86642/cod-ve07v1_kzz7yh-a86642.xml
+++ b/kzz7yh-a86642/cod-ve07v1_kzz7yh-a86642.xml
@@ -93,7 +93,7 @@
           </p>
           <p xml:id="kzz7yh-a86642-d1e161">
             ¶ Item reprobatio 
-            <lb ed="#V" n="100"/>est respectu quorandam qui in finali iniquitate morientur: sed 
+            <lb ed="#V" n="100"/>est respectu <sic>quorandam</sic> qui in finali iniquitate morientur: sed 
             re<lb ed="#V" n="101" break="no"/>spectu iniquitatis eorum deus non habet nisi simplicem 
             prescien<lb ed="#V" n="102" break="no"/>tiam: quia iniquitatis non est auctor: ergo videtur quod reprobatio 
             <lb ed="#V" n="103"/>penitus idem sit quod prescientia. 
@@ -136,7 +136,7 @@
           </p>
           <p xml:id="kzz7yh-a86642-d1e241">
             ¶ Ad 2m cum dicitur quod 
-            <lb ed="#V" n="131"/>nihil odisti eorum que fecisti etc. dicendum quod deus omens 
+            <lb ed="#V" n="131"/>nihil odisti eorum que fecisti etc. dicendum quod deus omnes 
             cre<lb ed="#V" n="132" break="no"/>aturas diligit inquantum omnibus vult aliquod bonum: aliquos 
             <lb ed="#V" n="133"/>tamen odit inquantum vult eis penam eternam propter 
             fina<lb ed="#V" n="134" break="no"/>lem iniquitatem eorum
@@ -157,7 +157,7 @@
           <head xml:id="kzz7yh-a86642-Hd1e286" type="question-title">Utrum obduratio sit pena vel culpa super illud ad Ro.</head>
           <p xml:id="kzz7yh-a86642-d1e275">
             <lb ed="#V" n="4"/>¶ Questio. II. 
-            <lb ed="#V" n="5"/>SEcundo queriture vtrum obduratio sit 
+            <lb ed="#V" n="5"/>SEcundo queritur: vtrum obduratio sit 
             <lb ed="#V" n="6"/>pena vel culpa super illud ad Ro. 
             <lb ed="#V" n="7"/>2. secundum duritiam tuam: dicit glosa. Obstinatio est 
             <lb ed="#V" n="8"/>indurate mentis in malitia pertinacia: per quam sit 
@@ -210,7 +210,7 @@
             ¶ Secundo modo est dispositio cuiuslibet 
             <lb ed="#V" n="38"/>culpe cui homo pertinaciter adheret: ita quod in ea desendat. 
             <lb ed="#V" n="39"/>Tertio modo est speciale genus peccati. Est enim 
-            pecca<lb ed="#V" n="40" break="no"/>tum in spiritum sanctum: cum illa rebellio ex maliti procedit. 
+            pecca<lb ed="#V" n="40" break="no"/>tum in spiritum sanctum: cum illa rebellio ex <sic>maliti</sic> procedit. 
           </p>
           <p xml:id="kzz7yh-a86642-d1e377">
             <lb ed="#V" n="41"/>¶ Ex dictis patet pro magna parte responsio ad 
@@ -228,9 +228,9 @@
             ¶ Ad 2m eum dicitur 
             <lb ed="#V" n="49"/>quod obduratione homo malus est etc. dico quod verum est: et 
             <lb ed="#V" n="50"/>causatur ex malitia. non tantummodo autem sumus mali 
-            extenden<lb ed="#V" n="51" break="no"/>do nomen malicie per culpam: sed etiam per culpe sequalam: 
+            extenden<lb ed="#V" n="51" break="no"/>do nomen <sic>malicie</sic> per culpam: sed etiam per culpe sequelam: 
             <lb ed="#V" n="52"/>maxime cum illa sequela est dispositio ad aliam culpam: 
-            <lb ed="#V" n="53"/>ad permanentiam culpercuius est effectus. Uel potest dici quod 
+            <lb ed="#V" n="53"/>ad permanentiam culpe: cuius est effectus. Uel potest dici quod 
             <lb ed="#V" n="54"/>homo non est malus obduratione formaliter nisi per acens 
             <lb ed="#V" n="55"/>scilicet inquantum malus est per culpam que non separatur ab 
             ob<lb ed="#V" n="56" break="no"/>duratione. per obdurationem autem tertio modo dictam que 
@@ -262,7 +262,7 @@
             in<lb ed="#V" n="72" break="no"/>tellectus est pena etc. dico quod non est simile de excecatione 
             <lb ed="#V" n="73"/>intellectus et obduratione affectus: quia intellectus non sic 
             <lb ed="#V" n="74"/>est liber: sicut voluntas: et ideo non ita habet se excecatio 
-            in<lb ed="#V" n="75" break="no"/>tellectus ad rationem culpe formaliter: sicut potest habem 
+            in<lb ed="#V" n="75" break="no"/>tellectus ad rationem culpe formaliter: sicut potest habere 
             ali<lb ed="#V" n="76" break="no"/>qua obduratio affectus.
           </p>
         </div>
@@ -313,7 +313,7 @@
             <lb ed="#V" n="103"/>Respondeo quod obduratio secundum quod est pena in 
             ho<lb ed="#V" n="104" break="no"/>mine et non culpa dicit quandam 
             <lb ed="#V" n="105"/>priuatam passionem scilicet inhabilitatem ad susceptionem gratie e 
-            <lb ed="#V" n="106"/>que inhabilitas prouenit ex peccato deo permitttente iusto 
+            <lb ed="#V" n="106"/>que inhabilitas prouenit ex peccato deo <sic>permitttente</sic> iusto 
             <lb ed="#V" n="107"/>iudicio. habet ergo causam efficientem scilicet liberum arbitrium non 
             <lb ed="#V" n="108"/>ipsum deum et causam promerentem scilicet peccatum. Hec ergo 
             <lb ed="#V" n="109"/>obduratio cum iusto dei iuditio permittatur accidere: iustum 
@@ -344,7 +344,7 @@
             quam<lb ed="#V" n="132" break="no"/>uis omnem obdurationem posset prohibere non tamen ad hoc 
             <lb ed="#V" n="133"/>tenetur: et ideo permittendo obdurationem fieri: non 
             prohiben<lb ed="#V" n="134" break="no"/>do eam per suam gratiam: non debet dici causa efficiens illius 
-            <lb ed="#V" n="135"/>obdurationis: maxime cum omens qui obdurantur permittat 
+            <lb ed="#V" n="135"/>obdurationis: maxime cum omnes qui obdurantur permittat 
             <lb ed="#V" n="136"/>iusto iudicio obdurari.
           </p>
           <p xml:id="kzz7yh-a86642-d1e629">

--- a/kzz7yh-a86642/cod-ve07v1_kzz7yh-a86642.xml
+++ b/kzz7yh-a86642/cod-ve07v1_kzz7yh-a86642.xml
@@ -89,7 +89,7 @@
             <lb ed="#V" n="96"/>est quod prescientia: minor probatur sic. Sapientie. xi. dicitur ad deum 
             <lb ed="#V" n="97"/>Nihil eorum odisti que fecisti: sed reprobatio si aliquid 
             ad<lb ed="#V" n="98" break="no"/>deret super prescientiam: hoc non esset nisi odium: ergo videtur quod 
-            <lb ed="#V" n="99"/>reprobon vltra prescientiam nihil addit.
+            <lb ed="#V" n="99"/>reprobatio vltra prescientiam nihil addit.
           </p>
           <p xml:id="kzz7yh-a86642-d1e161">
             ¶ Item reprobatio 
@@ -101,7 +101,7 @@
           <p xml:id="kzz7yh-a86642-d1e172">
             <lb ed="#V" n="104"/>Contra. <ref xml:id="kzz7yh-a86642-Rd1e182">Malach.</ref> dicit deus per prophetam: Iacob dilexi 
             <lb ed="#V" n="105"/>Esaum autem ideo habui: cum ergo illo verbo 
-            ex<lb ed="#V" n="106" break="no"/>primatur reprobatio esau: videtur quod terprobatio importat odium: 
+            ex<lb ed="#V" n="106" break="no"/>primatur reprobatio esau: videtur quod reprobatio importat odium: 
             <lb ed="#V" n="107"/>et sic aliquid addit vltra prescientiam.
           </p>
           <p xml:id="kzz7yh-a86642-d1e184">
@@ -111,18 +111,18 @@
             <lb ed="#V" n="110"/>ergo aliquid addit vltra prescientiam. 
           </p>
           <p xml:id="kzz7yh-a86642-d1e193">
-            <lb ed="#V" n="111"/>Respondeo quod reprobatio non nomiat 
+            <lb ed="#V" n="111"/>Respondeo quod reprobatio non nominat 
             praescien<lb ed="#V" n="112" break="no"/>tiam tantum: sed aliquid addit secundum rationem 
             <lb ed="#V" n="113"/>vnde differre videntur differentia simili illi differentie: quam 
             <lb ed="#V" n="114"/>species differt a genere: eo quod prescientia generalior est quam reprobatio 
-            <lb ed="#V" n="115"/>Prescientia enim est respectu quoruncumque sfuturorum: sed non 
-            re<lb ed="#V" n="116" break="no"/>probatio. Est enim reprobon prescientia future damnationis 
+            <lb ed="#V" n="115"/>Prescientia enim est respectu quorumcumque futurorum: sed non 
+            re<lb ed="#V" n="116" break="no"/>probatio. Est enim reprobatio prescientia future damnationis 
             quo<lb ed="#V" n="117" break="no"/>rumdam: quos pena non terminanda damnare proposuit propter eorum 
             <lb ed="#V" n="118"/>iniquitatem finalem. Cui videtur concordare magister. in praesenti <ref xml:id="kzz7yh-a86642-Rd1e219">Di. 
               <lb ed="#V" n="119"/>cap. 5. sic. d.</ref> Reprobatio est intelligenda prescientia iniquitatis 
             <lb ed="#V" n="120"/>quorundam: et preperatio damnationis eorundem: est ergo 
             repro<lb ed="#V" n="121" break="no"/>batio quedam pars prouidentie. Ad prouidum enim rectorem non 
-            <lb ed="#V" n="122"/>tantum pertinet ordinare bonam retribuitionem iustorum: sed etiam 
+            <lb ed="#V" n="122"/>tantum pertinet ordinare bonam retributionem iustorum: sed etiam 
             <lb ed="#V" n="123"/>iustam penam malorum. vnde sicut praedestinatio est pars 
             proui<lb ed="#V" n="124" break="no"/>dentie respectu illorum qui diuinitus ordinantur in eternam 
             sa<lb ed="#V" n="125" break="no"/>lutem: sic reprobatio est pars prouidentie respectu eorum qui 
@@ -232,8 +232,8 @@
             <lb ed="#V" n="52"/>maxime cum illa sequela est dispositio ad aliam culpam: 
             <lb ed="#V" n="53"/>ad permanentiam culpercuius est effectus. Uel potest dici quod 
             <lb ed="#V" n="54"/>homo non est malus obduratione formaliter nisi per acens 
-            <lb ed="#V" n="55"/>scilicet inquantum malus est per cum pam que non separatur ab 
-            ob<lb ed="#V" n="56" break="no"/>duratione. per obdurationemlaunt tertio modo dictam que 
+            <lb ed="#V" n="55"/>scilicet inquantum malus est per culpam que non separatur ab 
+            ob<lb ed="#V" n="56" break="no"/>duratione. per obdurationem autem tertio modo dictam que 
             <lb ed="#V" n="57"/>est speciale genus peccati: homo malus est formaliter.
           </p>
           <p xml:id="kzz7yh-a86642-d1e423">
@@ -248,7 +248,7 @@
             <lb ed="#V" n="63"/>Ad primum alterius partis cum dicitur quod illud 
             <lb ed="#V" n="64"/>quod meritis malis redditur est 
             <lb ed="#V" n="65"/>pena etc. dico quod verum est: et quandoque cum hoc est culpa. 
-            <lb ed="#V" n="66"/>Unde quandoque vna culpa est pena alterius eulpe: que die 
+            <lb ed="#V" n="66"/>Unde quandoque vna culpa est pena alterius culpe: que die 
             <lb ed="#V" n="67"/>reddi propter priorem culpam: non quia deus sit eius causa: 
             <lb ed="#V" n="68"/>sed quia propter priorem culpam deus permittit vt homo in illam 
             <!--00266.xml-->
@@ -288,7 +288,7 @@
           </p>
           <p xml:id="kzz7yh-a86642-d1e509">
             ¶ Item homo non potest digne penitere 
-            <lb ed="#V" n="88"/>de peccato finaliter: ad cuius penitentiam non est perdestina 
+            <lb ed="#V" n="88"/>de peccato finaliter: ad cuius paenitentiam non est praedestina 
             <lb ed="#V" n="89"/>tus: quia talis penitentia est per gratiam: et sicut dicit Aug. libro de 
             <lb ed="#V" n="90"/>praedestinatione sanctorum prope medium: gratia est 
             praedestinatio<lb ed="#V" n="91" break="no"/>nis effectus: ergo videtur quod deus non predestinando 
@@ -299,14 +299,14 @@
           <p xml:id="kzz7yh-a86642-d1e527">
             <lb ed="#V" n="95"/>Contra <ref xml:id="kzz7yh-a86642-Rd1e552">Ansel. de casu diaboli</ref> magis prope principium 
             <lb ed="#V" n="96"/>quam medium dicit quod malus angelus non ideo 
-            <lb ed="#V" n="97"/>non accepit perseuerentiam: quia deus non dedit: sed ideo deus 
+            <lb ed="#V" n="97"/>non accepit perseuerantiam: quia deus non dedit: sed ideo deus 
             <lb ed="#V" n="98"/>non dedit: quia ille non accepit: ergo videtur quod causa 
             obdu<lb ed="#V" n="99" break="no"/>rationis sue sit ipsemet et non deus.
           </p>
           <p xml:id="kzz7yh-a86642-d1e541">
             ¶ Item Augu. 83.q. 
             <lb ed="#V" n="100"/>q. 3. probat quod deo auctore non fit homo deterior. sed homo 
-            ef<lb ed="#V" n="101" break="no"/>ficitur deterior prr obdurationem: ergo deus non est actor 
+            ef<lb ed="#V" n="101" break="no"/>ficitur deterior per obdurationem: ergo deus non est actor 
             <lb ed="#V" n="102"/>obdurationis sue. 
           </p>
           <p xml:id="kzz7yh-a86642-d1e550">
@@ -321,7 +321,7 @@
             <lb ed="#V" n="111"/>omnis iustus ordo sit a deo: sequitur quod illa obduratio 
             respi<lb ed="#V" n="112" break="no"/>cit deum tanquam causam ordinantem: dicitur ergo deus 
             ho<lb ed="#V" n="113" break="no"/>minem obdurare: non quia illam obdurationem efficiat: sed 
-            <lb ed="#V" n="114"/>quia illam ordinat secundum quod ordo illi eompetit obdurationi: et 
+            <lb ed="#V" n="114"/>quia illam ordinat secundum quod ordo illi competit obdurationi: et 
             <lb ed="#V" n="115"/>quia illam obdurationem prouenire ex peccato permittit non 
             <lb ed="#V" n="116"/>conferendo adiutorium: per quod illa obduratio posset 
             prohi<lb ed="#V" n="117" break="no"/>beri: et praedictis concordat glo. super illud ad Roma. 9. Quem 
@@ -341,7 +341,7 @@
             guberna<lb ed="#V" n="129" break="no"/>toris est causa efficiens euersionis 
             <lb ed="#V" n="130"/>nauis etc. Dico quod verum est loquendo de illo nauta qui 
             po<lb ed="#V" n="131" break="no"/>test et tenetur prohibere nauis euersionem. Deus autem 
-            quam<lb ed="#V" n="132" break="no"/>uis omnem obduraitionem posset prohibere non tamenad hoc 
+            quam<lb ed="#V" n="132" break="no"/>uis omnem obdurationem posset prohibere non tamen ad hoc 
             <lb ed="#V" n="133"/>tenetur: et ideo permittendo obdurationem fieri: non 
             prohiben<lb ed="#V" n="134" break="no"/>do eam per suam gratiam: non debet dici causa efficiens illius 
             <lb ed="#V" n="135"/>obdurationis: maxime cum omens qui obdurantur permittat 
@@ -354,7 +354,7 @@
             <cb ed="#P" n="a"/>
             <lb ed="#V" n="1"/>ratio quae non est culpa: sed culpe sequela dicit entitatem 
             crea<lb ed="#V" n="2" break="no"/>tam etc. dico quod non est verum nisi extendas nomen entitatis etiam 
-            <lb ed="#V" n="3"/>ad priuationes entium. Est enim quedam inhilitas ad gratiae 
+            <lb ed="#V" n="3"/>ad priuationes entium. Est enim quedam inhabilitas ad gratiae 
             <lb ed="#V" n="4"/>susceptionem. Unde priuationem dicit sub ratione qua 
             obdu<lb ed="#V" n="5" break="no"/>ratio est.
           </p>
@@ -367,7 +367,7 @@
             <lb ed="#V" n="10"/>nullum praedestinasset: non posset sibi imponi quod aliquid 
             com<lb ed="#V" n="11" break="no"/>tra iustitiam fecisset: vel iustitiam ad quam teneretur 
             face<lb ed="#V" n="12" break="no"/>re obmisisset. verum glosa super illud ad Roma. 9. 
-            Quem<lb ed="#V" n="13" break="no"/>vult inducat. Uniuersum quappe genus humanum tam iusto 
+            Quem<lb ed="#V" n="13" break="no"/>vult inducat. Uniuersum quippe genus humanum tam iusto 
             <lb ed="#V" n="14"/>dei iudicio in apostatica radice damnatum est: vt etiam si 
             nul<lb ed="#V" n="15" break="no"/>lus inde liberaretur: nemo recte posset vituperare dei iustitiam. 
           </p>


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve07v1_kzz7yh-a86642.xml`.

## Applied changes

- p. 126r l. 99: reprobon → reprobatio: truncated/garbled form of reprobatio; context confirms full word needed
- p. 126r l. 106: terprobatio → reprobatio: garbled initial te/re misread
- p. 126r l. 111: nomiat → nominat: missing letter n (OCR drop)
- p. 126r l. 115: quoruncumque → quorumcumque: n/m misread; sfuturorum → futurorum: spurious s prefix
- p. 126r l. 116: reprobon → reprobatio: truncated/garbled form of reprobatio; context confirms full word needed
- p. 126r l. 122: retribuitionem → retributionem: spurious i inserted
- p. 126v l. 55: cum pam → culpam: word split incorrectly across lines; should be culpam without break
- p. 126v l. 56: obdurationemlaunt → obdurationem autem: garbled merge of two words (missing space + misread)
- p. 126v l. 66: eulpe → culpe: e/c misread at word start
- p. 126v l. 88: penitentiam → paenitentiam: not in word list (OCR transform matched); perdestina → praedestina: pre/prae misread (split word continues on next line)
- p. 126v l. 97: perseuerentiam → perseuerantiam: wrong vowel e/a in suffix
- p. 126v l. 101: prr → per: garbled vowel dropped
- p. 126v l. 114: eompetit → competit: e/c misread at word start
- p. 126v l. 132: obduraitionem → obdurationem: spurious i inserted; tamenad → tamen ad: missing space
- p. 127r l. 3: inhilitas → inhabilitas: missing letters 'ab' (OCR drop)
- p. 127r l. 13: quappe → quippe: a/i vowel misread

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_