### PR TITLE
Transcription corrections: cod-ve07v1_kzz7yh-a93314.xml (3 changes)

### DIFF
--- a/kzz7yh-a93314/cod-ve07v1_kzz7yh-a93314.xml
+++ b/kzz7yh-a93314/cod-ve07v1_kzz7yh-a93314.xml
@@ -177,7 +177,7 @@
         <p xml:id="kzz7yh-a93314-d1e351">
           <!--00285.xml-->
           <cb ed="#P" n="b"/>
-          <lb ed="#V" n="57"/>Unc illud restat etc. Superius 
+          <lb ed="#V" n="57"/>Nunc illud restat etc. Superius 
           deter<lb ed="#V" n="58" break="no"/>minauit magister de diuine 
           <lb ed="#V" n="59"/>et potentie vniuersalitate et immensitate. Hic determi¬. 
           <lb ed="#V" n="60"/>nat de eiusdem perfectione et diditur in partes duas. 
@@ -201,8 +201,8 @@
           <lb ed="#V" n="67"/>ibi incipit. Post hoc considerandum: in qua inquirit vtrum 
           me<lb ed="#V" n="68" break="no"/>liori modo possit facere quam facit. et diditur in partes duas: Quia 
           <lb ed="#V" n="69"/>primo proponit quaestionem: et respondet per distinctionem. Secundo 
-          <lb ed="#V" n="70"/>confirmat suam respensionem per auctoritatem ibi. Unde Augu. 
-          <lb ed="#V" n="71"/>Tunc sequitur illa pars quae disa fuit superius. Preterea 
+          <lb ed="#V" n="70"/>confirmat suam responsionem per auctoritatem ibi. Unde Augu. 
+          <lb ed="#V" n="71"/>Tunc sequitur illa pars quae diuisa fuit superius. Preterea 
           que<lb ed="#V" n="72" break="no"/>ri solet in qua agit de divinae potentie immutabilitate. et 
           didi<lb ed="#V" n="73" break="no"/>tur in partes tres.
         </p>


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve07v1_kzz7yh-a93314.xml`.

## Applied changes

- p. 136r l. 57: Unc → Nunc: initial N dropped (decorated initial OCR miss)
- p. 136r l. 70: respensionem → responsionem: e/o vowel misread
- p. 136r l. 71: disa → diuisa: missing 'ui'; context 'quae disa fuit superius' should read 'quae diuisa fuit superius'

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_