### PR TITLE
Transcription corrections: cod-ve09v2_kzz7yh-f103488.xml (3 changes)

### DIFF
--- a/kzz7yh-f103488/cod-ve09v2_kzz7yh-f103488.xml
+++ b/kzz7yh-f103488/cod-ve09v2_kzz7yh-f103488.xml
@@ -65,11 +65,11 @@
           acci<lb ed="#V" n="57" break="no"/>pitur voluntas non pro potentia: sed pro actu: nec ex hoc quod hoc 
           die<lb ed="#V" n="58" break="no"/>sequitur quod omne peccatum sit auaritia proprie dicta: quia hoc assecutio vel 
           <lb ed="#V" n="59"/>retentio non intelligitur respectu boni temporalis exterioris tantum: 
-          re<lb ed="#V" n="60" break="no"/>spectu cuius est auaritia proprie dicta: sed intelliter de quocumque 
+          re<lb ed="#V" n="60" break="no"/>spectu cuius est auaritia proprie dicta: sed intelligitur de quocumque 
           bo<lb ed="#V" n="61" break="no"/>no: quia omne peccatum commissionis in aliquo inordinato amore 
           consi<lb ed="#V" n="62" break="no"/>stit: vel ex eo causatur: voluntas est motus animi: hic etiam 
           acci<lb ed="#V" n="63" break="no"/>pitur voluntas non pro potentia: sed pro actu: non consisteret peccatum si 
-          <lb ed="#V" n="64"/>interditio non fuisset: quod intelligendum est de interditione per aliquam 
+          <lb ed="#V" n="64"/>interdictio non fuisset: quod intelligendum est de interdictione per aliquam 
           <lb ed="#V" n="65"/>legem: siue sit lex eterna: siue lex nature: vel diuina: vel 
           positi<lb ed="#V" n="66" break="no"/>ua. nihil enim peccatum est quod non sit per aliquam istarum legum prohibitum: 
           <lb ed="#V" n="67"/>non consistente peccato non solum malitia: sed virtus fortasse non esset id est 
@@ -80,7 +80,7 @@
         </p>
         <p xml:id="kzz7yh-f103488-d1e153">
           <lb ed="#V" n="70"/>¶ Uel potest dici quod ibi loquatur de virtute non secundum essentiam: sed 
-          <lb ed="#V" n="71"/>secundum rationem nominis: inquaentum dicitur a vi contra difficultatem: non est aliquam 
+          <lb ed="#V" n="71"/>secundum rationem nominis: inquantum dicitur a vi contra difficultatem: non est aliquam 
           <lb ed="#V" n="72"/>res mala nisi eadem res sit bona: quia omne malum fundatur in 
           ali<lb ed="#V" n="73" break="no"/>quo bono: vt superius ostensum est: declinatio a bono quod est 
           <lb ed="#V" n="74"/>signt id est aliquid ponit: vnde ibi non accipitur declinatio a bono 

--- a/kzz7yh-f103488/cod-ve09v2_kzz7yh-f103488.xml
+++ b/kzz7yh-f103488/cod-ve09v2_kzz7yh-f103488.xml
@@ -83,7 +83,7 @@
           <lb ed="#V" n="71"/>secundum rationem nominis: inquantum dicitur a vi contra difficultatem: non est aliquam 
           <lb ed="#V" n="72"/>res mala nisi eadem res sit bona: quia omne malum fundatur in 
           ali<lb ed="#V" n="73" break="no"/>quo bono: vt superius ostensum est: declinatio a bono quod est 
-          <lb ed="#V" n="74"/>signt id est aliquid ponit: vnde ibi non accipitur declinatio a bono 
+          <lb ed="#V" n="74"/>signat id est aliquid ponit: vnde ibi non accipitur declinatio a bono 
           <lb ed="#V" n="75"/>pro eo quod est non velle facere bonum: sed pro velle facere 
           bo<lb ed="#V" n="76" break="no"/>num: inquantum peccatum est: priuatio est vel corruptio boni: 
           <lb ed="#V" n="77"/>expositio huius verbi: satis habita est per dicta in quaestionibus: 


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve09v2_kzz7yh-f103488.xml`.

## Applied changes

- p. 145v l. 60: intelliter → intelligitur: garbled; missing 'igi' (OCR drop); context 'sed intelliter de quocumque bono' confirms intelligitur
- p. 145v l. 64: interditio → interdictio: missing ct; interditione → interdictione: missing ct
- p. 145v l. 71: inquaentum → inquantum: spurious ae diphthong inserted

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_