### PR TITLE
Transcription corrections: cod-ve09v2_kzz7yh-f104241.xml (9 changes)

### DIFF
--- a/kzz7yh-f104241/cod-ve09v2_kzz7yh-f104241.xml
+++ b/kzz7yh-f104241/cod-ve09v2_kzz7yh-f104241.xml
@@ -118,7 +118,7 @@
             <lb ed="#V" n="19"/>patet in peccato ire et inuidie. Aut ratione cause que est sub 
             <lb ed="#V" n="20"/>tractio diuini auxilii propter precedens peccatum: que sub 
             <lb ed="#V" n="21"/>tractio rationem pene habet: et ideo peccatum in quod labitur 
-            homo<lb ed="#V" n="22" break="no"/>propter  quod desertus est ab auxilio diuine gratiae: pena dici 
+            homo<lb ed="#V" n="22" break="no"/>propter hoc quod desertus est ab auxilio diuine gratiae: pena dici 
             <lb ed="#V" n="23"/>potest peccati precedentis: quia est causatum per penam 
             praece<lb ed="#V" n="24" break="no"/>dentis peccati.
           </p>

--- a/kzz7yh-f104241/cod-ve09v2_kzz7yh-f104241.xml
+++ b/kzz7yh-f104241/cod-ve09v2_kzz7yh-f104241.xml
@@ -118,7 +118,7 @@
             <lb ed="#V" n="19"/>patet in peccato ire et inuidie. Aut ratione cause que est sub 
             <lb ed="#V" n="20"/>tractio diuini auxilii propter precedens peccatum: que sub 
             <lb ed="#V" n="21"/>tractio rationem pene habet: et ideo peccatum in quod labitur 
-            homo<lb ed="#V" n="22" break="no"/>propter hoec quod desertus est ab auxilio diuine gratiae: pena dici 
+            homo<lb ed="#V" n="22" break="no"/>propter  quod desertus est ab auxilio diuine gratiae: pena dici 
             <lb ed="#V" n="23"/>potest peccati precedentis: quia est causatum per penam 
             praece<lb ed="#V" n="24" break="no"/>dentis peccati.
           </p>
@@ -175,7 +175,7 @@
           <p xml:id="kzz7yh-f104241-d1e311">
             ¶ Ad secundum 
             <lb ed="#V" n="64"/>dicendum: quod peccatum ratione deformitatis ordinem realem non habet 
-            <lb ed="#V" n="65"/>ad aliud peccatm per se: sed per accidens: inquantum scilicet subiectum propter 
+            <lb ed="#V" n="65"/>ad aliud peccatum per se: sed per accidens: inquantum scilicet subiectum propter 
             <lb ed="#V" n="66"/>vnam deformitatem iuste permittitur ledi per aliam peccati 
             defor<lb ed="#V" n="67" break="no"/>mitatem. et etiam per quandam reductionem scilicet inquantum sunt 
             <lb ed="#V" n="68"/>priuationes bonorum ordinatorum: quia tamen priuationes sunt quaedam 
@@ -275,7 +275,7 @@
             su<lb ed="#V" n="129" break="no"/>stinendo.
           </p>
           <p xml:id="kzz7yh-f104241-d1e494">
-            ¶ Ad 2m dicendum: quod propotio philosophi intelligenda est de 
+            ¶ Ad 2m dicendum: quod propositio philosophi intelligenda est de 
             passio<lb ed="#V" n="130" break="no"/>mibus secundum se et absolute: quia passionibus inquantu sunt a voluntate 
             <lb ed="#V" n="131"/>committente: vel omittente possumus laudari: vel vituperari. 
           </p>

--- a/kzz7yh-f104241/cod-ve09v2_kzz7yh-f104241.xml
+++ b/kzz7yh-f104241/cod-ve09v2_kzz7yh-f104241.xml
@@ -77,7 +77,7 @@
             <lb ed="#V" n="113"/>peccati.
           </p>
           <p xml:id="kzz7yh-f104241-d1e132">
-            ¶ Item pena ordinem het ad demeritum: sed 
+            ¶ Item pena ordinem habet ad demeritum: sed 
             pec<lb ed="#V" n="114" break="no"/>catum non habet ordinem ad peccatum: quia peccatum formaliter 
             priua<lb ed="#V" n="115" break="no"/>tio est: ordo autem aliqua essentia est: sed secundum Auic. 2. meta. 
             <lb ed="#V" n="116"/>capi. primo nulla realis proprietas potest esse in eo quod non 
@@ -92,7 +92,7 @@
             osten<lb ed="#V" n="3" break="no"/>sum: ergo nihil vnum et idem potest esse pena et peccatum. 
           </p>
           <p xml:id="kzz7yh-f104241-d1e159">
-            <lb ed="#V" n="4"/>Contra <ref xml:id="kzz7yh-f104241-Rd1e170">Apoc. vlti.</ref> iustum est: vt qui in fordibus est 
+            <lb ed="#V" n="4"/>Contra <ref xml:id="kzz7yh-f104241-Rd1e170">Apoc. vlti.</ref> iustum est: vt qui in sordibus est 
             <lb ed="#V" n="5"/>sordescat adhuc: ergo videtur quod homo 
             inci<lb ed="#V" n="6" break="no"/>dat in aliqua peccata propter alia que precesserunt.
           </p>
@@ -108,7 +108,7 @@
           </p>
           <p xml:id="kzz7yh-f104241-d1e185">
             ¶ Dicunt enim quidam quod cum de ratione 
-            pec<lb ed="#V" n="12" break="no"/>cati sit esse volutarium: et de ratione pene esse contra 
+            pec<lb ed="#V" n="12" break="no"/>cati sit esse voluntarium: et de ratione pene esse contra 
             volunta<lb ed="#V" n="13" break="no"/>tem: peccatum per se non potest esse pena alterius peccati: 
             <lb ed="#V" n="14"/>sed per accidens scilicet aut ratione sui effectus qui est diminutio 
             <lb ed="#V" n="15"/>aptitudinis naturalis ad virtutem que diminutio est quaedam 
@@ -177,12 +177,12 @@
             <lb ed="#V" n="64"/>dicendum: quod peccatum ratione deformitatis ordinem realem non habet 
             <lb ed="#V" n="65"/>ad aliud peccatm per se: sed per accidens: inquantum scilicet subiectum propter 
             <lb ed="#V" n="66"/>vnam deformitatem iuste permittitur ledi per aliam peccati 
-            defor<lb ed="#V" n="67" break="no"/>mitatem. et etiam per quamdim redctionem scilicet inquantum sunt 
+            defor<lb ed="#V" n="67" break="no"/>mitatem. et etiam per quandam reductionem scilicet inquantum sunt 
             <lb ed="#V" n="68"/>priuationes bonorum ordinatorum: quia tamen priuationes sunt quaedam 
             <!--00307.xml-->
             <cb ed="#P" n="b"/>
             <lb ed="#V" n="69"/>entia in ratione inquantum per suos habitus sunt 
-            apprehen<lb ed="#V" n="70" break="no"/>sibiles ab ea per se ordinem habent admuicem loquendo de 
+            apprehen<lb ed="#V" n="70" break="no"/>sibiles ab ea per se ordinem habent adinuicem loquendo de 
             <lb ed="#V" n="71"/>ordine non reali: sed secundum rationem.
           </p>
           <p xml:id="kzz7yh-f104241-d1e335">
@@ -254,7 +254,7 @@
             <lb ed="#V" n="110"/>a voluntate: cum inordinato murmure et impatientia 
             su<lb ed="#V" n="111" break="no"/>stinentur. Similiter potest dici de passionibus secundo 
             mo<lb ed="#V" n="112" break="no"/>do dictis. Passiones autem tertio modo dicte: rationem 
-            <lb ed="#V" n="113"/>etiam peccati non habent: nisi incomparatione ad 
+            <lb ed="#V" n="113"/>etiam peccati non habent: nisi in comparatione ad 
             volun<lb ed="#V" n="114" break="no"/>tatem: inquantum scilicet ex commissione: vel omissione 
             volun<lb ed="#V" n="115" break="no"/>tatis oriuntur: vel inquantum iam orte a voluntate 
             acce<lb ed="#V" n="116" break="no"/>ptantur: et tunc ipsa culpa formaliter est in voluntate materialiter 
@@ -265,11 +265,11 @@
             persuasibi<lb ed="#V" n="121" break="no"/>lis est a ratione. Sicut dicit philosophus. 1 ethi. ca. penul. 
           </p>
           <p xml:id="kzz7yh-f104241-d1e474">
-            <lb ed="#V" n="122"/>Ad primum in oppositum dicendum: quod <ref xml:id="kzz7yh-f104241-Rd1e493">Graego</ref> ibi 
+            <lb ed="#V" n="122"/>Ad primum in oppositum dicendum: quod <ref xml:id="kzz7yh-f104241-Rd1e493">Gregorius</ref> ibi 
             <lb ed="#V" n="123"/>loquitur de passionibus illatis ab 
             ex<lb ed="#V" n="124" break="no"/>teriori: vel de his quae oriuntur ab interiori per hoc quod natura humana 
             pe<lb ed="#V" n="125" break="no"/>naliter est corrupta: quae iuxta dicuntur inquantum ea patimur 
-            per<lb ed="#V" n="126" break="no"/>demerita nostra: vel per comparationem ad denm iuste permitte 
+            per<lb ed="#V" n="126" break="no"/>demerita nostra: vel per comparationem ad deum iuste permitte 
             <lb ed="#V" n="127"/>tem nos talia pati. Ex hoc tamen non sequitur quin voluntas 
             re<lb ed="#V" n="128" break="no"/>spectu earum peccare possit murmurando: vel impatienter 
             su<lb ed="#V" n="129" break="no"/>stinendo.
@@ -300,7 +300,7 @@
             ¶ 
             Argumen<lb ed="#V" n="5" break="no"/>ta ad oppositum procedunt de passionibus orientibus ab 
             in<lb ed="#V" n="6" break="no"/>teriori per hoc natura culpabiliter fuit corrupta: et procedunt 
-            <lb ed="#V" n="7"/>de ipsis incomparatione ad voluntatem inquantum per 
+            <lb ed="#V" n="7"/>de ipsis in comparatione ad voluntatem inquantum per 
             <lb ed="#V" n="8"/>eius commissionem: vel omissionem oriuntur vel ab ea acceptantur. 
           </p>
         </div>


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve09v2_kzz7yh-f104241.xml`.

## Applied changes

- p. 146v l. 113: het → habet: abbreviated or garbled form of habet; context reads 'pena ordinem habet ad demeritum'
- p. 147r l. 4: fordibus → sordibus: f/s misread at word start
- p. 147r l. 12: volutarium → voluntarium: l/n transposition (volu- instead of volu-n-)
- p. 147r l. 67: quamdim → quandam: m/n and i/a misread; redctionem → reductionem: missing 'u' (garbled OCR)
- p. 147r l. 70: admuicem → adinuicem: standard scholastic phrase 'ad invicem'; m misread for ni
- p. 147r l. 113: incomparatione → in comparatione: two words fused; context reads 'rationem peccati non habent: nisi in comparatione ad voluntatem'
- p. 147r l. 122: Graego → Gregorius: garbled proper name abbreviation; context is a citation of Gregory (cf. 'Greg.' elsewhere in the text)
- p. 147r l. 126: denm → deum: n/u misread, missing u; context reads 'per comparationem ad deum iuste permittente'
- p. 147v l. 7: incomparatione → in comparatione: two words fused; context reads 'de ipsis in comparatione ad voluntatem'

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_