### PR TITLE
Transcription corrections: cod-ve09v2_kzz7yh-f105545.xml (3 changes)

### DIFF
--- a/kzz7yh-f105545/cod-ve09v2_kzz7yh-f105545.xml
+++ b/kzz7yh-f105545/cod-ve09v2_kzz7yh-f105545.xml
@@ -106,8 +106,8 @@
           <!--00310.xml-->
           <cb ed="#P" n="b"/>
           <lb ed="#V" n="69"/>perem: Quidam bonitatem circumstantie informantis: vt 
-          da<lb ed="#V" n="70" break="no"/>re elemosynam ex compassione et liberalitate: Quidam habent 
-          <lb ed="#V" n="71"/>bonitatem finis et vere forme: vt dare elemosynam propter 
+          da<lb ed="#V" n="70" break="no"/>re <sic>elemosynam</sic> ex compassione et liberalitate: Quidam habent 
+          <lb ed="#V" n="71"/>bonitatem finis et vere forme: vt dare <sic>elemosynam</sic> propter 
           <lb ed="#V" n="72"/>deum et ex charitate. Et quomodo hec in speciali 
           intelli<lb ed="#V" n="73" break="no"/>genda sint propono inferius declarare. 
         </p>

--- a/kzz7yh-f105545/cod-ve09v2_kzz7yh-f105545.xml
+++ b/kzz7yh-f105545/cod-ve09v2_kzz7yh-f105545.xml
@@ -56,13 +56,13 @@
         <head xml:id="kzz7yh-f105545-Hd1e101">Circa litteram</head>
         <p xml:id="kzz7yh-f105545-d1e103">
           <lb ed="#V" n="29"/>CIrca litteram. peccatum est causa 
-          pec<lb ed="#V" n="30" break="no"/>cati id est dispotio <!--abbreviation--> inclinans 
+          pec<lb ed="#V" n="30" break="no"/>cati id est dispositio <!--abbreviation--> inclinans 
           <lb ed="#V" n="31"/>ad aliud peccatum tam ratione auersionis quam ratione 
           con<lb ed="#V" n="32" break="no"/>uersionis. Sed ratione auersionis inquantum per 
           ip<lb ed="#V" n="33" break="no"/>sam remouetur: vel diminuitur diuinum auxilium prohibens 
           <lb ed="#V" n="34"/>peccatum disponit: vel inclinat peccantem ad quodlibet aliud 
           <lb ed="#V" n="35"/>peccatum: quia in illa remotione: vel diminutione prohibentis 
-          con<lb ed="#V" n="36" break="no"/>municant omnia peccata secundum plus et minus. Raitione autem 
+          con<lb ed="#V" n="36" break="no"/>municant omnia peccata secundum plus et minus. Ratione autem 
           conuer<lb ed="#V" n="37" break="no"/>sionis secundum quam distinguuntur peccata non quodlibet inclinat 
           <lb ed="#V" n="38"/>ad quodlibet: sed peccatum vnius generis: disponit ad peccatum 
           <lb ed="#V" n="39"/>eiusdem generis: vt superbia ad superbiam: gula ad gulam: vel 
@@ -98,7 +98,7 @@
         </p>
         <p xml:id="kzz7yh-f105545-d1e187">
           ¶ Respondeo textus littere 
-          intelligi<lb ed="#V" n="64" break="no"/>tur de impossibiti per se: non de impossibili per accidens. Adduntur quoque 
+          intelligi<lb ed="#V" n="64" break="no"/>tur de impossibili per se: non de impossibili per accidens. Adduntur quoque 
           <lb ed="#V" n="65"/>quosdam non tantum essentia: sed etiam genere bonos esse: vt reficere 
           <lb ed="#V" n="66"/>esurientem qui est actus de genere operum misicordie. Hic notandum quod 
           <lb ed="#V" n="67"/>actuum: Quidam habent solam bonitatem efficientis: vt leuare 


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve09v2_kzz7yh-f105545.xml`.

## Applied changes

- p. 148v l. 30: dispotio → dispositio: missing 'i'; context reads 'peccatum est causa peccati id est dispositio inclinans'
- p. 148v l. 36: Raitione → Ratione: ai/a misread (spurious i inserted); context reads 'Ratione autem conversionis'
- p. 148v l. 64: impossibiti → impossibili: t/l misread; context reads 'de impossibili per se'

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_