### PR TITLE
Transcription corrections: cod-ve09v2_kzz7yh-f105662.xml (2 changes)

### DIFF
--- a/kzz7yh-f105662/cod-ve09v2_kzz7yh-f105662.xml
+++ b/kzz7yh-f105662/cod-ve09v2_kzz7yh-f105662.xml
@@ -83,7 +83,7 @@
           <lb ed="#V" n="18"/>contrarie opinionis confirmationem. ibi. Illa vero Aug. 
         </p>
         <p xml:id="kzz7yh-f105662-d1e543">
-          <lb ed="#V" n="19"/>¶ Tertio secundum istos ponit prime opeinionis 
+          <lb ed="#V" n="19"/>¶ Tertio secundum istos ponit prime opinionis 
           impugnatio<lb ed="#V" n="20" break="no"/>nem. ibi. In hoc autem verbo.
         </p>
         <p xml:id="kzz7yh-f105662-d1e550">
@@ -95,7 +95,7 @@
           vide<lb ed="#V" n="22" break="no"/>tur pro contraria opinione responsionem.
         </p>
         <p xml:id="kzz7yh-f105662-d1e560">
-          ¶ Secundo exr 
+          ¶ Secundo ex 
           <lb ed="#V" n="23"/>hoc elicit incidenter conclusionem. ibi. Ex quo colligitur. 
         </p>
         <p xml:id="kzz7yh-f105662-d1e565">


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve09v2_kzz7yh-f105662.xml`.

## Applied changes

- p. 149v l. 19: opeinionis → opinionis: spurious 'e' inserted (opei- → opi-); context reads 'prime opinionis impugnationem'
- p. 149v l. 22: exr → ex: spurious 'r' appended; context reads 'Secundo ex hoc elicit incidenter conclusionem'

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_