### PR TITLE
Transcription corrections: cod-ve09v2_kzz7yh-f106909.xml (6 changes)

### DIFF
--- a/kzz7yh-f106909/cod-ve09v2_kzz7yh-f106909.xml
+++ b/kzz7yh-f106909/cod-ve09v2_kzz7yh-f106909.xml
@@ -147,8 +147,8 @@
           <p xml:id="kzz7yh-f106909-d1e263">
             ¶ Ad secundum 
             <lb ed="#V" n="72"/>cum dicitur quod si sint aliqua duo quorum vnum non possit 
-            fie<lb ed="#V" n="73" break="no"/>ri sine alio: qui facit vnum cooperatur ad alterius factio 
-            <lb ed="#V" n="74"/>nem etc. Dico quod verum est sic intelligendo quod neutrum eorum 
+            fie<lb ed="#V" n="73" break="no"/>ri sine alio: qui facit vnum cooperatur ad alterius 
+            factio<lb ed="#V" n="74" break="no"/>nem etc. Dico quod verum est sic intelligendo quod neutrum eorum 
             <lb ed="#V" n="75"/>sine alio possit fieri: sed quamuis malitia que est in actione: 
             <lb ed="#V" n="76"/>non potuisset fieri sine actione: tamen illa actio fieri potuisset 
             <lb ed="#V" n="77"/>sine malitia. Uerbi gratia. in actione de qua minime 
@@ -200,8 +200,8 @@
             enun<lb ed="#V" n="105" break="no"/>ciatio 
             fal<lb ed="#V" n="106" break="no"/>sa inquantum falsa sit a deo. Et videtur quod sic: 
             <lb ed="#V" n="107"/>Quia illud est a deo quod non potest fieri nisi per 
-            <lb ed="#V" n="108"/>deum. Sed demonstrato aliquo homine peccatore: illa enum 
-            <lb ed="#V" n="109"/>ciatio qua peccator enunciatur falsificari non potest: nisi e 
+            <lb ed="#V" n="108"/>deum. Sed demonstrato aliquo homine peccatore: illa 
+            enun<lb ed="#V" n="109" break="no"/>ciatio qua peccator enunciatur falsificari non potest: nisi e 
             <lb ed="#V" n="110"/>deum: quia nullus alius a deo sibi iustitiam potest dare: 
             er<lb ed="#V" n="111" break="no"/>go videtur quod postquam iustificatus est falsitas 
             enunciatio<lb ed="#V" n="112" break="no"/>nis qua enunciatur peccator a deo est.
@@ -221,7 +221,7 @@
           </p>
           <p xml:id="kzz7yh-f106909-d1e394">
             ¶ Item. 3. Re. vlt. 
-            <lb ed="#V" n="120"/>dicit deus spiritui mendaci egredere et facita: dixerat enim 
+            <lb ed="#V" n="120"/>dicit deus spiritui mendaci egredere et fac ita: dixerat enim 
             <lb ed="#V" n="121"/>ille spiritus quod per mendacium deciperet regem israel: ergo 
             vi<lb ed="#V" n="122" break="no"/>detur quod illud mendacium quod dixerunt falsi prophete regi istul 
             <lb ed="#V" n="123"/>per suggestionem mendacis spiritus a deo fuerit imperatum. 
@@ -245,8 +245,8 @@
           <p xml:id="kzz7yh-f106909-d1e433">
             ¶ Ad cuius 
             intel<lb ed="#V" n="133" break="no"/>ligentiam sciendum quod secundum Ansel. lib. de veritate. cap. secundo 
-            <lb ed="#V" n="134"/>Alia est rectitudo et veritas enunciationis: quia signt ad quod 
-            <lb ed="#V" n="135"/>signandum facta est. Alia vero quia signt quod accepit 
+            <lb ed="#V" n="134"/>Alia est rectitudo et veritas enunciationis: quia signat ad quod 
+            <lb ed="#V" n="135"/>signandum facta est. Alia vero quia signat quod accepit 
             significa<lb ed="#V" n="136" break="no"/>re. Hanc enim secundam veritatem semper habet. Aliam ve¬ 
             <!--00315.xml-->
             <pb ed="#V" n="151-r"/>
@@ -278,8 +278,8 @@
             conformi<lb ed="#V" n="23" break="no"/>tatis ad ipsam rem. Et falsitas carentiam conformitatis 
             <lb ed="#V" n="24"/>ad ipsam rem. Intellectus autem creatus causans 
             enun<lb ed="#V" n="25" break="no"/>ciationem causat conformitatem eius ad rem vel carentiam 
-            <lb ed="#V" n="26"/>conformitatis: et ipsam carentiam causat ex sui defectibilita 
-            <lb ed="#V" n="27"/>te. Ueritas ergo vel falsitas in enunciatione sunt ab 
+            <lb ed="#V" n="26"/>conformitatis: et ipsam carentiam causat ex sui 
+            defectibilita<lb ed="#V" n="27" break="no"/>te. Ueritas ergo vel falsitas in enunciatione sunt ab 
             intel<lb ed="#V" n="28" break="no"/>lectu creato enunciante: quamuis ad hoc requiratur quod ita res 
             <lb ed="#V" n="29"/>se habeat vel non habeat: quia relatio non tantum requirit 
             subie<lb ed="#V" n="30" break="no"/>ctum in quo sit: sed terminum respectu cuius sit.

--- a/kzz7yh-f106909/cod-ve09v2_kzz7yh-f106909.xml
+++ b/kzz7yh-f106909/cod-ve09v2_kzz7yh-f106909.xml
@@ -223,7 +223,7 @@
             ¶ Item. 3. Re. vlt. 
             <lb ed="#V" n="120"/>dicit deus spiritui mendaci egredere et fac ita: dixerat enim 
             <lb ed="#V" n="121"/>ille spiritus quod per mendacium deciperet regem israel: ergo 
-            vi<lb ed="#V" n="122" break="no"/>detur quod illud mendacium quod dixerunt falsi prophete regi istul 
+            vi<lb ed="#V" n="122" break="no"/>detur quod illud mendacium quod dixerunt falsi prophete regi israel 
             <lb ed="#V" n="123"/>per suggestionem mendacis spiritus a deo fuerit imperatum. 
           </p>
           <p xml:id="kzz7yh-f106909-d1e406">


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve09v2_kzz7yh-f106909.xml`.

## Applied changes

- p. 150v l. 74: 'factio' + 'nem' split across line break without break="no" on lb n=74
- p. 150v l. 109: enum|ciatio → enun|ciatio: n/m misread in 'enunciatio' split across line break; needs break="no" on lb n=109
- p. 150v l. 120: facita → fac ita: two words run together ('egredere et fac ita' = 'go out and do thus')
- p. 150v l. 134: signt → signat: missing 'a' (garbled OCR)
- p. 150v l. 135: signt → signat: missing 'a' (garbled OCR)
- p. 151r l. 27: 'defectibilita' + 'te' split across line break without break="no" on lb n=27

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_