### PR TITLE
Transcription corrections: cod-ve09v2_kzz7yh-f107373.xml (6 changes)

### DIFF
--- a/kzz7yh-f107373/cod-ve09v2_kzz7yh-f107373.xml
+++ b/kzz7yh-f107373/cod-ve09v2_kzz7yh-f107373.xml
@@ -115,7 +115,7 @@
             <lb ed="#V" n="79"/>corum: casus et fortuna sunt cause per accidens: ergo 
             redu<lb ed="#V" n="80" break="no"/>cuntur in aliquam causam creatam per se. Effectus ergo casuales 
             for<lb ed="#V" n="81" break="no"/>tuiti mediantibus suis causis accidentalibus: que sunt 
-            ca<lb ed="#V" n="82" break="no"/>sus et fortuna reductn ur in aliquam causam creatam: que est 
+            ca<lb ed="#V" n="82" break="no"/>sus et fortuna reducuntur in aliquam causam creatam: que est 
             <lb ed="#V" n="83"/>causa eorum per se.
           </p>
           <p xml:id="kzz7yh-f107373-d1e214">
@@ -137,8 +137,8 @@
             do<lb ed="#V" n="96" break="no"/>mus per accidens: quia albedo est accidens edificatoris quod 
             <lb ed="#V" n="97"/>est causa domus per se. Sed quia causant effectum praeter 
             intentio<lb ed="#V" n="98" break="no"/>nem: qui non de necessitate nec sepe: sed raro causatur ab eis: 
-            <lb ed="#V" n="99"/>et ideo quia ille causae vere suum effectu producunt: non opetet quod sit 
-            <lb ed="#V" n="100"/>alia causa casata: que illius effectus sit causa per se.
+            <lb ed="#V" n="99"/>et ideo quia ille causae vere suum effectu producunt: non oportet quod sit 
+            <lb ed="#V" n="100"/>alia causa causata: que illius effectus sit causa per se.
           </p>
           <p xml:id="kzz7yh-f107373-d1e256">
             ¶ Preterea 
@@ -164,7 +164,7 @@
             <lb ed="#V" n="117"/>ex concursu plurium causarum: qui necessarius non est. Contra hoc 
             <lb ed="#V" n="118"/>arguitur: quia ille concursus effectus quidam est: et ab vna causa 
             nara<lb ed="#V" n="119" break="no"/>li vel pluribus factus: ergo de necessitate factus est: nisi 
-            im<lb ed="#V" n="120" break="no"/>pediatur per liberum arbo diuinum angelicum vel humanum. 
+            im<lb ed="#V" n="120" break="no"/>pediatur per liberum arbitrium diuinum angelicum vel humanum. 
             <lb ed="#V" n="121"/>In effectibus autem casualibus: qui fortuiti sunt: quod ideo dico: quia 
             <lb ed="#V" n="122"/>omnis fortuna casus est: sed non conuertitur: non sic est: quia 
             <lb ed="#V" n="123"/>effectus fortuiti: cum sint ab agente per voluntatem 
@@ -186,7 +186,7 @@
             <cb ed="#P" n="a"/>
             <lb ed="#V" n="1"/>bitoris in illo foro in tali hora causa per se fuit aliqua: 
             vtpo<lb ed="#V" n="2" break="no"/>te tunc emere vinum: et ideo quamuis ille concursus sit fortuitus per 
-            <lb ed="#V" n="3"/>comparationem ad predietam voluntatem debitoris tantum: tamen due 
+            <lb ed="#V" n="3"/>comparationem ad praedictam voluntatem debitoris tantum: tamen due 
             <lb ed="#V" n="4"/>predicte voluntates simul fuerunt causa per se illius 
             con<lb ed="#V" n="5" break="no"/>cursus: quia ad illas duas voluntates: non sequitur raro: 
             <lb ed="#V" n="6"/>sed sepe. Concursus tamen actuum volendi scilicet actus ipsius 
@@ -208,7 +208,7 @@
             <lb ed="#V" n="18"/>quod omne peraccidens reducitur ad per se etc. Hoc est 
             in<lb ed="#V" n="19" break="no"/>telligendum de per accidens quod consistit in hoc quod aliquod 
             <lb ed="#V" n="20"/>accidens est vt in subiecto in causa per se. Sicut fuit positum 
-            <lb ed="#V" n="21"/>exitom in corpore quaestionis de albedine respectu edificatoris: 
+            <lb ed="#V" n="21"/>exemplum in corpore quaestionis de albedine respectu edificatoris: 
             <lb ed="#V" n="22"/>Unde ibi illud argumentum sufficienter est solutum.
           </p>
           <p xml:id="kzz7yh-f107373-d1e396">

--- a/kzz7yh-f107373/cod-ve09v2_kzz7yh-f107373.xml
+++ b/kzz7yh-f107373/cod-ve09v2_kzz7yh-f107373.xml
@@ -250,7 +250,7 @@
             ¶ Item potentior est caua per se in operando quam causa per 
             ac<lb ed="#V" n="46" break="no"/>cidens: sed causa per se non potest producere suum effectum nisi 
             <lb ed="#V" n="47"/>adiuuetur a deo in operando: ergo multo minus casus et 
-            <lb ed="#V" n="48"/>fortunaeque sunt causae per accidens: vt vult philosophus. 2. philosophy.) 
+            <lb ed="#V" n="48"/>fortuna (que sunt causae per accidens: vt vult philosophus. 2. phy.) 
             <lb ed="#V" n="49"/>possunt producere suum effectum nisi a deo iuuentur in 
             ope<lb ed="#V" n="50" break="no"/>rando: ergo omnes effectus casuales et fortuiti 
             reducun<lb ed="#V" n="51" break="no"/>tur in deum: sicut in causam.

--- a/kzz7yh-f107373/cod-ve09v2_kzz7yh-f107373.xml
+++ b/kzz7yh-f107373/cod-ve09v2_kzz7yh-f107373.xml
@@ -132,7 +132,7 @@
             <lb ed="#V" n="91"/>non omnes effectus 
             <lb ed="#V" n="92"/>fortuiti: nec omnes effectus casuales reducuntur in aliquam causam 
             <lb ed="#V" n="93"/>creatam: que sit causa eorum. Casus enim et fortuna non dicuntur causae 
-            per<lb ed="#V" n="94" break="no"/>accidens alicuius effectus: quia sint accidentia alicuius causae: quie per 
+            per<lb ed="#V" n="94" break="no"/>accidens alicuius effectus: quia sint accidentia alicuius causae: quae per 
             <lb ed="#V" n="95"/>se sit causa effectus illius. Sicut dicimus quod album est causa 
             do<lb ed="#V" n="96" break="no"/>mus per accidens: quia albedo est accidens edificatoris quod 
             <lb ed="#V" n="97"/>est causa domus per se. Sed quia causant effectum praeter 
@@ -250,7 +250,7 @@
             ¶ Item potentior est caua per se in operando quam causa per 
             ac<lb ed="#V" n="46" break="no"/>cidens: sed causa per se non potest producere suum effectum nisi 
             <lb ed="#V" n="47"/>adiuuetur a deo in operando: ergo multo minus casus et 
-            <lb ed="#V" n="48"/>fortunacque sunt causae per accidens: vt vult philosophus. 2. philosophy.) 
+            <lb ed="#V" n="48"/>fortunaeque sunt causae per accidens: vt vult philosophus. 2. philosophy.) 
             <lb ed="#V" n="49"/>possunt producere suum effectum nisi a deo iuuentur in 
             ope<lb ed="#V" n="50" break="no"/>rando: ergo omnes effectus casuales et fortuiti 
             reducun<lb ed="#V" n="51" break="no"/>tur in deum: sicut in causam.


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve09v2_kzz7yh-f107373.xml`.

## Applied changes

- p. 151r l. 82: reductn ur → reducuntur: garbled OCR split of 'reducuntur' within the line
- p. 151r l. 99: opetet → oportet: OCR misread (e/or transposition); 'non oportet quod sit'
- p. 151r l. 100: casata → causata: not in word list (OCR transform matched)
- p. 151r l. 120: arbo → arbitrium: truncated OCR of 'liberum arbitrium' (free will)
- p. 151v l. 3: predietam → praedictam: ie/ic OCR misread
- p. 151v l. 21: exitom → exemplum: garbled OCR of 'exemplum' ('Sicut fuit positum exemplum in corpore quaestionis')

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_