### PR TITLE
Transcription corrections: cod-ve09v2_kzz7yh-f107924.xml (3 changes)

### DIFF
--- a/kzz7yh-f107924/cod-ve09v2_kzz7yh-f107924.xml
+++ b/kzz7yh-f107924/cod-ve09v2_kzz7yh-f107924.xml
@@ -61,7 +61,7 @@
           notan<lb ed="#V" n="121" break="no"/>dum quod res potest accipi communiter: et sic 
           comprehen<lb ed="#V" n="122" break="no"/>dit omne illud quod cadit in cognitione: et sic dicitur a 
           <lb ed="#V" n="123"/>reor reris. Alio modo proprie: et sic conuertitur cum ente. 
-          <lb ed="#V" n="124"/>Tertio modo magis proprie: et fic tantum modo dicitur de ente 
+          <lb ed="#V" n="124"/>Tertio modo magis proprie: et sic tantum modo dicitur de ente 
           <lb ed="#V" n="125"/>per se: quod est substantia.
         </p>
         <p xml:id="kzz7yh-f107924-d1e123">
@@ -85,7 +85,7 @@
           <lb ed="#V" n="133"/>quod conseruat naturam. Tertio modo pro quolibet ente 
           quod<lb ed="#V" n="134" break="no"/>cumque sit illud: et hoc tertio modo accipitur natura in 
           ver<lb ed="#V" n="135" break="no"/>bo proposito. Quid mirum si deus non dicitur esse actor 
-          <lb ed="#V" n="136"/>eorum: inquantum nihil sunt. Uidetur enim efficacite 
+          <lb ed="#V" n="136"/>eorum: inquantum nihil sunt. Uidetur enim efficaciter 
           <!--00317.xml-->
           <pb ed="#V" n="152-r"/>
           <cb ed="#P" n="a"/>
@@ -99,7 +99,7 @@
           <lb ed="#V" n="8"/>sed deficientem: quod dici non potest de illo: quod simpliciter 
           ni<lb ed="#V" n="9" break="no"/>hil est. Iniquitas ipsa non est substantia. Nota hic quod potest 
           <lb ed="#V" n="10"/>dici substantia. Uno modo ens per se stans naturaliter: 
-          <lb ed="#V" n="11"/>et sic accipitur proprie. Alio modo accipitur comnissime: et 
+          <lb ed="#V" n="11"/>et sic accipitur proprie. Alio modo accipitur communissime: et 
           <lb ed="#V" n="12"/>sic accipitur pro quolibet ente. et hoc modo accipiendo 
           <lb ed="#V" n="13"/>substantiam dicimus quod illud quod nulla substantia est 
           ni<lb ed="#V" n="14" break="no"/>hil est: et vtroque modo verum est quod deformitas 


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve09v2_kzz7yh-f107924.xml`.

## Applied changes

- p. 151v l. 124: fic → sic: long-s (ſ) misread as 'f' ('et fic tantum modo' → 'et sic tantum modo')
- p. 151v l. 136: efficacite → efficaciter: missing final r
- p. 152r l. 11: comnissime → communissime: spurious n, missing u ('Alio modo accipitur communissime')

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_