### PR TITLE
Transcription corrections: cod-ve09v2_kzz7yh-f108039.xml (1 change)

### DIFF
--- a/kzz7yh-f108039/cod-ve09v2_kzz7yh-f108039.xml
+++ b/kzz7yh-f108039/cod-ve09v2_kzz7yh-f108039.xml
@@ -316,8 +316,8 @@
           <lb ed="#V" n="24"/>Cumque intentio.
         </p>
         <p xml:id="kzz7yh-f108039-d1e645">
-          ¶ Quarto comparat voluntatem ad extem 
-          <lb ed="#V" n="25"/>riorem actum dist. 42. ibi. Cum autem voluntas.
+          ¶ Quarto comparat voluntatem ad 
+          exter<lb ed="#V" n="25" break="no"/>iorem actum dist. 42. ibi. Cum autem voluntas.
         </p>
         <p xml:id="kzz7yh-f108039-d1e650">
           ¶ Prima in 


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve09v2_kzz7yh-f108039.xml`.

## Applied changes

- p. 153r l. 25: exteriorem split across lb n=25 without break=no: 'extem' (misread 'm' for 'r') ends line 24, 'riorem' starts line 25; correct stem is 'exter', suffix 'iorem'; add break=no to lb n=25

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_