### PR TITLE
Transcription corrections: cod-ve09v2_kzz7yh-f108684.xml (3 changes)

### DIFF
--- a/kzz7yh-f108684/cod-ve09v2_kzz7yh-f108684.xml
+++ b/kzz7yh-f108684/cod-ve09v2_kzz7yh-f108684.xml
@@ -231,7 +231,7 @@
             <lb ed="#V" n="14"/>boni actus voluntatis.
           </p>
           <p xml:id="kzz7yh-f108684-d1e400">
-            ¶ Item pslamum inclinaui cor meum 
+            ¶ Item psalmus inclinaui cor meum 
             <lb ed="#V" n="15"/>ad fa. iusti. I. in eter. propter re. Sed plurium bonorum actuum 
             <lb ed="#V" n="16"/>voluntatis plures sunt retributiones: ergo non omnium 
             <lb ed="#V" n="17"/>bonorum actuum voluntatis est vnus finis.
@@ -266,7 +266,7 @@
           </p>
           <p xml:id="kzz7yh-f108684-d1e456">
             ¶ Item Glosionus super illud ad 
-            <lb ed="#V" n="35"/>Phitl primo. Siue per occasionem etc. dicit quod quisquis 
+            <lb ed="#V" n="35"/>Phil. primo. Siue per occasionem etc. dicit quod quisquis 
             <lb ed="#V" n="36"/>preter deum: aliquid querit non caste deum querit: ergo 
             bo<lb ed="#V" n="37" break="no"/>ne voluntates preter deum non possunt constituere finem alium. 
           </p>
@@ -515,7 +515,7 @@
           </p>
           <p xml:id="kzz7yh-f108684-d1e886">
             ¶ Ad secundum dicendum quod secundum Glosionus super illud 
-            <lb ed="#V" n="45"/>pslam. Cum inuocarem: finis accipi potest pro consumptione 
+            <lb ed="#V" n="45"/>psalmum. Cum inuocarem: finis accipi potest pro consumptione 
             <lb ed="#V" n="46"/>et pro consumatione: primo modo loquendo omnium 
             ma<lb ed="#V" n="47" break="no"/>larum voluntatum: vnus est finis non numero: sed 
             similitu<lb ed="#V" n="48" break="no"/>dinem scilicet afflictio eterna: que in qualibet voluntate damnata 

--- a/kzz7yh-f108684/cod-ve09v2_kzz7yh-f108684.xml
+++ b/kzz7yh-f108684/cod-ve09v2_kzz7yh-f108684.xml
@@ -493,7 +493,7 @@
             vo<lb ed="#V" n="25" break="no"/>lentis. Si autem diuersi sunt genere vel specie: habent 
             di<lb ed="#V" n="26" break="no"/>uersos fines genere vel specie differentes. Et hoc propter 
             im<lb ed="#V" n="27" break="no"/>perfectionem appetibilis: quia enim vnus appetit 
-            delecta<lb ed="#V" n="28" break="no"/>tionem in delitiis carnalibus. Alius appetit temporalem 
+            delecta<lb ed="#V" n="28" break="no"/>tionem in <sic>delitiis</sic> carnalibus. Alius appetit temporalem 
             suffi<lb ed="#V" n="29" break="no"/>cientiam et alius excellentiam: que simul non sunt in eodem 
             <lb ed="#V" n="30"/>bono creato: propter eius imperfectionem. Ideo ille 
             volun<lb ed="#V" n="31" break="no"/>tates diuersos habent fines specie vel genere differentes: 

--- a/kzz7yh-f108684/cod-ve09v2_kzz7yh-f108684.xml
+++ b/kzz7yh-f108684/cod-ve09v2_kzz7yh-f108684.xml
@@ -296,7 +296,7 @@
             ¶ Ad secundum dicendum: quod illa 
             au<lb ed="#V" n="50" break="no"/>ctoritas vel intelligenda est de retributione principali: que 
             <lb ed="#V" n="51"/>est ipse deus: qui se dicit mercedem amicorum suorum. Unde 
-            <lb ed="#V" n="52"/>Genen 15 dicit ad Abraham: ego protector tuus sum: et 
+            <lb ed="#V" n="52"/>Genes. 15 dicit ad Abraham: ego protector tuus sum: et 
             mer<lb ed="#V" n="53" break="no"/>ces tua magnanimis. Aut intelligenda est de 
             retributio<lb ed="#V" n="54" break="no"/>ne: que est finis secundo modo dictus: et sic non est 
             inconue<lb ed="#V" n="55" break="no"/>niens bonarum voluntatum esse plures finis.
@@ -374,7 +374,7 @@
           </p>
           <p xml:id="kzz7yh-f108684-d1e636">
             ¶ Alio 
-            <lb ed="#V" n="93"/>modo pro quete voluntatis in illo bono: tertio modo pro principali 
+            <lb ed="#V" n="93"/>modo pro quiete voluntatis in illo bono: tertio modo pro principali 
             <lb ed="#V" n="94"/>habitu quo anima in illo quiescit.
           </p>
           <p xml:id="kzz7yh-f108684-d1e643">
@@ -493,8 +493,8 @@
             vo<lb ed="#V" n="25" break="no"/>lentis. Si autem diuersi sunt genere vel specie: habent 
             di<lb ed="#V" n="26" break="no"/>uersos fines genere vel specie differentes. Et hoc propter 
             im<lb ed="#V" n="27" break="no"/>perfectionem appetibilis: quia enim vnus appetit 
-            delecta<lb ed="#V" n="28" break="no"/>tionem in delitiis carnalibus. Alius appetit temporalem sus 
-            <lb ed="#V" n="29"/>ficientiam et alius excellentiam: que simul non sunt in eodem 
+            delecta<lb ed="#V" n="28" break="no"/>tionem in delitiis carnalibus. Alius appetit temporalem 
+            suffi<lb ed="#V" n="29" break="no"/>cientiam et alius excellentiam: que simul non sunt in eodem 
             <lb ed="#V" n="30"/>bono creato: propter eius imperfectionem. Ideo ille 
             volun<lb ed="#V" n="31" break="no"/>tates diuersos habent fines specie vel genere differentes: 
             <lb ed="#V" n="32"/>Sed quia omnia que bone voluntates appetunt 


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve09v2_kzz7yh-f108684.xml`.

## Applied changes

- p. 153v l. 52: Genen → Genes.: garbled abbreviation for Genesis; correct abbreviated form is 'Genes.'
- p. 153v l. 93: quete → quiete: not in word list (OCR transform matched)
- p. 154r l. 29: sufficientiam split across lb n=29 without break=no: 'sus' ends line 28, 'ficientiam' starts line 29; 'sus' is misread for 'suffi'; add break=no to lb n=29

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_