### PR TITLE
Transcription corrections: cod-ve09v2_kzz7yh-f109525.xml (40 changes)

### DIFF
--- a/kzz7yh-f109525/cod-ve09v2_kzz7yh-f109525.xml
+++ b/kzz7yh-f109525/cod-ve09v2_kzz7yh-f109525.xml
@@ -55,7 +55,7 @@
       <div xml:id="kzz7yh-f109525"><!-- l2d38a2 -->
         <head xml:id="kzz7yh-f109525-Hd1e101">Articulus 2</head>
         <p xml:id="kzz7yh-f109525-d1e103">
-          <lb ed="#V" n="64"/>COnsequeter queritur de secundo 
+          <lb ed="#V" n="64"/>COnsequenter queritur de secundo 
           <lb ed="#V" n="65"/>principali. Et circa 
           <lb ed="#V" n="66"/>hoc queruntur quatuor.
         </p>
@@ -110,7 +110,7 @@
             ¶ Item Aug. 10. de trini. ca id est 
             <lb ed="#V" n="90"/>firmissime nouimus amari nisi nota non posse: sed non omnes 
             <lb ed="#V" n="91"/>cognoscunt finem: quia secundum philosophum id est ethico. cap. 6 plures 
-            erra<lb ed="#V" n="92" break="no"/>uerunt circa cognitionem finis. Unde quida posuerunt 
+            erra<lb ed="#V" n="92" break="no"/>uerunt circa cognitionem finis. Unde quidam posuerunt 
             <lb ed="#V" n="93"/>eam in voluptatibus: quidam in honoribus: quidam in 
             diui<lb ed="#V" n="94" break="no"/>tiis: ergo non omnis voluntas finem appetit. 
           </p>
@@ -189,7 +189,7 @@
             <!--00322.xml-->
             <pb ed="#V" n="154-v"/>
             <cb ed="#P" n="a"/>
-            <lb ed="#V" n="1"/>creator hoc indidit. Sed beatitundo finis est: ergo omnes 
+            <lb ed="#V" n="1"/>creator hoc indidit. Sed beatitudo finis est: ergo omnes 
             <lb ed="#V" n="2"/>naturaliter appetunt finem.
           </p>
           <p xml:id="kzz7yh-f109525-d1e335">
@@ -201,7 +201,7 @@
             con<lb ed="#V" n="7" break="no"/>sumatiuum scientie.
           </p>
           <p xml:id="kzz7yh-f109525-d1e349">
-            ¶ Preterea Glo. super illud pslamum. 
+            ¶ Preterea Glo. super illud psalmum. 
             Bea<lb ed="#V" n="8" break="no"/>ta gens. dicit quod animus est naturaliter capax beatitudinis. 
             <lb ed="#V" n="9"/>Sed nulla creatura capax alicuius boni naturaliter est 
             <lb ed="#V" n="10"/>derelicta sine omni naturali inclinatione ad illud: ergo 
@@ -244,7 +244,7 @@
             <lb ed="#V" n="39"/>tantum sub ratione qua liberum arbitrium est: sed etiam sub 
             ra<lb ed="#V" n="40" break="no"/>tione qua deliberatiuum: non est libere velle absolute: sic 
             <lb ed="#V" n="41"/>enim eligere est actus liberi arbitrii. Sed secundum Dam. libro 
-            <lb ed="#V" n="42"/>2. cap. 24. Oportet omnio consilium antecedere electionem. Et philosophus 
+            <lb ed="#V" n="42"/>2. cap. 24. Oportet omnino consilium antecedere electionem. Et philosophus 
             <lb ed="#V" n="43"/>3. ethico. cap. 4 dicit quod voluntarium non omne eligibile: 
             <lb ed="#V" n="44"/>sed certe quod preconsiliatum: ergo libere velle non est actus 
             no<lb ed="#V" n="45" break="no"/>stri liberi arbitrii nisi inquantum consideratur post 
@@ -271,7 +271,7 @@
             <lb ed="#V" n="60"/>est determinata voluntas natura vt refugere non possit 
             il<lb ed="#V" n="61" break="no"/>lud bonum quod sibi representatur ab intellectu: vt in se 
             com<lb ed="#V" n="62" break="no"/>prehendens omnem rationem appetibilitatis: et nullam rationem 
-            <lb ed="#V" n="63"/>fugibilitatis: ergo post qualencumque considerationem: finis 
+            <lb ed="#V" n="63"/>fugibilitatis: ergo post qualemcumque considerationem: finis 
             <lb ed="#V" n="64"/>voluntas de necessitate absque omni coactione vult finem. 
           </p>
           <p xml:id="kzz7yh-f109525-d1e489">
@@ -290,7 +290,7 @@
             ¶ Ad 
             <lb ed="#V" n="70"/>tertium dicendum: quod voluntas de necessitate vult sinem: et 
             natura<lb ed="#V" n="71" break="no"/>liter et libere: quia quamuis sub alia ratione ipsa voluntas sit 
-            <lb ed="#V" n="72"/>nama: et sub alia ratione libera: et suum velle finem sub alia 
+            <lb ed="#V" n="72"/>natura: et sub alia ratione libera: et suum velle finem sub alia 
             ra<lb ed="#V" n="73" break="no"/>tione liberum: tamen quia iste due rationes non discordant: 
             <lb ed="#V" n="74"/>sed concordant. Sicut realiter eadem est potentia que est 
             na<lb ed="#V" n="75" break="no"/>tura: et que est libera. Ita realiter idem numero actus 
@@ -328,7 +328,7 @@
           </p>
           <p xml:id="kzz7yh-f109525-d1e580">
             ¶ Item vnus 
-            <lb ed="#V" n="97"/>motts simplex non est a duobus motoribus. Cum ergo 
+            <lb ed="#V" n="97"/>motus simplex non est a duobus motoribus. Cum ergo 
             vel<lb ed="#V" n="98" break="no"/>le sit motus simplex et voluntas moueatur ab 
             appetibi<lb ed="#V" n="99" break="no"/>li: vt habetur. 3. de anima. non mouet seipsam ad 
             volen<lb ed="#V" n="100" break="no"/>dum finem: nec aliquid aliud.
@@ -452,7 +452,7 @@
           <p xml:id="kzz7yh-f109525-d1e795">
             <lb ed="#V" n="38"/>Contra hoc arguo sic aut intellectus mouet primo 
             vo<lb ed="#V" n="39" break="no"/>luntatem et postea voluntas intellectum: et tunc 
-            <lb ed="#V" n="40"/>interum intellectus voluntatem: aut voluntas primo mouet 
+            <lb ed="#V" n="40"/>iterum intellectus voluntatem: aut voluntas primo mouet 
             <lb ed="#V" n="41"/>intellectum. Si intellectus primo mouet voluntatem cum 
             di<lb ed="#V" n="42" break="no"/>ctamen intellectus: omnem actum voluntatis precedens 
             <lb ed="#V" n="43"/>sit necessarium: vt in hac eadem dist. ostendetur in illa 
@@ -462,7 +462,7 @@
             cau<lb ed="#V" n="47" break="no"/>sa: sequitur quod motus voluntatis causatus in ea per 
             predi<lb ed="#V" n="48" break="no"/>ctum motum intellectus esset necessarius. Et pari ratione 
             <lb ed="#V" n="49"/>potest probari quod secundus motus intellectus per predictum 
-            <lb ed="#V" n="50"/>motum voluntatis causatus effet necessarius. Et vlterius 
+            <lb ed="#V" n="50"/>motum voluntatis causatus esset necessarius. Et vlterius 
             <lb ed="#V" n="51"/>quod secundus motus voluntatis causatus per secundum actum 
             <lb ed="#V" n="52"/>intellectus esset necessarius: et sic deinceps. Et sic in 
             nul<lb ed="#V" n="53" break="no"/>lo actu intellectus: et in nullo actu voluntatis esset 
@@ -501,7 +501,7 @@
             <lb ed="#V" n="75"/>et ex consequenti quod secundus motus intellectus per 
             pre<lb ed="#V" n="76" break="no"/>dictum actum voluntatis causatus esset necessarius. Et 
             <lb ed="#V" n="77"/>vlterius quod secundus motus voluntatis causatus per secundum 
-            <lb ed="#V" n="78"/>actum inteliectus esset necessarius. Et sic deincegs secundum 
+            <lb ed="#V" n="78"/>actum intellectus esset necessarius. Et sic deinceps secundum 
             mo<lb ed="#V" n="79" break="no"/>dum: qui superius tactus est. Cum ergo omnibus 
             fideli<lb ed="#V" n="80" break="no"/>bus certum sit voluntatem liberam esse non tantum a 
             coactio<lb ed="#V" n="81" break="no"/>ne: sed etiam a naturali necessitate respectu eorum que sunt 
@@ -551,7 +551,7 @@
             ¶ Quod autem habens voluntatem non 
             <lb ed="#V" n="117"/>determinet se ad volendum finem: patet ratione. Quod enim 
             <lb ed="#V" n="118"/>determinat se ad aliquem motum potest se mouere motu 
-            <lb ed="#V" n="119"/>opposito illi motui. Et hoc trahi potest ex sententia phlosophi. 8. 
+            <lb ed="#V" n="119"/>opposito illi motui. Et hoc trahi potest ex sententia philosophi. 8. 
             <lb ed="#V" n="120"/>physicorum. Sed habens voluntatem non potest se mouere 
             <lb ed="#V" n="121"/>motu opposito illi motui: quo vult sinem: quia ipsum de 
             <lb ed="#V" n="122"/>necessitate vult: vt in precedenti questione visum est. 
@@ -579,7 +579,7 @@
             <cb ed="#P" n="a"/>
             <lb ed="#V" n="1"/>luntati dedit talem naturam: vt habens voluntatem per eam 
             <lb ed="#V" n="2"/>non possit non velle finem si non assit impedimentum impediens 
-            vo<lb ed="#V" n="3" break="no"/>luntatis quemlibet actum velabsentia actualis cognitionis in intellectu 
+            vo<lb ed="#V" n="3" break="no"/>luntatis quemlibet actum vel absentia actualis cognitionis in intellectu 
           </p>
           <p xml:id="kzz7yh-f109525-d1e1053">
             <lb ed="#V" n="4"/>¶ Quod autem habens potentiam voluntatis per eam moueat 
@@ -654,8 +654,8 @@
           </p>
           <p xml:id="kzz7yh-f109525-d1e1191">
             ¶ Ad 6m 
-            <lb ed="#V" n="60"/>dicendum quod illa propositio Anselumus ad hoc quod habeat 
-            verita<lb ed="#V" n="61" break="no"/>tem intelligenda est de motu volutnatis ad quem 
+            <lb ed="#V" n="60"/>dicendum quod illa propositio Anselmi ad hoc quod habeat 
+            verita<lb ed="#V" n="61" break="no"/>tem intelligenda est de motu voluntatis ad quem 
             volun<lb ed="#V" n="62" break="no"/>tas determinat se: et per velle se ita mouere intelligit 
             vel<lb ed="#V" n="63" break="no"/>le sinem: in cuius virtute determinat se ad volendum ea 
             <lb ed="#V" n="64"/>que sunt ad finem.
@@ -729,7 +729,7 @@
           <p xml:id="kzz7yh-f109525-d1e1317">
             ¶ Preterea quicquid 
             <lb ed="#V" n="103"/>voluntas vult: vult sub ratione boni: vt superius 
-            habi<lb ed="#V" n="104" break="no"/>tum est. Sed quelibet bonitas parricularis est aliqua 
+            habi<lb ed="#V" n="104" break="no"/>tum est. Sed quelibet bonitas particularis est aliqua 
             vir<lb ed="#V" n="105" break="no"/>tus vltimi sinis: est enim quedam participatio 
             sufficien<lb ed="#V" n="106" break="no"/>tissimi boni complentis totum appetitum quod bonum est 
             <lb ed="#V" n="107"/>vltimus finis: ergo quicquid vult voluntas vult in 
@@ -746,7 +746,7 @@
           </p>
           <p xml:id="kzz7yh-f109525-d1e1349">
             ¶ Preterea Ansel. de casu diaboli. ca. 12. dicit quod 
-            ho<lb ed="#V" n="115" break="no"/>mo per naturalem voluntatem vitandi incommodu: aut 
+            ho<lb ed="#V" n="115" break="no"/>mo per naturalem voluntatem vitandi incommodum: aut 
             <lb ed="#V" n="116"/>habendi commodum se mouet ad alias voluntates. Sed 
             <lb ed="#V" n="117"/>in vltimo fine includitur omnis commoditas et 
             excludi<lb ed="#V" n="118" break="no"/>tur ab eo incommoditas: ergo quicquid vult voluntas 
@@ -763,8 +763,8 @@
           </p>
           <p xml:id="kzz7yh-f109525-d1e1381">
             ¶ Ad secundum cum dicitur 
-            <lb ed="#V" n="127"/>quod homines multa mala volunt que contrariantur vlt 
-            <lb ed="#V" n="128"/>mo fini etc. Dico quod verum est. Sed non volunt ea sub 
+            <lb ed="#V" n="127"/>quod homines multa mala volunt que contrariantur 
+            vlt<lb ed="#V" n="128" break="no"/>mo fini etc. Dico quod verum est. Sed non volunt ea sub 
             <lb ed="#V" n="129"/>ratione qua contrariantur vltimo fini. Sed ratione 
             ali<lb ed="#V" n="130" break="no"/>cuius boni substrati illis deformitatibus: que 
             vlti<lb ed="#V" n="131" break="no"/>ni repugnant quas deformitates nullo modo 
@@ -801,10 +801,10 @@
             cogno<lb ed="#V" n="14" break="no"/>scere eam: et quia prius est rem cognoscere quam aduertere se 
             co<lb ed="#V" n="15" break="no"/>gnoscere. Ideo potest aliquis aliquam rem cognoscere et non 
             <lb ed="#V" n="16"/>aduertit quod cognoscat. Et similiter potest aliquando aliquid vel 
-            <lb ed="#V" n="17"/>le: et non aquertit quod illud velit. Dicunt ergo quod quaesdoncumque 
+            <lb ed="#V" n="17"/>le: et non aduertit quod illud velit. Dicunt ergo quod quandocumque 
             ali<lb ed="#V" n="18" break="no"/>quis vult aliquam rem propter aliquem sinem: semper actu 
             <lb ed="#V" n="19"/>vult illum finem: sed non aduertit se velle: et etiam illum 
-            cogno<lb ed="#V" n="20" break="no"/>scit: sed non semper aduertit se cognoscere: et ideo non opeet 
+            cogno<lb ed="#V" n="20" break="no"/>scit: sed non semper aduertit se cognoscere: et ideo non oportet 
             <lb ed="#V" n="21"/>quod semper de illo cogitet: quia cogitare importat 
             cognitio<lb ed="#V" n="22" break="no"/>nem et cognitionem cognitionis.
           </p>
@@ -813,7 +813,7 @@
             <lb ed="#V" n="23"/>et melius quod transeunte actu volendi aliquam rem que est 
             <lb ed="#V" n="24"/>finis illius rei quam ego volo bene remanet aliqua virtus 
             <lb ed="#V" n="25"/>eius in actu secundo inquantum in proximo fine actus secundi: est 
-            <lb ed="#V" n="26"/>aliquavertus et participatio primi intenti. 
+            <lb ed="#V" n="26"/>aliqua virtus et participatio primi intenti. 
           </p>
         </div>
         <div xml:id="kzz7yh-f109525-Dd1e1480">
@@ -828,28 +828,28 @@
             intelle<lb ed="#V" n="31" break="no"/>ctus dissentire non potest a conclusione certitudinaliter 
             vi<lb ed="#V" n="32" break="no"/>sa eius connexione ad principium: ergo cum ita se habeat 
             fi<lb ed="#V" n="33" break="no"/>nis in agibilibus respectu voluntatis: sicut principia in 
-            spe<lb ed="#V" n="34" break="no"/>culabilibus respectu intellectus: secundum sententiam phlosophi. 7. ethicorum 
+            spe<lb ed="#V" n="34" break="no"/>culabilibus respectu intellectus: secundum sententiam philosophi. 7. ethicorum 
             <lb ed="#V" n="35"/>cap. 12. Uoluntas non potest velle contrarium illius quod 
             intel<lb ed="#V" n="36" break="no"/>lectus iudicat habere necessariam connexionem cum fine. 
           </p>
           <p xml:id="kzz7yh-f109525-d1e1508">
             <lb ed="#V" n="37"/>¶ Item secundum sententiam philosophi. 2. Top. Si simpliciter ad 
             simpli<lb ed="#V" n="38" break="no"/>citer: et magis ad magis. Sed bonum a voluntate 
-            appeti<lb ed="#V" n="39" break="no"/>tur et nihil aliud: quia secundum Diony. 4. cap. de diui. no. Nihit 
+            appeti<lb ed="#V" n="39" break="no"/>tur et nihil aliud: quia secundum Diony. 4. cap. de diui. no. Nihil 
             <lb ed="#V" n="40"/>appetitur sub ratione mali: ergo semper magis bonum: 
             ma<lb ed="#V" n="41" break="no"/>gis a voluntate appetitur: quod non esset verum: si voluntas 
             pos<lb ed="#V" n="42" break="no"/>set se mouere contra iudicium intellectus.
           </p>
           <p xml:id="kzz7yh-f109525-d1e1524">
-            ¶ Item Anselmnus 
+            ¶ Item Anselmus 
             <lb ed="#V" n="43"/>lib. de veritate. cap. 12. dicit quod omnis voluntas habet quid 
             <lb ed="#V" n="44"/>et cur: sed si per intellectum representarentur voluntati 
             ali<lb ed="#V" n="45" break="no"/>qua duo: vt equaliter eligibilia non esset causa: quare 
             vo<lb ed="#V" n="46" break="no"/>luntas eligeret vnum eorum significatum altero dimisso: ergo non 
             <lb ed="#V" n="47"/>posset se determinare ad eligendum hoc signatum a dimisso. b.o 
-            <lb ed="#V" n="48"/>Sed facilius posset se determinare ad ialud quod iudicatur equa 
+            <lb ed="#V" n="48"/>Sed facilius posset se determinare ad illud quod iudicatur equa 
             <lb ed="#V" n="49"/>eligibile alii quam ad illud quod iudicatur minus eligibile quam 
-            <lb ed="#V" n="50"/>aliud: ergo nuquam potest voluntas velle illud: cuius 
+            <lb ed="#V" n="50"/>aliud: ergo nunquam potest voluntas velle illud: cuius 
             con<lb ed="#V" n="51" break="no"/>trarium intellectus dictat magis eligendum.
           </p>
           <p xml:id="kzz7yh-f109525-d1e1546">
@@ -864,7 +864,7 @@
           <p xml:id="kzz7yh-f109525-d1e1563">
             ¶ Item <ref xml:id="kzz7yh-f109525-Rd1e1605">philosophus. 3 ethi. cap. 3.</ref> dicit quod ignorat 
             <lb ed="#V" n="58"/>omnis malus que opetet operari: et a quibus fugiendum: et 
-            pro<lb ed="#V" n="59" break="no"/>pter tale peccatum iniusti et viverlaiter mali fiunt: ergo videtur 
+            pro<lb ed="#V" n="59" break="no"/>pter tale peccatum iniusti et vniuersaliter mali fiunt: ergo videtur 
             <lb ed="#V" n="60"/>quod si non esset error in iudicio intellectus voluntas non posset 
             <lb ed="#V" n="61"/>in eligendo errare: quod non esset verum si posset se mouere 
             com<lb ed="#V" n="62" break="no"/>tra iudicium intellectus.
@@ -892,7 +892,7 @@
           <p xml:id="kzz7yh-f109525-d1e1614">
             ¶ Item si voluntas non posset se mouere contra 
             <lb ed="#V" n="76"/>iudicium intellectus: tunc cum homo sciret quid esset 
-            <lb ed="#V" n="77"/>agendum: et in vniuersali et in particulari non esset monem 
+            <lb ed="#V" n="77"/>agendum: et in vniuersali et in particulari non esset monen 
             <lb ed="#V" n="78"/>dus: vt vellet facere illud quod scit: quia non posset non 
             <lb ed="#V" n="79"/>velle facere illud. Sed sicut dicit Aug. 3 lib. de. libero 
             ar<lb ed="#V" n="80" break="no"/>bitrio: non multum post principium: quisquis existimat non 
@@ -903,7 +903,7 @@
           <p xml:id="kzz7yh-f109525-d1e1634">
             ¶ Item Ber. de 
             <lb ed="#V" n="84"/>libero arbitrio. non multum post principium dicit: quod 
-            volun<lb ed="#V" n="85" break="no"/>tas non semper ex ratione: sed numquam absqueratione mouetur: 
+            volun<lb ed="#V" n="85" break="no"/>tas non semper ex ratione: sed numquam absque ratione mouetur: 
             <lb ed="#V" n="86"/>ita vt multa faciat per ipsam contra ipsam hoc est per eius 
             <lb ed="#V" n="87"/>quasi ministerium contra eius consilium siue iudicium. 
           </p>
@@ -918,7 +918,7 @@
             <lb ed="#V" n="92"/>dicit quod si aliqui duo equaliter affecti animo et corpore: et 
             <lb ed="#V" n="93"/>omnibus aliis conditionibus paribus videant vnius 
             cor<lb ed="#V" n="94" break="no"/>poris pulchritudinem non dispariliter occurrentem eorum 
-            <lb ed="#V" n="95"/>aspectibus: vnus eorum potest moueri ad illicite fruendu 
+            <lb ed="#V" n="95"/>aspectibus: vnus eorum potest moueri ad illicite fruendum 
             <lb ed="#V" n="96"/>et aliter in voluntate pudica perseuerare stabiliter. Sed 
             <lb ed="#V" n="97"/>per suppositionem: equale est iudicium in vtroque: ergo cum 
             <lb ed="#V" n="98"/>ipsi eligant contraria electio alterius eorum est 
@@ -1001,7 +1001,7 @@
             inclinan<lb ed="#V" n="19" break="no"/>tes ad aliquid eligendum: aut auertere ab inspectione 
             ra<lb ed="#V" n="20" break="no"/>tionum illarum: est voluntatem velle aliquid eorum que sunt 
             <lb ed="#V" n="21"/>ad finem: ergo voluntas potest velle aliquid eorum que sunt 
-            <lb ed="#V" n="22"/>ad finem non determinata ad boc per iudicium intellectus. 
+            <lb ed="#V" n="22"/>ad finem non determinata ad hoc per iudicium intellectus. 
           </p>
           <p xml:id="kzz7yh-f109525-d1e1829">
             <lb ed="#V" n="23"/>¶ Alii dicunt ad questionem quod antequam voluntas 
@@ -1018,7 +1018,7 @@
             preter<lb ed="#V" n="32" break="no"/>iudicium intellectus: non tamen contra predictum eius 
             iudi<lb ed="#V" n="33" break="no"/>cium. Et innituntur aliquibus rationibus factis in opponendo 
             <lb ed="#V" n="34"/>ad hanc partem: et auctoritati philosophi sumpte de. 7. ethic. que 
-            <lb ed="#V" n="35"/>in opponendo aliegata est. Et philosopho dicenti in. 2. celi. et 
+            <lb ed="#V" n="35"/>in opponendo allegata est. Et philosopho dicenti in. 2. celi. et 
             mun<lb ed="#V" n="36" break="no"/>di. deficiente et famelico valde a quo elongatur cibus et 
             po<lb ed="#V" n="37" break="no"/>tus equaliter: quia cogitur vt quiescat: et non moueatur omnio. 
             <lb ed="#V" n="38"/>Hic autem non esset verum si voluntas se determinare posset: 
@@ -1028,11 +1028,11 @@
             vo<lb ed="#V" n="41" break="no"/>luntas non est minus libera in 
             vo<lb ed="#V" n="42" break="no"/>lendo aliquid eorum que sunt ad finem respectu cuius 
             pre<lb ed="#V" n="43" break="no"/>cessit deliberatum consilium intellectus: quam ante vt ostendam. 
-            <lb ed="#V" n="44"/>Sed ante confilium intellectus voluntas potuisset contrarium 
+            <lb ed="#V" n="44"/>Sed ante consilium intellectus voluntas potuisset contrarium 
             <lb ed="#V" n="45"/>illius eligere: vt etiam dicit praedicta opinio: ergo et hoc potest 
             <lb ed="#V" n="46"/>post deliberatum consilium intellectus. Maiorem probo sic. 
             vo<lb ed="#V" n="47" break="no"/>luntas non est minus libera respectu actus eligendi: quam 
-            re<lb ed="#V" n="48" break="no"/>spectu cuiuscumque alterius actus: sed actus eligendi nonest 
+            re<lb ed="#V" n="48" break="no"/>spectu cuiuscumque alterius actus: sed actus eligendi non est 
             <lb ed="#V" n="49"/>a voluntate nisi post deliberatum consilium intellectus. Unde 
             <lb ed="#V" n="50"/>philosophus. 3. ethi. cap. 5. dicit quod voluntarium non omne eligibile: 
             <lb ed="#V" n="51"/>sed certe quod preconsiliatum. hoc idem vult Dam. lib. 2. ca. 
@@ -1043,7 +1043,7 @@
             ¶ Preterea actus 
             <lb ed="#V" n="54"/>procedentes a voluntate ante deliberationem procedunt 
             ab<lb ed="#V" n="55" break="no"/>ea ex surreptione. Sed illi procedunt ab ea ante 
-            delibera<lb ed="#V" n="56" break="no"/>tionem qui ab ea procedunt ante confilium intellectus: actus 
+            delibera<lb ed="#V" n="56" break="no"/>tionem qui ab ea procedunt ante consilium intellectus: actus 
             <lb ed="#V" n="57"/>autem procedens post deliberatum consilium intellectus: 
             proce<lb ed="#V" n="58" break="no"/>dit ab ea deliberatiue. Sed constat quod voluntas est 
             libe<lb ed="#V" n="59" break="no"/>rior respectu suorum actuum ab ea procedentium ex 
@@ -1090,7 +1090,7 @@
             ¶ Uel potest dici quod conclusio pars est 
             <lb ed="#V" n="90"/>rei significate per maiorem in syllogismo. Unde in hoc 
             <lb ed="#V" n="91"/>syllogismo: omnis beatus est iustus paulus est beatus: 
-            er<lb ed="#V" n="92" break="no"/>go paulus est iustus: res significata per conclusionem est pers 
+            er<lb ed="#V" n="92" break="no"/>go paulus est iustus: res significata per conclusionem est pars 
             <lb ed="#V" n="93"/>rei significate per maiorem. Et ideo intellectus consentiens 
             <lb ed="#V" n="94"/>maiori et euidenter videns conclusionem in ea 
             contineri<lb ed="#V" n="95" break="no"/>ab illa dissentire non potest: quia hoc implicaret 
@@ -1099,7 +1099,7 @@
             <lb ed="#V" n="98"/>illius: et ideo potest illa voluntas non velle: quamuis velit 
             fi<lb ed="#V" n="99" break="no"/>nem. Inter enim aliqua duo: quorum vnum sequitur ad 
             <lb ed="#V" n="100"/>aliud: voluntas separare potest: si vnum non includatur in 
-            <lb ed="#V" n="101"/>effentia alterius. Sicut mulier vere penitens: et habens 
+            <lb ed="#V" n="101"/>essentia alterius. Sicut mulier vere penitens: et habens 
             <lb ed="#V" n="102"/>quandam valentem filium de fornicatione dolet se fornicasse 
             <lb ed="#V" n="103"/>et tame vult illum filium habuisse.
           </p>
@@ -1164,19 +1164,19 @@
             ¶ Ad quintum dicendum: quod illa 
             proposi<lb ed="#V" n="7" break="no"/>tio philosophi: ad hoc vt habeat veritatem intelligenda 
             <lb ed="#V" n="8"/>est: vel de errore intellectus causante malitiam in 
-            volun<lb ed="#V" n="9" break="no"/>tate. Uel de causato ex malitia voluntatis subdisiunctione. 
+            volun<lb ed="#V" n="9" break="no"/>tate. Uel de causato ex malitia voluntatis sub distinctione. 
             Ip<lb ed="#V" n="10" break="no"/>se enim. 5 ethi. ca. 14. distinguit peccatum ex electione contra 
             pec<lb ed="#V" n="11" break="no"/>catum ex ignorantia.
           </p>
           <p xml:id="kzz7yh-f109525-d1e2143">
             ¶ Ad sextum dicendum: quod non est 
-            consentien<lb ed="#V" n="12" break="no"/>dum ibi philosopho: nisi exponatut sic: vt intelligatur de 
+            consentien<lb ed="#V" n="12" break="no"/>dum ibi philosopho: nisi exponatur sic: vt intelligatur de 
             conclu<lb ed="#V" n="13" break="no"/>sione immediata: illa enim de necessitate bene sequitur. 
             Uer<lb ed="#V" n="14" break="no"/>bi gratia ex ista maiore: omne iniustum est fugiendum: et 
             <lb ed="#V" n="15"/>ista minore: accipere rem alienam inuito domino est 
             iniu<lb ed="#V" n="16" break="no"/>stum: sequitur de necessitate quod accipere rem alienam 
             inui<lb ed="#V" n="17" break="no"/>to domino est fugiendum. Sed ista secunda conclusio que 
-            <lb ed="#V" n="18"/>est velle fagere acceptionem rei inuito domino: non 
+            <lb ed="#V" n="18"/>est velle fugere acceptionem rei inuito domino: non 
             sequi<lb ed="#V" n="19" break="no"/>tur de necessitate.
           </p>
           <p xml:id="kzz7yh-f109525-d1e2163">

--- a/kzz7yh-f109525/cod-ve09v2_kzz7yh-f109525.xml
+++ b/kzz7yh-f109525/cod-ve09v2_kzz7yh-f109525.xml
@@ -154,7 +154,7 @@
           <p xml:id="kzz7yh-f109525-d1e271">
             ¶ Uidetur 
             er<lb ed="#V" n="122" break="no"/>go mihi dicendum ad questionem quod voluntas inquantum 
-            <lb ed="#V" n="123"/>libera de necessitate vult finem sub ratione gnaturali sub qua 
+            <lb ed="#V" n="123"/>libera de necessitate vult finem sub ratione generali sub qua 
             ge<lb ed="#V" n="124" break="no"/>neraliter est omni intellectui motus: que est bonum: maxime 
             com<lb ed="#V" n="125" break="no"/>plens: et perficiens totum appetitum: tale enim bonum est 
             <lb ed="#V" n="126"/>sufficientissimum. Sub hac autem ratione generali: finis 
@@ -195,7 +195,7 @@
           <p xml:id="kzz7yh-f109525-d1e335">
             ¶ Preterea omne quod 
             ha<lb ed="#V" n="3" break="no"/>bet aliquem naturalem motum naturaliter appetit 
-            fi<lb ed="#V" n="4" break="no"/>nem: qui est consumatio motus illius. Sed vt dicitur 
+            fi<lb ed="#V" n="4" break="no"/>nem: qui est <sic>consumatio</sic> motus illius. Sed vt dicitur 
             <lb ed="#V" n="5"/>primo metaphysi. Omnes homines natura scire 
             deside<lb ed="#V" n="6" break="no"/>rant: ergo naturaliter per voluntatem appetunt finem 
             con<lb ed="#V" n="7" break="no"/>sumatiuum scientie.
@@ -426,7 +426,7 @@
             <lb ed="#V" n="19"/>cognitionem principiorum possit se mouere in virtute illius 
             <lb ed="#V" n="20"/>cognitionis ad actualem cognitionem conclusionum: ergo similiter 
             <lb ed="#V" n="21"/>negari non potest: quin voluntas postquam est in actu 
-            volen<lb ed="#V" n="22" break="no"/>di finem agibilium possit se moucre ad agibilia que sunt 
+            volen<lb ed="#V" n="22" break="no"/>di finem agibilium possit se <sic>moucre</sic> ad agibilia que sunt 
             <lb ed="#V" n="23"/>ad finem: cum sic se habeat finis respectu agibilium: sicut 
             <lb ed="#V" n="24"/>principia respectu speculabilium.
           </p>
@@ -521,7 +521,7 @@
             <lb ed="#V" n="92"/>sed tamen nihil vult non possit habere voluntatem primam a se. 
           </p>
           <p xml:id="kzz7yh-f109525-d1e932">
-            <lb ed="#V" n="93"/>¶ Quamuis autem haec opinio videatur concordare ipsi Anselmnus. 
+            <lb ed="#V" n="93"/>¶ Quamuis autem haec opinio videatur concordare ipsi Anselmi. 
             <lb ed="#V" n="94"/>et sit multum probabilis. Aliqubus tamen non placet: quia secundum eam non 
             <lb ed="#V" n="95"/>vident quomodo voluntas esset libera a coactione respectu finis 
             <lb ed="#V" n="96"/>nec videtur eis rationabile quod possit se mouere ad volendum 
@@ -534,7 +534,7 @@
             mo<lb ed="#V" n="102" break="no"/>ueat se ad volendum: sed habens voluntatem mouet se ad 
             <lb ed="#V" n="103"/>volendum per eam. Nec vere dici potest quod habens 
             volun<lb ed="#V" n="104" break="no"/>tatem determinet se ad volendum finem: et tamen vere dicitur quod 
-            ha<lb ed="#V" n="105" break="no"/>bens potentiam voluntatia per eam mouet se ad volendum 
+            ha<lb ed="#V" n="105" break="no"/>bens potentiam <sic>voluntatia</sic> per eam mouet se ad volendum 
             <lb ed="#V" n="106"/>non tantum ea que sunt ad sinem: sed etiam finem. Quod autem 
             <lb ed="#V" n="107"/>sit improprius sermo: cum dicitur voluntas mouet se ad 
             vo<lb ed="#V" n="108" break="no"/>lendum patet: quia actus sunt a suppositis per formas. 
@@ -863,7 +863,7 @@
           </p>
           <p xml:id="kzz7yh-f109525-d1e1563">
             ¶ Item <ref xml:id="kzz7yh-f109525-Rd1e1605">philosophus. 3 ethi. cap. 3.</ref> dicit quod ignorat 
-            <lb ed="#V" n="58"/>omnis malus que opetet operari: et a quibus fugiendum: et 
+            <lb ed="#V" n="58"/>omnis malus que oportet operari: et a quibus fugiendum: et 
             pro<lb ed="#V" n="59" break="no"/>pter tale peccatum iniusti et vniuersaliter mali fiunt: ergo videtur 
             <lb ed="#V" n="60"/>quod si non esset error in iudicio intellectus voluntas non posset 
             <lb ed="#V" n="61"/>in eligendo errare: quod non esset verum si posset se mouere 
@@ -1056,7 +1056,7 @@
           </p>
           <p xml:id="kzz7yh-f109525-d1e1930">
             ¶ Preterea quanto voluntas magis habet 
-            <lb ed="#V" n="66"/>rationem liberi arbitrii tanto libetius potest se determinare. Sed 
+            <lb ed="#V" n="66"/>rationem liberi arbitrii tanto <sic>libetius</sic> potest se determinare. Sed 
             <lb ed="#V" n="67"/>magis habet rationem liberi arbitrii post deliberatum consilium 
             <lb ed="#V" n="68"/>intellectus: quam ante: ergo post deliberatum consilium intel¬ 
             <!--00326.xml-->
@@ -1146,7 +1146,7 @@
             <lb ed="#V" n="133"/>ab eterno reprobauit quosdam determinate: et alios 
             ele<lb ed="#V" n="134" break="no"/>git: et redditur ratio: quare aliqus elegit: et aliquos reprobauit. 
             <lb ed="#V" n="135"/>Sed quare hunc signatum scilicet Iacob elegerit: et Esau 
-            repro<lb ed="#V" n="136" break="no"/>bauerit nulla alia videtur posse rediratio: nisi quia voluit 
+            repro<lb ed="#V" n="136" break="no"/>bauerit nulla alia videtur posse redi ratio: nisi quia voluit 
             <!--00327.xml-->
             <pb ed="#V" n="157-r"/>
             <cb ed="#P" n="a"/>


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve09v2_kzz7yh-f109525.xml`.

## Applied changes

- p. 154r l. 64: COnsequeter → COnsequenter: t/r transposition (missing 'n')
- p. 154r l. 92: quida → quidam: final m dropped
- p. 154v l. 1: beatitundo → beatitudo: n/d transposition
- p. 154v l. 7: pslamum → psalmum: transposed letters in psalmus
- p. 154v l. 42: omnio → omnino: missing 'n'
- p. 154v l. 63: qualencumque → qualemcumque: accusative form of qualiscumque; fugibilitatis is valid medieval Latin
- p. 154v l. 72: nama → natura: garbled word
- p. 154v l. 97: motts → motus: garbled ending
- p. 155r l. 40: interum → iterum: spurious 'n' inserted
- p. 155r l. 50: effet → esset: garbled imperfect subjunctive of esse
- p. 155r l. 78: inteliectus → intellectus: missing 'l'; deincegs → deinceps: g/p misread
- p. 155r l. 119: phlosophi → philosophi: missing 'i' (metathesis)
- p. 155v l. 3: velabsentia → vel absentia: two words run together
- p. 155v l. 60: Anselumus → Anselmi: genitive required after 'propositio'; garbled form
- p. 155v l. 61: volutnatis → voluntatis: transposed letters
- p. 155v l. 104: parricularis → particularis: doubled 'r' for 't'
- p. 155v l. 115: incommodu → incommodum: final m dropped
- p. 155v l. 128: vlt|mo split across line break without break="no" on lb n=128
- p. 156r l. 17: aquertit → aduertit: v/q misread; quaesdoncumque → quandocumque: garbled quandocumque
- p. 156r l. 20: opeet → oportet: garbled/truncated form
- p. 156r l. 26: aliquavertus → aliqua virtus: two words run together with garbling
- p. 156r l. 34: phlosophi → philosophi: missing 'i' (metathesis)
- p. 156r l. 39: Nihit → Nihil: t/l misread
- p. 156r l. 42: Anselmnus → Anselmus: spurious 'n' inserted
- p. 156r l. 48: ialud → illud: 'i' for first 'l', garbled
- p. 156r l. 50: nuquam → nunquam: missing 'n'
- p. 156r l. 59: viverlaiter → vniuersaliter: garbled word (Aristotle: 'universaliter mali fiunt')
- p. 156r l. 77: monem → monen: stem of gerundive monendus split across line break (see line 78 'dus'); vniuersali is valid
- p. 156r l. 85: absqueratione → absque ratione: two words run together
- p. 156r l. 95: fruendu → fruendum: final m dropped
- p. 156v l. 22: boc → hoc: b/h misread
- p. 156v l. 35: aliegata → allegata: spurious 'i' inserted
- p. 156v l. 44: confilium → consilium: f/s misread (long-s as f)
- p. 156v l. 48: nonest → non est: two words run together
- p. 156v l. 56: confilium → consilium: f/s misread (long-s as f)
- p. 156v l. 92: pers → pars: e/a misread
- p. 156v l. 101: effentia → essentia: f/s misread (long-s as f); penitens is orthographic variant retained
- p. 157r l. 9: subdisiunctione → sub distinctione: two words run together; 'disiunctione' garbled from 'distinctione'
- p. 157r l. 12: exponatut → exponatur: final 't' for 'r' transposition in passive subjunctive
- p. 157r l. 18: fagere → fugere: a/u misread in fugere (to flee)

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_