### PR TITLE
Transcription corrections: cod-ve09v2_kzz7yh-f11117.xml (12 changes)

### DIFF
--- a/kzz7yh-f11117/cod-ve09v2_kzz7yh-f11117.xml
+++ b/kzz7yh-f11117/cod-ve09v2_kzz7yh-f11117.xml
@@ -65,7 +65,7 @@
         </p>
         <p xml:id="kzz7yh-f11117-d1e117">
           ¶ Secundo vtrum sit 
-          actua<lb ed="#V" n="83" break="no"/>lior: quam forma quoruncumque corporum. 
+          actua<lb ed="#V" n="83" break="no"/>lior: quam forma quorumcumque corporum. 
         </p>
         <div xml:id="kzz7yh-f11117-Dd1e122">
           <head xml:id="kzz7yh-f11117-Hd1e124">Quaestio 1</head>
@@ -76,7 +76,7 @@
             vni<lb ed="#V" n="85" break="no"/>genea cum materia corporalium. Quia 
             prae<lb ed="#V" n="86" break="no"/>libro de mirabilibus sacre scripture. c. i. dicit de deo 
             <lb ed="#V" n="87"/>quod ex inferiori materia: quam ipse prius ex nihilo condidit 
-            <lb ed="#V" n="88"/>cuctorum visibilium: intellectualium: et intellectu carentium: species 
+            <lb ed="#V" n="88"/>cunctorum visibilium: intellectualium: et intellectu carentium: species 
             <lb ed="#V" n="89"/>multiformes diuisit. Ergo vnigenea est materia et 
             intellectua<lb ed="#V" n="90" break="no"/>lium et corporalium.
           </p>
@@ -96,14 +96,14 @@
           </p>
           <p xml:id="kzz7yh-f11117-d1e166">
             <lb ed="#V" n="99"/>Contra philosophus d es de generione vna est tantum matera habentium ad 
-            <lb ed="#V" n="100"/>seinuicem tramsmutationem. Sed secundum Boe. in libro 
+            <lb ed="#V" n="100"/>se inuicem transmutationem. Sed secundum Boe. in libro 
             <lb ed="#V" n="101"/>de duabus naturis. et vna persona christi. c. 7. nec substantia 
             cor<lb ed="#V" n="102" break="no"/>porea incorpoream: neque incorporea in ea quae est corpus 
             muta<lb ed="#V" n="103" break="no"/>ri potest. Ergo non habent vnigeneam materiam. 
           </p>
           <p xml:id="kzz7yh-f11117-d1e180">
-            <lb ed="#V" n="104"/>Respondeo quod secundum quosdam: maeria angelorum est vne 
-            <lb ed="#V" n="105"/>genea: cum materia corporalium: ad 
+            <lb ed="#V" n="104"/>Respondeo quod secundum quosdam: maeria angelorum est 
+            vnige<lb ed="#V" n="105" break="no"/>nea: cum materia corporalium: ad 
             similitu<lb ed="#V" n="106" break="no"/>dinem qua diceremus plures annulos de auro habere materiam 
             vnige<lb ed="#V" n="107" break="no"/>neam id est similem in substantialitate. Et hi innituntur rationibus 
             fa<lb ed="#V" n="108" break="no"/>ctis ad hanc partem. Addentes est aliam rationem scilicet quod numerus est 
@@ -143,7 +143,7 @@
           <p xml:id="kzz7yh-f11117-d1e251">
             ¶ Si autem quelibet respicit vtrumque 
             ac<lb ed="#V" n="132" break="no"/>tum indifferenter. tunc iudicamus eas esse vnigenee 
-            na<lb ed="#V" n="133" break="no"/>ture. Unde quia materia cuiuslibet elaienti est in potentia ad formam 
+            na<lb ed="#V" n="133" break="no"/>ture. Unde quia materia cuiuslibet elementi est in potentia ad formam 
             <lb ed="#V" n="134"/>cuiuslibet elementi. Dicimus quod in eis est materiam vniuoce. Cum 
             <lb ed="#V" n="135"/>ergo materia angelorum sit determinata ad formam spiritualem. et illi sit 
             <lb ed="#V" n="136"/>
@@ -152,14 +152,14 @@
             <cb ed="#P" n="a"/>
             <lb ed="#V" n="1"/>materia ipsorum corporum sit proportio nata forme corporali: ita vt 
             <lb ed="#V" n="2"/>non sit in potentia ad angelicam formam. Quia sicut dicit 
-            <lb ed="#V" n="3"/>Boesus in lib. de duabus naturis. et vna persona christi. c. 7. 
+            <lb ed="#V" n="3"/>Boetius in lib. de duabus naturis. et vna persona christi. c. 7. 
             <lb ed="#V" n="4"/>Substantia corporea in incorpoream mutari non potest: nec 
             <lb ed="#V" n="5"/>econuerso. sequitur quod materia in spiritibus et corporibus 
             <lb ed="#V" n="6"/>non est vniuoce.
           </p>
           <p xml:id="kzz7yh-f11117-d1e284">
             ¶ Ad hoc etiam sunt auctoritates. dicit 
-            <lb ed="#V" n="7"/>enim commen. super. 8. metaphi. sic. ideo dicit Themisttus. quod 
+            <lb ed="#V" n="7"/>enim commen. super. 8. metaphi. sic. ideo dicit Themistius. quod 
             <lb ed="#V" n="8"/>sol et luna et stelle: aut sunt forme sine materiis: aut habet 
             <lb ed="#V" n="9"/>materias per equiuocationem: sicut dispositio in materiam 
             intel<lb ed="#V" n="10" break="no"/>lectus.
@@ -196,7 +196,7 @@
             ostende<lb ed="#V" n="30" break="no"/>tur: est aliqua possibilitas ad vnam formam: que non est 
             ac<lb ed="#V" n="31" break="no"/>aliam. Unde principium pure potentiale materie generabilium et 
             <lb ed="#V" n="32"/>corruptibilium concreatum. quod est transmutabile: in formam 
-            <lb ed="#V" n="33"/>substantialem: non est tramsmutabile in formam accidentalem. 
+            <lb ed="#V" n="33"/>substantialem: non est transmutabile in formam accidentalem. 
             <lb ed="#V" n="34"/>nec econuerso. vt inferius declarabitur. cum tractabitur de 
             <lb ed="#V" n="35"/>isto principio pure possibili.
           </p>
@@ -208,7 +208,7 @@
         </div>
         <div xml:id="kzz7yh-f11117-Dd1e370">
           <head xml:id="kzz7yh-f11117-Hd1e372">Quaestio 2</head>
-          <head xml:id="kzz7yh-f11117-Hd1e380" type="question-title">Utrum angeli materia sit actualior quam cuiscunque corporis forma</head>
+          <head xml:id="kzz7yh-f11117-Hd1e380" type="question-title">Utrum angeli materia sit actualior quam cuiuscunque corporis forma</head>
           <p xml:id="kzz7yh-f11117-d1e374">
             Quaestio II 
             <lb ed="#V" n="38"/>SEcundo queritur vtrum angeli materia 
@@ -255,7 +255,7 @@
             <!--00046.xml-->
             <cb ed="#P" n="b"/>
             <lb ed="#V" n="69"/>est. quam quaecumque actio pure corporalis. ergo nobilius est principium 
-            <lb ed="#V" n="70"/>passiuum substantie intellectualis: quam principium actiuu 
+            <lb ed="#V" n="70"/>passiuum substantie intellectualis: quam principium actiuum 
             cu<lb ed="#V" n="71" break="no"/>iuscumque substantie corporalis pure. Sed principium passiuum 
             <lb ed="#V" n="72"/>substantie intellectualis est illud quod in ipsa dicitur materia 
             prin<lb ed="#V" n="73" break="no"/>cipium actiuum substantie corporalis. est eius corporalis 
@@ -273,7 +273,7 @@
             <lb ed="#V" n="82"/>ad argumenta que sunt contra eam per modum sequentem. 
           </p>
           <p xml:id="kzz7yh-f11117-d1e493">
-            <lb ed="#V" n="83"/>Ad primum dici potest quod si forma corporis eset 
+            <lb ed="#V" n="83"/>Ad primum dici potest quod si forma corporis esset 
             <lb ed="#V" n="84"/>possibilis ad patiendum tali 
             pas<lb ed="#V" n="85" break="no"/>sione: qua patitur angeli materia: nobilior esset quam sit 
             mo<lb ed="#V" n="86" break="no"/>do. quia ex nobilitate nature create est vt per ipsum 
@@ -307,7 +307,7 @@
             <lb ed="#V" n="106"/>vltimam actualitatem in illa specie. Materia autem ipsius 
             angeli<lb ed="#V" n="107" break="no"/>non importat vltimam actualitatem ipsius speciei in qua est per 
             <lb ed="#V" n="108"/>reductionem. Non autem est inconueniens quod aliquid citra 
-            vl<lb ed="#V" n="109" break="no"/>timam actualitatem nobitissime speciei sit actualius 
+            vl<lb ed="#V" n="109" break="no"/>timam actualitatem nobilissime speciei sit actualius 
             actualita<lb ed="#V" n="110" break="no"/>te speciei pure corporalis. 
           </p>
           <p xml:id="kzz7yh-f11117-d1e565">

--- a/kzz7yh-f11117/cod-ve09v2_kzz7yh-f11117.xml
+++ b/kzz7yh-f11117/cod-ve09v2_kzz7yh-f11117.xml
@@ -95,7 +95,7 @@
             <lb ed="#V" n="98"/>ma et forma substantie: inquantum est substantia. 
           </p>
           <p xml:id="kzz7yh-f11117-d1e166">
-            <lb ed="#V" n="99"/>Contra philosophus d es de generione vna est tantum matera habentium ad 
+            <lb ed="#V" n="99"/>Contra philosophus i. de generatione. vna est tantum materia habentium ad 
             <lb ed="#V" n="100"/>se inuicem transmutationem. Sed secundum Boe. in libro 
             <lb ed="#V" n="101"/>de duabus naturis. et vna persona christi. c. 7. nec substantia 
             cor<lb ed="#V" n="102" break="no"/>porea incorpoream: neque incorporea in ea quae est corpus 

--- a/kzz7yh-f11117/cod-ve09v2_kzz7yh-f11117.xml
+++ b/kzz7yh-f11117/cod-ve09v2_kzz7yh-f11117.xml
@@ -102,7 +102,7 @@
             muta<lb ed="#V" n="103" break="no"/>ri potest. Ergo non habent vnigeneam materiam. 
           </p>
           <p xml:id="kzz7yh-f11117-d1e180">
-            <lb ed="#V" n="104"/>Respondeo quod secundum quosdam: maeria angelorum est 
+            <lb ed="#V" n="104"/>Respondeo quod secundum quosdam: materia angelorum est 
             vnige<lb ed="#V" n="105" break="no"/>nea: cum materia corporalium: ad 
             similitu<lb ed="#V" n="106" break="no"/>dinem qua diceremus plures annulos de auro habere materiam 
             vnige<lb ed="#V" n="107" break="no"/>neam id est similem in substantialitate. Et hi innituntur rationibus 


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve09v2_kzz7yh-f11117.xml`.

## Applied changes

- p. 16r l. 83: quoruncumque → quorumcumque: 'n' misread for 'm' in genitive plural pronoun
- p. 16r l. 88: cuctorum → cunctorum: missing 'n' in 'cunctorum' (of all)
- p. 16r l. 100: seinuicem → se inuicem: spurious merge of 'se' and 'inuicem'; tramsmutationem → transmutationem: transposed 'r' and 'a' ('trams' → 'trans')
- p. 16r l. 105: vnigenea split across lb n=105 without break=no: 'vne' ends line 104 (misread fragment; full stem is 'vnige'), 'genea' starts line 105; add break=no to lb n=105
- p. 16r l. 133: elaienti → elementi: garbled OCR; context 'materia cuiuslibet elaienti est in potentia ad formam cuiuslibet elementi' confirms correction
- p. 16v l. 3: Boesus → Boetius: garbled proper name; reference to Boethius 'de duabus naturis'
- p. 16v l. 7: Themisttus → Themistius: doubled 't' is OCR error; Themistius is the Aristotelian commentator
- p. 16v l. 33: tramsmutabile → transmutabile: transposed 'r' and 'a' ('trams' → 'trans')
- p. 16v l. 37: cuiscunque → cuiuscunque: not in word list (OCR transform matched)
- p. 16v l. 70: actiuu → actiuum: missing final 'm'; 'principium actiuum' is the correct accusative form
- p. 16v l. 83: eset → esset: missing doubled 's' in imperfect subjunctive
- p. 16v l. 109: nobitissime → nobilissime: 't' misread for 'l' in superlative

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_