### PR TITLE
Transcription corrections: cod-ve09v2_kzz7yh-f111603.xml (10 changes)

### DIFF
--- a/kzz7yh-f111603/cod-ve09v2_kzz7yh-f111603.xml
+++ b/kzz7yh-f111603/cod-ve09v2_kzz7yh-f111603.xml
@@ -120,8 +120,8 @@
           <p xml:id="kzz7yh-f111603-d1e206">
             ¶ Primo modo ista naturalia carentia 
             cognitio<lb ed="#V" n="55" break="no"/>ne tendunt in finem sibi praestitutum a conditore nature. 
-            Si<lb ed="#V" n="56" break="no"/>cut etiam tendunt in finem sagitta directa ad aliquenter 
-            <lb ed="#V" n="57"/>minum a sagittante.
+            Si<lb ed="#V" n="56" break="no"/>cut etiam tendunt in finem sagitta directa ad 
+            aliquem ter<lb ed="#V" n="57" break="no"/>minum a sagittante.
           </p>
           <p xml:id="kzz7yh-f111603-d1e215">
             ¶ Secundo modo bruta animalia 
@@ -213,7 +213,7 @@
             mo<lb ed="#V" n="109" break="no"/>uere se ipsam: et omnia alia que in nobis sunt ad finem. 
             <lb ed="#V" n="110"/>Unde Anselmus in lib. de concor. praescientie et liberi arbitrii 
             lon<lb ed="#V" n="111" break="no"/>ge ante finem: dicit quod voluntas est instrumentum quod 
-            mo<lb ed="#V" n="112" break="no"/>uet omnia alia instrumenta quibus spotonte vtimur: et que 
+            mo<lb ed="#V" n="112" break="no"/>uet omnia alia instrumenta quibus sponte vtimur: et que 
             <lb ed="#V" n="113"/>sunt in nobis: vt manum: linguam: visum. Et que sunt 
             ex<lb ed="#V" n="114" break="no"/>tra nos: vt stilum et securim: et facit omnes voluntarios 
             <lb ed="#V" n="115"/>motus: ipsa vero se suis affectionibus mouet: et ideo 
@@ -246,7 +246,7 @@
             <lb ed="#V" n="131"/>voluntatis respectu finis est fruitio etc. dico quod non omnis 
             <lb ed="#V" n="132"/>actus voluntatis respectu finis est fruitio. Ad cuius 
             intel<lb ed="#V" n="133" break="no"/>ligentiam sciendum quod voluntas mouetur infinem 
-            tripli<lb ed="#V" n="134" break="no"/>citer. Uno modo abiolute: et sic actus voluntatis respectu 
+            tripli<lb ed="#V" n="134" break="no"/>citer. Uno modo absolute: et sic actus voluntatis respectu 
             <lb ed="#V" n="135"/>finis absolute dicitur velle. Et sic intellexit philosophus. 3. ethi. 
             <lb ed="#V" n="136"/>ca. 5. vbi dicit quod voluntas est magis finis. Alio modo secundum 
             <!--00328.xml-->
@@ -305,7 +305,7 @@
           </p>
           <p xml:id="kzz7yh-f111603-d1e527">
             ¶ Item 
-            <lb ed="#V" n="31"/>Aigazel 3 libr. meta. ca. 4. sicut non possumus 
+            <lb ed="#V" n="31"/>Algazel 3 libr. meta. ca. 4. sicut non possumus 
             imaginari<lb ed="#V" n="32" break="no"/>duas celaturas: vel duas figuras in eadem cera: sic non possunt 
             <lb ed="#V" n="33"/>imaginari in anima esse due discrete scientie simul 
             presen<lb ed="#V" n="34" break="no"/>tes eodem modo. Sed magis capax est anima scientiarum 
@@ -358,9 +358,9 @@
             <lb ed="#V" n="69"/>non ordinetur ad aliud: nec intendantur sub vna ratione. 
             <!--00328.xml-->
             <cb ed="#P" n="b"/>
-            <lb ed="#V" n="70"/>Sicut experimentaliter patet: cum homo simul intendie 
+            <lb ed="#V" n="70"/>Sicut experimentaliter patet: cum homo simul intendit 
             <lb ed="#V" n="71"/>studere aliquam quaestionem: et aliqua placentia audire que 
-            nar<lb ed="#V" n="72" break="no"/>rantur a circunstantibus. Illa enim ita simul intendit quod 
+            nar<lb ed="#V" n="72" break="no"/>rantur a circumstantibus. Illa enim ita simul intendit quod 
             <lb ed="#V" n="73"/>vnumquodque eorum diminute. Dicunt tamen aliqui quod illa 
             <lb ed="#V" n="74"/>duo sub vna ratione intendit scilicet sub ratione complacentie.
           </p>
@@ -479,7 +479,7 @@
             <!--00329.xml-->
             <pb ed="#V" n="158-r"/>
             <cb ed="#P" n="a"/>
-            <lb ed="#V" n="1"/>spacium vsque ad terminum est vnus motus: ergo similie 
+            <lb ed="#V" n="1"/>spacium vsque ad terminum est vnus motus: ergo similiter 
             <lb ed="#V" n="2"/>tendentia voluntatis ad finem per illud quod est ad finem 
             <lb ed="#V" n="3"/>est vnus actus.
           </p>
@@ -510,10 +510,10 @@
           <p xml:id="kzz7yh-f111603-d1e886">
             <lb ed="#V" n="20"/>Ad primum in oppositum dicendum: quod illa 
             au<lb ed="#V" n="21" break="no"/>ctoritas <name xml:id="kzz7yh-f111603-Nd1e935">Augustini</name> intelligenda est 
-            <lb ed="#V" n="22"/>secundum quod voluntas absolute fertur inuisionem fenestre: et etiam 
-            <lb ed="#V" n="23"/>inuisionem transeuntium. Quod patet: quia cuilibet istorum 
+            <lb ed="#V" n="22"/>secundum quod voluntas absolute fertur in visionem fenestre: et etiam 
+            <lb ed="#V" n="23"/>in visionem transeuntium. Quod patet: quia cuilibet istorum 
             <lb ed="#V" n="24"/>actuum assignat finem suum: dicit enim quod voluntatis 
-            vi<lb ed="#V" n="25" break="no"/>dendi senestram: finis est fenestre visio: et voluntatis 
+            vi<lb ed="#V" n="25" break="no"/>dendi fenestram: finis est fenestre visio: et voluntatis 
             viden<lb ed="#V" n="26" break="no"/>di per fenestram transeuntes: finis est visio transeuntium. 
             <lb ed="#V" n="27"/>Cum autem voluntas vult aliquid non secundum se et absolute: sed 
             <lb ed="#V" n="28"/>in relatione ad finem: talis motionis non est finis duplex: 

--- a/kzz7yh-f111603/cod-ve09v2_kzz7yh-f111603.xml
+++ b/kzz7yh-f111603/cod-ve09v2_kzz7yh-f111603.xml
@@ -330,7 +330,7 @@
           <p xml:id="kzz7yh-f111603-d1e573">
             ¶ Item voluntas aliquando vnum praeeligit alii: quia 
             <lb ed="#V" n="48"/>ad plura valet quam aliud: quia secundum philosophum. 3. topi. plura bona 
-            <lb ed="#V" n="49"/>paurioribus sunt eligenda. Sed praeeligere vnum alii: quia 
+            <lb ed="#V" n="49"/><sic>paurioribus</sic> sunt eligenda. Sed praeeligere vnum alii: quia 
             <lb ed="#V" n="50"/>valet ad plura non est sine intentione plurium: ergo 
             homo<lb ed="#V" n="51" break="no"/>simul intendit aliquando plura. 
           </p>
@@ -387,7 +387,7 @@
           <p xml:id="kzz7yh-f111603-d1e678">
             ¶ Ad 
             se<lb ed="#V" n="87" break="no"/>cundum dicendum: quod et si anima intendendo totam se 
-            conuer<lb ed="#V" n="88" break="no"/>tat ad intentum: quia simplex est: non opetet tamen quod hoc 
+            conuer<lb ed="#V" n="88" break="no"/>tat ad intentum: quia simplex est: non oportet tamen quod hoc 
             sem<lb ed="#V" n="89" break="no"/>per sit secundum totum conatum suum qui in plures portiones 
             di<lb ed="#V" n="90" break="no"/>uisibilis est.
           </p>


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve09v2_kzz7yh-f111603.xml`.

## Applied changes

- p. 157r l. 57: terminum split across lb n=57 without break=no: 'aliquenter' at end of line 56 is garbled 'aliquem ter' (word + split stem); 'minum' starts line 57; add break=no to lb n=57
- p. 157r l. 112: spotonte → sponte: spurious 'o' inserted; 'sponte vtimur' is the correct Latin phrase
- p. 157r l. 134: abiolute → absolute: 'i' misread for 's'; 'absolute' is the correct adverb
- p. 157v l. 31: Aigazel → Algazel: 'i' misread for 'l'; correct name for al-Ghazali in scholastic Latin
- p. 157v l. 70: intendie → intendit: 'e' misread for 't' at word end; 'cum homo simul intendit' is the correct form
- p. 157v l. 72: circunstantibus → circumstantibus: missing 'm' after 'cir'; standard spelling of 'circumstantibus'
- p. 158r l. 1: similie → similiter: garbled adverb; 'ergo similiter tendentia' is the correct reading
- p. 158r l. 22: inuisionem → in visionem: spurious merge of preposition 'in' with noun 'visionem'; 'fertur in visionem fenestre' is the correct reading
- p. 158r l. 23: inuisionem → in visionem: spurious merge of preposition 'in' with noun 'visionem'
- p. 158r l. 25: senestram → fenestram: 's' misread for 'f' at word start; fenestre is valid medieval spelling of 'fenestrae'

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_