### PR TITLE
Transcription corrections: cod-ve07v1_kzz7yh-a98373.xml (8 changes)

### DIFF
--- a/kzz7yh-a98373/cod-ve07v1_kzz7yh-a98373.xml
+++ b/kzz7yh-a98373/cod-ve07v1_kzz7yh-a98373.xml
@@ -137,7 +137,7 @@
           </p>
           <p xml:id="kzz7yh-a98373-d1e233">
             ¶ Quarto modo 
-            po<lb ed="#V" n="82" break="no"/>test esse sensus quod velit omnes homines saluos fieri consequnter: hoc est 
+            po<lb ed="#V" n="82" break="no"/>test esse sensus quod velit omnes homines saluos fieri consequenter: hoc est 
             con<lb ed="#V" n="83" break="no"/>pensatis omnibus conditionibus hominis. Et hoc est simpliciter 
             vel<lb ed="#V" n="84" break="no"/>le omnes homines saluos fieri: et in isto sensu non est verum quod deus 
             ve<lb ed="#V" n="85" break="no"/>lit omnes homines saluos fieri. Omnes enim illi quod sic vult 
@@ -492,7 +492,7 @@
             ¶ Questio. VI 
             <lb ed="#V" n="54"/>SExto queritur quaeritur vtrum 
             bonum<lb ed="#V" n="55" break="no"/>sit mala fieri: et 
-            vi<lb ed="#V" n="56" break="no"/>detur quod sic Hug. i. libro de sacramentius per. 4. c. 5 bonum fuit 
+            vi<lb ed="#V" n="56" break="no"/>detur quod sic Hug. i. libro de sacramentis per. 4. c. 5 bonum fuit 
             <lb ed="#V" n="57"/>esse et bona et mala: et voluit vtrunque esse deus: quia 
             <lb ed="#V" n="58"/>vtrunque esse bonum fuit: sed quod est bonum esse bonum est 
             <lb ed="#V" n="59"/>fieri: ergo bonum est mala fieri. Item idem Hug. eodem libro per. 
@@ -542,7 +542,7 @@
             <lb ed="#V" n="89"/>bonum his qui secundum propositum vocati sunt sancti. Ubi dicit 
             <lb ed="#V" n="90"/>Glo. etiam casus in peccatum mortale. Dicit etiam Damas. 
             <lb ed="#V" n="91"/>2 lir. c. 29. Conceditur quis i. permittitur et in nephariam incidere 
-            <lb ed="#V" n="92"/>operationem: quandoquoin directionem alterius deterioris 
+            <lb ed="#V" n="92"/>operationem: quandoque in directionem alterius deterioris 
             passio<lb ed="#V" n="93" break="no"/>nis: et quandoque etiam per accidens bonum est malum fieri non 
             fa<lb ed="#V" n="94" break="no"/>cientibus ipsum malum inquantum deus per suam prouidentiam 
             <lb ed="#V" n="95"/>de malis maiora bona elicit: et sic malum fieri non dicitur 
@@ -572,7 +572,7 @@
             <lb ed="#V" n="108"/>¶ SDuto 
             ill<lb ed="#V" n="109" break="no"/>SEptimo queritur vtrum malum sit 
             ordina<lb ed="#V" n="110" break="no"/>bile: et videtur quod sic. Hug. i. libro de 
-            <lb ed="#V" n="111"/>sacramentius per. 4. c. 6. dicit de deo. Uidet mala procul quae 
+            <lb ed="#V" n="111"/>sacramentis per. 4. c. 6. dicit de deo. Uidet mala procul quae 
             fu<lb ed="#V" n="112" break="no"/>tura erant cum bonis plusquam erant et considerauit: quia 
             <lb ed="#V" n="113"/>malis adiunctis bona commendarentur et pulchriora fierent 
             <lb ed="#V" n="114"/>comparatione malorum: sed ea per quorum adiunctionem bona 
@@ -702,18 +702,18 @@
             <lb ed="#V" n="55"/>bonum esse malum. Superius enim ostensum est quod non est bonum 
             <lb ed="#V" n="56"/>simpliciter et per se mala fieri: ergo malum non est de perfectione. 
             <lb ed="#V" n="57"/>vniuersi. Item illud quo amoto vniuersum est melius non 
-            <lb ed="#V" n="58"/>est de perfectione vniuersi: sed si osmenes qui mali sunt essent boni 
+            <lb ed="#V" n="58"/>est de perfectione vniuersi: sed si omnes qui mali sunt essent boni 
             <lb ed="#V" n="59"/>vniuersum esset melius: ergo malum non est de perfectione vniuersi. 
           </p>
           <p xml:id="kzz7yh-a98373-d1e1290">
             <lb ed="#V" n="60"/>Respondeo cum sit considerare vniuersi perfectionem 
             <lb ed="#V" n="61"/>essentialem et accidentalem dico quod malum 
-            ra<lb ed="#V" n="62" break="no"/>tione ipsius deforitatis non est de vniuersi perfectione essentia 
+            ra<lb ed="#V" n="62" break="no"/>tione ipsius deformitatis non est de vniuersi perfectione essentia 
             <lb ed="#V" n="63"/>li vllo modo. Si autem loquamur de perfectione vniuersi 
             acciden<lb ed="#V" n="64" break="no"/>tali: sic dico: quamuis malum de ratione deformitatis non sit de perfectione 
             <lb ed="#V" n="65"/>vniuersi per se quia non est accidens bonum: tamen per accidens est de 
             perfecti<lb ed="#V" n="66" break="no"/>one tali inquantum scilicet esse sibi substrata est de perfectione 
-            vniuer<lb ed="#V" n="67" break="no"/>si: et inquantum iusta pena que propter ipsam infligitur est maior bomni 
+            vniuer<lb ed="#V" n="67" break="no"/>si: et inquantum iusta pena que propter ipsam infligitur est maior boni 
             <lb ed="#V" n="68"/>manifestatio: que est propter oppositionem mali: etiam magna bona 
             <!--00302.xml-->
             <cb ed="#P" n="b"/>
@@ -723,7 +723,7 @@
             <lb ed="#V" n="72"/>illa deformitate qua res est mala considerata secundum se.
           </p>
           <p xml:id="kzz7yh-a98373-d1e1325">
-            ¶ Tmen 
+            ¶ Tamen 
             ac<lb ed="#V" n="73" break="no"/>cepta illa deformitate cum bono quod eius occasione per dei 
             pro<lb ed="#V" n="74" break="no"/>uidentiam elicitum est: dico quod vniuersum est perfectius quam 
             <lb ed="#V" n="75"/>si illa duo simul essent substrata de vniuerso: sicut cyphus 

--- a/kzz7yh-a98373/cod-ve07v1_kzz7yh-a98373.xml
+++ b/kzz7yh-a98373/cod-ve07v1_kzz7yh-a98373.xml
@@ -182,7 +182,7 @@
             ¶ Item Hug. i. libro de sacramentis per 
             <lb ed="#V" n="112"/>4. c. 12. Si dicitur deus vult malum fieri aliquibus interpositis subicium. 
             <lb ed="#V" n="113"/>gitur refutat hoc mens pia non quia quod dicitur non bene dicitur: 
-            <lb ed="#V" n="114"/>sed quia quod bene dicitur non bene intelligitur: ergo bedicitur in 
+            <lb ed="#V" n="114"/>sed quia quod bene dicitur non bene intelligitur: ergo bene dicitur in 
             <lb ed="#V" n="115"/>rei ueritate quod deus vult malum.
           </p>
           <p xml:id="kzz7yh-a98373-d1e326">
@@ -696,7 +696,7 @@
           <p xml:id="kzz7yh-a98373-d1e1265">
             <lb ed="#V" n="50"/>Contra. Aui. 4. libr. Metaphy. c. 3. Res non est 
             ma<lb ed="#V" n="51" break="no"/>la nisi inquantum ipsa est priuatio perfectionis 
-            <lb ed="#V" n="52"/>sed illud quod est priuatio perfectionis: non est de persectione 
+            <lb ed="#V" n="52"/>sed illud quod est priuatio perfectionis: non est de perfectione 
             vni<lb ed="#V" n="53" break="no"/>uersi: ergo malum non est de perfectione vniuersi. Item 
             bo<lb ed="#V" n="54" break="no"/>num est esse illud quod est de perfectione vniuersi: sed non est 
             <lb ed="#V" n="55"/>bonum esse malum. Superius enim ostensum est quod non est bonum 
@@ -718,7 +718,7 @@
             <!--00302.xml-->
             <cb ed="#P" n="b"/>
             <lb ed="#V" n="69"/>que a deo sunt elicita ex malis: vel occasione malorum sunt 
-            <lb ed="#V" n="70"/>de persectione vniuersi: sicut cicatrix in corpore matris 
+            <lb ed="#V" n="70"/>de perfectione vniuersi: sicut cicatrix in corpore matris 
             resur<lb ed="#V" n="71" break="no"/>gentis: et plura alia: et sic patet quod vniuersum esset perfectius sine 
             <lb ed="#V" n="72"/>illa deformitate qua res est mala considerata secundum se.
           </p>


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve07v1_kzz7yh-a98373.xml`.

## Applied changes

- p. 143r l. 82: consequnter → consequenter: not in word list (OCR transform matched)
- p. 144r l. 56: sacramentius → sacramentis: reference to Hugh of St. Victor's 'De Sacramentis'; -ius ending is a misread
- p. 144r l. 92: quandoquoin → quandoque in: two words run together; 'quandoque in directionem alterius deterioris'
- p. 144r l. 111: sacramentius → sacramentis: reference to Hugh of St. Victor's 'De Sacramentis'; -ius ending is a misread
- p. 144v l. 58: osmenes → omnes: letters transposed/garbled OCR; 's' intruded between 'o' and 'm'
- p. 144v l. 62: deforitatis → deformitatis: missing 'm'; genitive of deformitas
- p. 144v l. 67: bomni → boni: spurious 'm' inserted; genitive of bonum
- p. 144v l. 72: Tmen → Tamen: not in word list (OCR transform matched)

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_