### PR TITLE
Transcription corrections: cod-ve09v2_kzz7yh-f112937.xml (9 changes)

### DIFF
--- a/kzz7yh-f112937/cod-ve09v2_kzz7yh-f112937.xml
+++ b/kzz7yh-f112937/cod-ve09v2_kzz7yh-f112937.xml
@@ -233,14 +233,14 @@
           </p>
           <p xml:id="kzz7yh-f112937-d1e400">
             ¶ Ad secundum dicendum: quod 
-            <lb ed="#V" n="87"/>voluntas nostra liberima est inquantum cogi non potest: tamen 
+            <lb ed="#V" n="87"/>voluntas nostra <sic>liberima</sic> est inquantum cogi non potest: tamen 
             <lb ed="#V" n="88"/>quia defectibilis est: non est ita libera: sicut diuina volutas quae 
             <lb ed="#V" n="89"/>deficere non potest: potestas tamen peccandi non est contra 
             li<lb ed="#V" n="90" break="no"/>bertatem a coactione.
           </p>
           <p xml:id="kzz7yh-f112937-d1e411">
             ¶ Ad tertium cum dicitur: quod nihil 
-            <lb ed="#V" n="91"/>incliinatur nisi ad sibi conueniens etc. dico quod verum est 
+            <lb ed="#V" n="91"/><sic>incliinatur</sic> nisi ad sibi conueniens etc. dico quod verum est 
             <lb ed="#V" n="92"/>naturali inclinatione. Inclinatione tamen deliberatiua 
             frequen<lb ed="#V" n="93" break="no"/>ter inclinatur aliquid per accidens in illud quod non est sibi 
             <lb ed="#V" n="94"/>conueniens: et hoc sufficit ad peccatum.
@@ -290,7 +290,7 @@
           </p>
           <p xml:id="kzz7yh-f112937-d1e494">
             ¶ Item secundum philosophum id est 
-            <lb ed="#V" n="119"/>de generatione: corruptio vnius est genratio alterius: 
+            <lb ed="#V" n="119"/>de <sic>genratio</sic>ne: corruptio vnius est generatio alterius: 
             er<lb ed="#V" n="120" break="no"/>go similiter abiectio mali que est nolle malum est 
             inductio<lb ed="#V" n="121" break="no"/>boni que est velle bonum.
           </p>

--- a/kzz7yh-f112937/cod-ve09v2_kzz7yh-f112937.xml
+++ b/kzz7yh-f112937/cod-ve09v2_kzz7yh-f112937.xml
@@ -105,7 +105,7 @@
           </p>
           <p xml:id="kzz7yh-f112937-d1e181">
             ¶ Item sicut voluntas praesupponit intellectum: ita 
-            intel<lb ed="#V" n="11" break="no"/>lectus pesupponit naturam: ergo sicut voluntas non est 
+            intel<lb ed="#V" n="11" break="no"/>lectus praesupponit naturam: ergo sicut voluntas non est 
             intelle<lb ed="#V" n="12" break="no"/>ctus: ita videtur quod nec volutas nec intellectus sint natura. 
           </p>
           <p xml:id="kzz7yh-f112937-d1e188">
@@ -136,7 +136,7 @@
             bo<lb ed="#V" n="31" break="no"/>num incomparatione ad aliud quod diuersimode mouet secundum 
             <lb ed="#V" n="32"/>diuersam sui comparationem ad diuersa: eius regula 
             intel<lb ed="#V" n="33" break="no"/>lectus cognitio acquisita vel infusa: et in natura consiliante 
-            <lb ed="#V" n="34"/>est a voluntate post intellus consiliationem: seu deliberationem. 
+            <lb ed="#V" n="34"/>est a voluntate post intellectus consiliationem: seu deliberationem. 
           </p>
           <p xml:id="kzz7yh-f112937-d1e244">
             <lb ed="#V" n="35"/>Ad primum in oppositum dicendum: quod philosophus ibi 
@@ -184,9 +184,9 @@
           </p>
           <p xml:id="kzz7yh-f112937-d1e315">
             ¶ Item voluntas est liber 
-            <lb ed="#V" n="58"/>rima. Sed posse peccare est contra libertatem. Unde Anselmnus 
+            <lb ed="#V" n="58"/>rima. Sed posse peccare est contra libertatem. Unde Anselmus 
             <lb ed="#V" n="59"/>in libro de libertate arbitrii: parum post principium: dicit 
-            <lb ed="#V" n="60"/>quod ipotestas peccandi: nec est libertas: nec pars libertatis: 
+            <lb ed="#V" n="60"/>quod potestas peccandi: nec est libertas: nec pars libertatis: 
             <lb ed="#V" n="61"/>ergo actus voluntatis nunquam potest esse peccatum.
           </p>
           <p xml:id="kzz7yh-f112937-d1e326">
@@ -197,7 +197,7 @@
           </p>
           <p xml:id="kzz7yh-f112937-d1e335">
             ¶ Item actum 
-            <lb ed="#V" n="65"/>reponitur in specesartie per suum primarium et formale obiectum. 
+            <lb ed="#V" n="65"/>reponitur in specie per suum primarium et formale obiectum. 
             <lb ed="#V" n="66"/>Sed illud quod primo et principaliter est voluntatis motiuum 
             <lb ed="#V" n="67"/>in quolibet eius obiecte est ratio boni: ergo quilibet actus 
             <lb ed="#V" n="68"/>voluntatis est in specie bonorum actuum.
@@ -265,7 +265,7 @@
             pos<lb ed="#V" n="103" break="no"/>sit velle bonum: et nolle malum. Et videtur quod sic: 
             <lb ed="#V" n="104"/>quia in motu locali accessus et recessus: sut vnus 
             <lb ed="#V" n="105"/>motus: ergo a simili in motu voluntatis recessus a malo quod 
-            <lb ed="#V" n="106"/>est nolle malum: et accessus ad bonum qui est velle bonu 
+            <lb ed="#V" n="106"/>est nolle malum: et accessus ad bonumm qui est velle bonu 
             <lb ed="#V" n="107"/>sunt vnus motus.
           </p>
           <p xml:id="kzz7yh-f112937-d1e462">
@@ -273,7 +273,7 @@
             <lb ed="#V" n="108"/>boni ratione sit minus malum ad maius malum: ergo a 
             si<lb ed="#V" n="109" break="no"/>mili non malum respectu mali habet rationem boni Sed 
             nol<lb ed="#V" n="110" break="no"/>le malum est velle non habere: vel non esse malum: ergo cum non habere 
-            <lb ed="#V" n="111"/>malum rationem boni hebeat: vt probatum est: codem actu potest 
+            <lb ed="#V" n="111"/>malum rationem boni hebeat: vt probatum est: eodem actu potest 
             volun<lb ed="#V" n="112" break="no"/>tas nolle malum et velle bonum.
           </p>
           <p xml:id="kzz7yh-f112937-d1e475">
@@ -310,7 +310,7 @@
             <lb ed="#V" n="129"/>actus moueri ad repellendum malum: et moueri ad 
             declinatio<lb ed="#V" n="130" break="no"/>nem mali vel fugam: quam nolle malum: et velle bonum. Sed 
             <lb ed="#V" n="131"/>velle repellere malum: et fugere malum: duo motus sunt: 
-            <lb ed="#V" n="132"/>scilicet audacia et timor: ergo duo motts sunt: nolle 
+            <lb ed="#V" n="132"/>scilicet audacia et timor: ergo duo motus sunt: nolle 
             ma<lb ed="#V" n="133" break="no"/>lum et velle bonum. 
           </p>
           <p xml:id="kzz7yh-f112937-d1e534">
@@ -406,7 +406,7 @@
           <p xml:id="kzz7yh-f112937-d1e702">
             ¶ Ad quantum 
             <lb ed="#V" n="63"/>dicendum: quod non fuit intentio philosophi: quod corruptio vnius 
-            con<lb ed="#V" n="64" break="no"/>trarii esset alterius genetatio: sed quod ad corruptionem vnius: 
+            con<lb ed="#V" n="64" break="no"/>trarii esset alterius generatio: sed quod ad corruptionem vnius: 
             <lb ed="#V" n="65"/>sequitur generatio alterius: quia natura non intendit 
             corru<lb ed="#V" n="66" break="no"/>ptionem: nisi propter generationem.
           </p>


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve09v2_kzz7yh-f112937.xml`.

## Applied changes

- p. 159r l. 11: pesupponit → praesupponit: pe- is OCR misread of prae-; context is intellectus pesupponit naturam
- p. 159r l. 34: intellus → intellectus: missing -ect- in the middle; context is post intellus consiliationem
- p. 159r l. 58: Anselmnus → Anselmus: extra n inserted by OCR
- p. 159r l. 60: ipotestas → potestas: spurious leading i from OCR; context is ipotestas peccandi nec est libertas
- p. 159r l. 65: specesartie → specie: garbled OCR of specie; context is reponitur in specie per suum primarium et formale obiectum
- p. 159r l. 106: bonu → bonum: final m dropped by OCR; context is accessus ad bonum qui est velle bonum
- p. 159r l. 111: codem → eodem: c/e misread at word start; context is vt probatum est: eodem actu potest
- p. 159r l. 132: motts → motus: garbled OCR; context is ergo duo motus sunt: nolle
- p. 159v l. 64: genetatio → generatio: t/r transposition

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_