### PR TITLE
Transcription corrections: cod-ve09v2_kzz7yh-f113600.xml (6 changes)

### DIFF
--- a/kzz7yh-f113600/cod-ve09v2_kzz7yh-f113600.xml
+++ b/kzz7yh-f113600/cod-ve09v2_kzz7yh-f113600.xml
@@ -165,7 +165,7 @@
           </p>
           <p xml:id="kzz7yh-f113600-d1e290">
             ¶ Item accusare est actus: sed conscientie 
-            pecca<lb ed="#V" n="12" break="no"/>torum eos accusabunt iniuditio: ergo conscientia dicit actum. 
+            pecca<lb ed="#V" n="12" break="no"/>torum eos accusabunt in iuditio: ergo conscientia dicit actum. 
           </p>
           <p xml:id="kzz7yh-f113600-d1e295">
             <lb ed="#V" n="13"/>¶ Item actus conscientie diuersificantur in specie: sed 
@@ -203,7 +203,7 @@
             <lb ed="#V" n="36"/>Sed sicut non est vnus habitus scientie acquisite: 
             respe<lb ed="#V" n="37" break="no"/>ctu omnium actuum intellectus practici: ita non est vnus 
             <lb ed="#V" n="38"/>habitus conscientie acquisite respectu omnium actuum 
-            <lb ed="#V" n="39"/>conscientie: sed plures: naturalis tamen conscientia(secundum quod 
+            <lb ed="#V" n="39"/>conscientie: sed plures: naturalis tamen conscientia (secundum quod 
             <lb ed="#V" n="40"/>accipitur pro quodam naturali lumine respectu primorum 
             <lb ed="#V" n="41"/>principiorum: vel primi principii quod melius dicitur 
             agi<lb ed="#V" n="42" break="no"/>bilium in vno subiecto) vna est numero: in pluribus 
@@ -235,7 +235,7 @@
           </p>
           <p xml:id="kzz7yh-f113600-d1e420">
             ¶ Ad tertium dicendum: quod lex dei dicitur pungere 
-            <lb ed="#V" n="63"/>conscientiam nostram: propter hoc quod per legem ipsam intellus formatus aliquo 
+            <lb ed="#V" n="63"/>conscientiam nostram: propter hoc quod per legem ipsam intellectus formatus aliquo 
             <lb ed="#V" n="64"/>habitum conscientie: magis pungit et stimulat nostram voluntatem 
             <lb ed="#V" n="65"/>ad conformandum se legi diuine.
           </p>
@@ -326,14 +326,14 @@
             <lb ed="#V" n="118"/>si abstinere a fornicatione proponatur voluntati: vt tale 
             ma<lb ed="#V" n="119" break="no"/>lum: cuius contrarium necessarium est ad salutem: velle 
             <lb ed="#V" n="120"/>abstinere ex deliberatione a fornicatione peccatum esset 
-            <lb ed="#V" n="121"/>mortale manente praedicto dictamine. Uolendo etiam 
+            <lb ed="#V" n="121"/>mortale manente praedicto dictamine. Uoluendo etiam 
             for<lb ed="#V" n="122" break="no"/>nicari homo peccaret mortaliter: vnde manente tali 
             dicta<lb ed="#V" n="123" break="no"/>mine: homo esset perplexus. Et quia per talem 
             conscien<lb ed="#V" n="124" break="no"/>tiam quamdiu durat: obligatur homo ad faciendum illud 
             <lb ed="#V" n="125"/>quod secundum rei veritatem sibi facere non licet: ideo obligatur 
             <lb ed="#V" n="126"/>ad deponendum conscientiam talem: qua a mota absolutus 
             <lb ed="#V" n="127"/>est ab illo ad quod ligabatur per eius dictamen. Similiter 
-            <lb ed="#V" n="128"/>si aliquod imdifferens dictat esse necessarium ad salutem: 
+            <lb ed="#V" n="128"/>si aliquod indifferens dictat esse necessarium ad salutem: 
             <lb ed="#V" n="129"/>manente illo ligamine obligati sumus: remoto illo dicta 
             <lb ed="#V" n="130"/>mine absoluti: quia ad faciendum illud indifferens non 
             <lb ed="#V" n="131"/>eramus obligati per aliam legem. 
@@ -378,7 +378,7 @@
           <p xml:id="kzz7yh-f113600-d1e670">
             ¶ Ad secundum 
             <lb ed="#V" n="18"/>dicendum: quod quamuis per conscientiam erroneam possit esse 
-            <lb ed="#V" n="19"/>perplexus durante dictamine illius con scientie: tamen 
+            <lb ed="#V" n="19"/>perplexus durante dictamine illius conscientie: tamen 
             sim<lb ed="#V" n="20" break="no"/>pliciter perplexus esse non potest: quia talem conscientiam potest 
             <lb ed="#V" n="21"/>deponere: quo facto ab illa perplexitate liberatus est.
           </p>

--- a/kzz7yh-f113600/cod-ve09v2_kzz7yh-f113600.xml
+++ b/kzz7yh-f113600/cod-ve09v2_kzz7yh-f113600.xml
@@ -252,7 +252,7 @@
             obli<lb ed="#V" n="68" break="no"/>get hominem ad volendum: vel faciendum il¬ 
             <!--00333.xml-->
             <cb ed="#P" n="b"/>
-            <lb ed="#V" n="69"/>lud quod dictat necssearium ad salutem. Et videtur quod 
+            <lb ed="#V" n="69"/>lud quod dictat <sic>necssearium</sic> ad salutem. Et videtur quod 
             <lb ed="#V" n="70"/>sic: <ref xml:id="kzz7yh-f113600-Rd1e508">glosa super illud</ref> ad <ref xml:id="kzz7yh-f113600-Rd1e510">Rom. 14.</ref> <quote xml:id="kzz7yh-f113600-Qd1e512" source="http://scta.info/resource/rom14_23@12-19">omne quod non est ex 
               side<lb ed="#V" n="71" break="no"/>peccatum est</quote>: dicit quod quamuis fiat quod bonum est: si tamen 
             <lb ed="#V" n="72"/>non faciendum credat peccatum est: ergo conscientia 
@@ -352,7 +352,7 @@
           <p xml:id="kzz7yh-f113600-d1e626">
             ¶ Ad tertium 
             <lb ed="#V" n="3"/>dicendum: quod in apparatu reprehenditur magister 
-            Gratia<lb ed="#V" n="4" break="no"/>nus impassu predicto.
+            Gratia<lb ed="#V" n="4" break="no"/>nus <sic>im</sic> passu predicto.
           </p>
           <p xml:id="kzz7yh-f113600-d1e634">
             ¶ Ad quartum dicendum est: sicut 


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve09v2_kzz7yh-f113600.xml`.

## Applied changes

- p. 160r l. 12: iniuditio → in iuditio: missing space between preposition and noun (in iudicio/iuditio)
- p. 160r l. 39: conscientia(secundum → conscientia (secundum: missing space before opening parenthesis
- p. 160r l. 63: intellus → intellectus: missing letters -ect-
- p. 160r l. 121: Uolendo → Uoluendo: not in word list (OCR transform matched)
- p. 160r l. 128: imdifferens → indifferens: m/n misread before d
- p. 160v l. 19: con scientie → conscientie: spurious space within compound word

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_