### PR TITLE
Transcription corrections: cod-ve09v2_kzz7yh-f114224.xml (11 changes)

### DIFF
--- a/kzz7yh-f114224/cod-ve09v2_kzz7yh-f114224.xml
+++ b/kzz7yh-f114224/cod-ve09v2_kzz7yh-f114224.xml
@@ -99,7 +99,7 @@
           </p>
           <p xml:id="kzz7yh-f114224-d1e172">
             <lb ed="#V" n="59"/>Contra <ref xml:id="kzz7yh-f114224-Rd1e182">Ezech. I.</ref> super verbum praedictum dicit 
-            glo<lb ed="#V" n="60" break="no"/>sa quod synderesis est sintilla conscientie: sed 
+            glo<lb ed="#V" n="60" break="no"/>sa quod synderesis est <sic>sintilla</sic> conscientie: sed 
             con<lb ed="#V" n="61" break="no"/>scientia est in intellectu: ergo et synderesis vt videtur.
           </p>
           <p xml:id="kzz7yh-f114224-d1e182">
@@ -151,7 +151,7 @@
           <p xml:id="kzz7yh-f114224-d1e271">
             ¶ Ex praedictis patet quod si 
             di<lb ed="#V" n="98" break="no"/>catur synderesis: inclinatiuum ad bonum absolute per 
-            mo<lb ed="#V" n="99" break="no"/>dum persuadentis non necessitantis: sic est in intellcctu. 
+            mo<lb ed="#V" n="99" break="no"/>dum persuadentis non necessitantis: sic est in <sic>intellcctu.</sic> 
             Si<lb ed="#V" n="100" break="no"/>autem dicatur inclinatiuum ad bonum absolute: vel in 
             ge<lb ed="#V" n="101" break="no"/>nerali per modum necessitantis: sic est in affectu. Et sic 
             lo<lb ed="#V" n="102" break="no"/>quendo de synderesi procedunt argumenta ad primam 
@@ -330,7 +330,7 @@
             <lb ed="#V" n="79"/>Hoc autem dicunt differre: sicut differunt naturalis inclinatio leuis 
             <lb ed="#V" n="80"/>ad motum sursum et grauis deorsum. Quamuis enim graue non 
             <lb ed="#V" n="81"/>moueatur deorsum aliquando propter aliquod prohibens: naturaliter 
-            <lb ed="#V" n="82"/>tamen ad illum motum inclinatur: quod experitur homo rem grauem sup 
+            <lb ed="#V" n="82"/>tamen ad illum motum inclinatur: quod experitur homo rem grauem super 
             <lb ed="#V" n="83"/>se sustinens. Illa autem inclinatio: nec est virtus mouens: nec est 
             <lb ed="#V" n="84"/>ipse motus. Unde Auic. 9. meta. ca. 2. loquens de inclinatione 
             <lb ed="#V" n="85"/>corporis ad naturalem motu: dicit quod inclinatio illa aliud est 
@@ -362,7 +362,7 @@
           </p>
           <p xml:id="kzz7yh-f114224-d1e656">
             ¶ Sed contra hoc arguitur: odium 
-            re<lb ed="#V" n="102" break="no"/>ducitur ad amorem: quia amor boni ratio est odum oppositi 
+            re<lb ed="#V" n="102" break="no"/>ducitur ad amorem: quia amor boni ratio est odii oppositi 
             <lb ed="#V" n="103"/>mali: ergo damnati nullo modo naturaliter detestarentur 
             <lb ed="#V" n="104"/>malum: nisi vniuersaliter diligerent bonum oppositum.
           </p>
@@ -393,7 +393,7 @@
             di<lb ed="#V" n="127" break="no"/>cit translatio abbatis: quod in eo quod desiderant: esse viuere et 
             <lb ed="#V" n="128"/>intelligere que tria de numero existentium sunt: pulchrum 
             <lb ed="#V" n="129"/>et bonum desiderant. Et infra in eodem ca. secundum eandem 
-            trans<lb ed="#V" n="130" break="no"/>lationem: principinm et finis omnium malorum: aliquo modo est 
+            trans<lb ed="#V" n="130" break="no"/>lationem: <sic>principinm</sic> et finis omnium malorum: aliquo modo est 
             <lb ed="#V" n="131"/>bonum: quia consideratione boni fiunt quicumque fiunt: siue 
             bo<lb ed="#V" n="132" break="no"/>na: siue contraria. Sequitur ergo ex predictis quod 
             syndere<lb ed="#V" n="133" break="no"/>sis per peccatum non potest: quantum ad omnem sui actum totaliter extingui. 

--- a/kzz7yh-f114224/cod-ve09v2_kzz7yh-f114224.xml
+++ b/kzz7yh-f114224/cod-ve09v2_kzz7yh-f114224.xml
@@ -225,7 +225,7 @@
             <lb ed="#V" n="9"/>actus eius nunquam potest esse peccatum: nec ad peccatum inclinatio. Sed 
             <lb ed="#V" n="10"/>est inclinatio ad retrahendum nos a peccato. Synderesis 
             <lb ed="#V" n="11"/>enim considerata secundum quod est in intellectu: est aliquid quo 
-            deter<lb ed="#V" n="12" break="no"/>minatur naturaliter intells ad dictandum bonum absolute esse 
+            deter<lb ed="#V" n="12" break="no"/>minatur naturaliter intellectus ad dictandum bonum absolute esse 
             <lb ed="#V" n="13"/>volendum. Planum est autem quod hic actus non potest esse peccatum: 
             <lb ed="#V" n="14"/>nec inclinatio ad peccatum. Nec potest habere actum repugnantem 
             <lb ed="#V" n="15"/>isti actui: quia eadem natura non potest habere duos naturales actus sibi 
@@ -240,7 +240,7 @@
             <lb ed="#V" n="21"/>terminatur naturaliter ad bonum absolute volendum: talis autem 
             <lb ed="#V" n="22"/>actus: nec est peccatum: nec dispositio ad peccatum. Nec potest 
             <lb ed="#V" n="23"/>habere actum isti actui repugnantem: quia natura non assuescit 
-            <lb ed="#V" n="24"/>incontrarium: vt iam dictum est: nullum ergo potest actum 
+            <lb ed="#V" n="24"/>in contrarium: vt iam dictum est: nullum ergo potest actum 
             <lb ed="#V" n="25"/>habere qui sit peccatum vel dispositio ad peccatum. 
           </p>
           <p xml:id="kzz7yh-f114224-d1e447">
@@ -264,7 +264,7 @@
           <p xml:id="kzz7yh-f114224-d1e481">
             ¶ Ad tertium 
             dicen<lb ed="#V" n="39" break="no"/>dum: quod actus synderesis aut est actus conscientie 
-            natura<lb ed="#V" n="40" break="no"/>lis: que non potest errare: aut mouet volutatem secundum 
+            natura<lb ed="#V" n="40" break="no"/>lis: que non potest errare: aut mouet voluntatem secundum 
             dicta<lb ed="#V" n="41" break="no"/>men illius actus: non tamen quia intellectus sic dictat: sed 
             <lb ed="#V" n="42"/>quia ad bonum absolute naturaliter determinata est: et ad 
             ip<lb ed="#V" n="43" break="no"/>sum naturaliter mouet: presupposita tamen per intellectum 
@@ -292,7 +292,7 @@
             <lb ed="#V" n="55"/>et synderesis per peccatum extingui potest: quantum ad omnem sui actum. 
           </p>
           <p xml:id="kzz7yh-f114224-d1e531">
-            <lb ed="#V" n="56"/>¶ Item glosa super illud palmus corrupti sunt: dict id est ab omni 
+            <lb ed="#V" n="56"/>¶ Item glosa super illud palmus corrupti sunt: dicit id est ab omni 
             <lb ed="#V" n="57"/>vi rationis priuati. Sed actus synderesis est aliqua vis rationis: 
             <lb ed="#V" n="58"/>ergo synderesis: quantum ad omnem sui actum in aliquibus potest 
             <lb ed="#V" n="59"/>totaliter extingui.
@@ -312,7 +312,7 @@
             vi<lb ed="#V" n="68" break="no"/>detur quod humana natura per peccatum non ita deprauari potest: 
             <!--00335.xml-->
             <cb ed="#P" n="b"/>
-            <lb ed="#V" n="69"/>qun in ea remaneat aliqua naturalis dilectio probiratis.
+            <lb ed="#V" n="69"/>quin in ea remaneat aliqua naturalis dilectio probiratis.
           </p>
           <p xml:id="kzz7yh-f114224-d1e574">
             ¶ Item 
@@ -336,7 +336,7 @@
             <lb ed="#V" n="85"/>corporis ad naturalem motu: dicit quod inclinatio illa aliud est 
             <lb ed="#V" n="86"/>quam motus sine dubio: et aliud est quam virtus mouens. Dicunt 
             <lb ed="#V" n="87"/>ergo quod quantum ad actum inclinandi: nullo modo potest 
-            extin<lb ed="#V" n="88" break="no"/>gui synderesis per peccatum: nec inuiatoribus: nec in damna 
+            extin<lb ed="#V" n="88" break="no"/>gui synderesis per peccatum: nec in viatoribus: nec in damna 
             <lb ed="#V" n="89"/>tis. Sed quantum ad naturalem amorem boni: et naturalem 
             detesta<lb ed="#V" n="90" break="no"/>tionem mali: et si non possit totaliter extingui in 
             viatori<lb ed="#V" n="91" break="no"/>bus: tamen extinctum est totaliter in damnatis.
@@ -367,7 +367,7 @@
             <lb ed="#V" n="104"/>malum: nisi vniuersaliter diligerent bonum oppositum.
           </p>
           <p xml:id="kzz7yh-f114224-d1e665">
-            ¶ Idon videtur. 
+            ¶ Ideo videtur. 
             <lb ed="#V" n="105"/>mihi dicendum: quod si ad horam possit esse synderesis absque 
             <lb ed="#V" n="106"/>naturali cognitione et dilectione boui: propter aliquod 
             im<lb ed="#V" n="107" break="no"/>pedimentum superueniens creature rationali: sicut 
@@ -376,7 +376,7 @@
             <lb ed="#V" n="110"/>nunquam potest auferri possibilitas exeundi in naturalem 
             co<lb ed="#V" n="111" break="no"/>gnitionem et dilectionem boni absolute dicti: siue boni 
             in<lb ed="#V" n="112" break="no"/>generasi: cuius cognitio et amor nobis naturaliter sunt 
-            im<lb ed="#V" n="113" break="no"/>pressa secundum quod dicit Boetius de consolius lib. 3. parum post 
+            im<lb ed="#V" n="113" break="no"/>pressa secundum quod dicit Boetius de consolatione lib. 3. parum post 
             <lb ed="#V" n="114"/>principium. Impeditur autem in nobis synderesis ab 
             actua<lb ed="#V" n="115" break="no"/>li dilectione boni: aliquando per corporis impedimentum. 
             <lb ed="#V" n="116"/>Et quamuis aliqui dicant quod in damnatis perpetuo 
@@ -385,7 +385,7 @@
             vide<lb ed="#V" n="119" break="no"/>tur hoc verum: quia cum voluntas nihil possit velle: nisi et 
             <lb ed="#V" n="120"/>sub ratione boni: et damnati aliqua velint. Sequitur quod 
             <lb ed="#V" n="121"/>eorum voluntas mouetur per aliquam rationem boni: 
-            <lb ed="#V" n="122"/>quod non vsderetur verum: nisi in eis esset: vel interdum esse 
+            <lb ed="#V" n="122"/>quod non videretur verum: nisi in eis esset: vel interdum esse 
             <lb ed="#V" n="123"/>posset naturalis cognitio et amor boni absolute: siue in 
             ge<lb ed="#V" n="124" break="no"/>nerali. Cui videtur concordare Diony. 4. ca. de di. no. dicens 
             <lb ed="#V" n="125"/>de demonibus: quod bonum et optimum concupiscunt esse 
@@ -394,7 +394,7 @@
             <lb ed="#V" n="128"/>intelligere que tria de numero existentium sunt: pulchrum 
             <lb ed="#V" n="129"/>et bonum desiderant. Et infra in eodem ca. secundum eandem 
             trans<lb ed="#V" n="130" break="no"/>lationem: principinm et finis omnium malorum: aliquo modo est 
-            <lb ed="#V" n="131"/>bonum: quia consideratione boni fiunt quicumque siunt: siue 
+            <lb ed="#V" n="131"/>bonum: quia consideratione boni fiunt quicumque fiunt: siue 
             bo<lb ed="#V" n="132" break="no"/>na: siue contraria. Sequitur ergo ex predictis quod 
             syndere<lb ed="#V" n="133" break="no"/>sis per peccatum non potest: quantum ad omnem sui actum totaliter extingui. 
           </p>
@@ -414,7 +414,7 @@
           <p xml:id="kzz7yh-f114224-d1e756">
             ¶ Ad 
             <lb ed="#V" n="6"/>2m dicendum: quod quamuis fomes possit extingui quantum ad omnem sui 
-            <lb ed="#V" n="7"/>actum per praeuilegiatam gratiam: non tamen ex hoc sequitur quod synderesis quantum 
+            <lb ed="#V" n="7"/>actum per priuilegiatam gratiam: non tamen ex hoc sequitur quod synderesis quantum 
             <lb ed="#V" n="8"/>ad omnem sui actum possit extingui per culpam. Fomes enim est in nobis 
             <lb ed="#V" n="9"/>per corruptionem nature: cuius refectibilitas suppleri potest per gratiam 
             <lb ed="#V" n="10"/>praiuilegiatam. Sed synderesis est in nobis per naturam ipsius anime quae 


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve09v2_kzz7yh-f114224.xml`.

## Applied changes

- p. 161r l. 12: intells → intellectus: garbled abbreviation, missing -ectus
- p. 161r l. 24: incontrarium → in contrarium: missing space between preposition and noun
- p. 161r l. 40: volutatem → voluntatem: missing 'n', t/r transposition corrected
- p. 161r l. 56: dict → dicit: not in word list (OCR transform matched)
- p. 161r l. 69: qun → quin: missing i; also probiratis → probitatis in same line
- p. 161r l. 88: inuiatoribus → in viatoribus: missing space; viatoribus = wayfarers (standard scholastic term)
- p. 161r l. 104: Idon → Ideo: misread; context 'Ideo videtur mihi dicendum'
- p. 161r l. 113: consolius → consolatione: garbled; refers to Boethius 'De Consolatione Philosophiae lib. 3'
- p. 161r l. 122: vsderetur → videretur: vs/vi misread; context 'quod non videretur verum'
- p. 161r l. 131: siunt → fiunt: s/f misread at word start
- p. 161v l. 7: praeuilegiatam → priuilegiatam: ae/i spelling error in prefix; priuilegiatam = privileged

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_