### PR TITLE
Transcription corrections: cod-ve09v2_kzz7yh-f114928.xml (18 changes)

### DIFF
--- a/kzz7yh-f114928/cod-ve09v2_kzz7yh-f114928.xml
+++ b/kzz7yh-f114928/cod-ve09v2_kzz7yh-f114928.xml
@@ -80,11 +80,11 @@
           <lb ed="#V" n="34"/>magnum malum: sicut velle malum. Ideo potest dici quod quamuis 
           vo<lb ed="#V" n="35" break="no"/>luntas feratur in rem intellectam: tamen quia ipsa res sub ratione qua bona non 
           <lb ed="#V" n="36"/>est obiectum intellectus: sed sub ratione qui ens vel vera: nec est obiectum 
-          volun<lb ed="#V" n="37" break="no"/>tatis sub ratione qua vera: sed sub ratione quae bomna: ideo actio intellius 
+          volun<lb ed="#V" n="37" break="no"/>tatis sub ratione qua vera: sed sub ratione qua bona: ideo actio intellectus 
           re<lb ed="#V" n="38" break="no"/>spectu ipsius rei non dicitur bona: sed vera: et actio voluntatis respectu 
           <lb ed="#V" n="39"/>eiusdem: non dicitur vera: sed bomna. Sic dico quod malum est obiectum per accidens 
           <lb ed="#V" n="40"/>intellectus sub ratione quae oppositum enti vel vero: per cuius speciem ex 
-          conseqenti<lb ed="#V" n="41" break="no"/>intelligitur. Et ita patet quod est obictum intellus sub ratione qua fflunitum. Est autem 
+          conseqenti<lb ed="#V" n="41" break="no"/>intelligitur. Et ita patet quod est obiectum intellectus sub ratione qua falsum. Est autem 
           <lb ed="#V" n="42"/>obiectum voluntatis per accidens sub ratione quae apparens bonum. Et ideo 
           <lb ed="#V" n="43"/>sicut voluntas in volendo malum non debet dici falsa secundum mala: ita 
           <lb ed="#V" n="44"/>intellectus intelligendo malum non debet dici malus: sed verus si 
@@ -103,7 +103,7 @@
         </p>
         <p xml:id="kzz7yh-f114928-d1e189">
           ¶ Per 
-          <lb ed="#V" n="54"/>hoc patet rasntns ad argumta.
+          <lb ed="#V" n="54"/>hoc patet responsio ad argumenta.
         </p>
         <p xml:id="kzz7yh-f114928-d1e194">
           ¶ Superior scintilla rationis: quae est vt 

--- a/kzz7yh-f114928/cod-ve09v2_kzz7yh-f114928.xml
+++ b/kzz7yh-f114928/cod-ve09v2_kzz7yh-f114928.xml
@@ -55,7 +55,7 @@
       <div xml:id="kzz7yh-f114928"><!-- l2d39cl -->
         <head xml:id="kzz7yh-f114928-Hd1e101">Circa litteram</head>
         <p xml:id="kzz7yh-f114928-d1e103">
-          <lb ed="#V" n="21"/>CIrca litteram: intelligem mala vel memorari 
+          <lb ed="#V" n="21"/>CIrca litteram: intelligere mala vel memorari 
           ma<lb ed="#V" n="22" break="no"/>lum non est.
         </p>
         <p xml:id="kzz7yh-f114928-d1e110">
@@ -66,36 +66,36 @@
           ¶ Preterea velle mala malum esta Responsio intellectus 
           <lb ed="#V" n="24"/>intelligendo malum non conformatur rei: nisi secundum esse quod habet in 
           <lb ed="#V" n="25"/>anima: secundum autem illud esse mala non est. Uoluntas vero conformatur rei secundum 
-          <lb ed="#V" n="26"/>esse quod habet extranimam. vbi potest esse bomna vel mala. Sed hoc non sufficit. 
-          <lb ed="#V" n="27"/>Inteltilius enim per similitudinem rei aliquo modo conformatur ipsi rei 
+          <lb ed="#V" n="26"/>esse quod habet extra animam. vbi potest esse bona vel mala. Sed hoc non sufficit. 
+          <lb ed="#V" n="27"/>Intellectus enim per similitudinem rei aliquo modo conformatur ipsi rei 
           existen<lb ed="#V" n="28" break="no"/>ti extra animam: aliter enim ipsam et suum esse reale non intelligeret: et ex 
-          <lb ed="#V" n="29"/>conseqenti in illam non ferretur voluntas.
+          <lb ed="#V" n="29"/>consequenti in illam non ferretur voluntas.
         </p>
         <p xml:id="kzz7yh-f114928-d1e131">
           ¶ Alii dicunt quod si intellectus per 
           <lb ed="#V" n="30"/>similitudinem rei assimiletur ei: non tamen transformatur in eam: sicut 
           volun<lb ed="#V" n="31" break="no"/>tas transformatur in rem volitam: propter maiorem vim vnionis ex parte 
           <lb ed="#V" n="32"/>voluntatis quam ex parte intellius. Sed hoc non sufficit: quia per hoc non 
-          red<lb ed="#V" n="33" break="no"/>ditur ratio: quare intelligem malum non est malum: sed tantum quare non est ita 
-          <lb ed="#V" n="34"/>magnum malum: sicut velle malum. Ido potest dici quod quamuis 
+          red<lb ed="#V" n="33" break="no"/>ditur ratio: quare intelligere malum non est malum: sed tantum quare non est ita 
+          <lb ed="#V" n="34"/>magnum malum: sicut velle malum. Ideo potest dici quod quamuis 
           vo<lb ed="#V" n="35" break="no"/>luntas feratur in rem intellectam: tamen quia ipsa res sub ratione qua bona non 
-          <lb ed="#V" n="36"/>est obiecum intellilus: sed sub ratione qui ens vel vera: nec est obiecitum 
+          <lb ed="#V" n="36"/>est obiectum intellectus: sed sub ratione qui ens vel vera: nec est obiectum 
           volun<lb ed="#V" n="37" break="no"/>tatis sub ratione qua vera: sed sub ratione quae bomna: ideo actio intellius 
           re<lb ed="#V" n="38" break="no"/>spectu ipsius rei non dicitur bona: sed vera: et actio voluntatis respectu 
           <lb ed="#V" n="39"/>eiusdem: non dicitur vera: sed bomna. Sic dico quod malum est obiectum per accidens 
-          <lb ed="#V" n="40"/>intellilus sub ratione quae oppositum enti vel vero: per cuius speciem ex 
+          <lb ed="#V" n="40"/>intellectus sub ratione quae oppositum enti vel vero: per cuius speciem ex 
           conseqenti<lb ed="#V" n="41" break="no"/>intelligitur. Et ita patet quod est obictum intellus sub ratione qua fflunitum. Est autem 
-          <lb ed="#V" n="42"/>obiecum voluntatis per accidens sub ratione quae apparens bonum. Et ideo 
+          <lb ed="#V" n="42"/>obiectum voluntatis per accidens sub ratione quae apparens bonum. Et ideo 
           <lb ed="#V" n="43"/>sicut voluntas in volendo malum non debet dici falsa secundum mala: ita 
-          <lb ed="#V" n="44"/>intellilus intelligendo malum non debet dici malus: sed verus si 
+          <lb ed="#V" n="44"/>intellectus intelligendo malum non debet dici malus: sed verus si 
           intelli<lb ed="#V" n="45" break="no"/>git sicut est: vel falsus si aliter iudicat quam est iudicandum: est enim 
           <lb ed="#V" n="46"/>de actibus secundum formalem rationem obiecti.
         </p>
         <p xml:id="kzz7yh-f114928-d1e171">
           ¶ Potest est dici quod per 
           simpli<lb ed="#V" n="47" break="no"/>cem apprehensionem mali non determinatur intelligens: ad aliquam 
-          rea<lb ed="#V" n="48" break="no"/>lem consuctionem cum malo: per apprehensionem dictantem malum esse pro 
-          <lb ed="#V" n="49"/>sequendum inclinatur apprehendens ad aliquam realem coninctionem cum 
+          rea<lb ed="#V" n="48" break="no"/>lem coniunctionem cum malo: per apprehensionem dictantem malum esse pro 
+          <lb ed="#V" n="49"/>sequendum inclinatur apprehendens ad aliquam realem coniunctionem cum 
           <lb ed="#V" n="50"/>malo. Per velle malum determinatur ad realem coniunctionem cum 
           <lb ed="#V" n="51"/>malo: ita vt hanc realem coniunctionem exequatur si non assit 
           impedi<lb ed="#V" n="52" break="no"/>mentum: quare hoc facem non audeat: vel valeat: et ideo primus actus trium 
@@ -110,12 +110,12 @@
           <lb ed="#V" n="55"/>ait Hiero. in caym non potuit extingui. Huic concordat Aug. 
           <lb ed="#V" n="56"/>22. de ci. ca. 24. dicens de homine lapso in peccatum per quem lapsum 
           con<lb ed="#V" n="57" break="no"/>paratus est pecoribus quod in eo non penitus extincta est quaedam velut 
-          <lb ed="#V" n="58"/>scintilla rationis in quae factus est ad imaginem dei. Bonum seper vult 
+          <lb ed="#V" n="58"/>scintilla rationis in quae factus est ad imaginem dei. Bonum semper vult 
           <lb ed="#V" n="59"/>et malum odit.
         </p>
         <p xml:id="kzz7yh-f114928-d1e207">
           ¶ Contra vt superius ostensum est voluntas naturalis 
-          <lb ed="#V" n="60"/>et deliberatiua sunt vna pomus. Una autem pomsmo non potest simul 
+          <lb ed="#V" n="60"/>et deliberatiua sunt vna pomus. Una autem potentia non potest simul 
           moue<lb ed="#V" n="61" break="no"/>ri motibus oppositis: ergo cum aliquando velit homo deliberatiue 
           ma<lb ed="#V" n="62" break="no"/>lum: tunc non vult naturaliter bonum.
         </p>
@@ -126,15 +126,15 @@
         </p>
         <p xml:id="kzz7yh-f114928-d1e223">
           ¶ Responsio quod voluntas naturalis semper dicitur 
-          velle<lb ed="#V" n="65" break="no"/>bonum: non quia seper velit bonum in actu: sicut bene concludit argumentum 
+          velle<lb ed="#V" n="65" break="no"/>bonum: non quia semper velit bonum in actu: sicut bene concludit argumentum 
           <lb ed="#V" n="66"/>secundum. Sed quia semper vult bonum: vel in actu: vel in habitu. 
         </p>
         <p xml:id="kzz7yh-f114928-d1e231">
-          <lb ed="#V" n="67"/>¶ Primum tamen argumentum non bene procedit. Si enim valeret sequaeretur 
+          <lb ed="#V" n="67"/>¶ Primum tamen argumentum non bene procedit. Si enim valeret sequeretur 
           <lb ed="#V" n="68"/>quod in demonibus qua semper deliberatiue volunt aliquod malum 
           <!--00336.xml-->
           <cb ed="#P" n="b"/>
-          <lb ed="#V" n="69"/>voluntas nunquam vellet naturaliter bonum absolute sen in getriali: 
+          <lb ed="#V" n="69"/>voluntas nunquam vellet naturaliter bonum absolute seu in generali: 
           <lb ed="#V" n="70"/>quod superius declaratum est esse sulicintum. Dicendum ergo ad 
           argumen<lb ed="#V" n="71" break="no"/>tum: quod homo simul naturaliter potest velle bonum et deliberatiue 
           velle<lb ed="#V" n="72" break="no"/>malum: quia cum voluntas deliberatiua: nunquam possit 
@@ -144,7 +144,7 @@
           <lb ed="#V" n="76"/>boni absolute mouet se voluntas ad alia velle: Unde 
           Ansel<lb ed="#V" n="77" break="no"/>de casu dia. ca. 12. dicit quod per naturalem voluntatem mouet se qui 
           li<lb ed="#V" n="78" break="no"/>bet ad alias voluntates. Ante gratiam: licet velit homo naturaliter 
-          bo<lb ed="#V" n="79" break="no"/>num: non tamen absolute concedi opoertet bonam habere voluntatem. 
+          bo<lb ed="#V" n="79" break="no"/>num: non tamen absolute concedi oportet bonam habere voluntatem. 
           Uelle<lb ed="#V" n="80" break="no"/>enim naturale non est: ita completum velle quod sufficienter disponat 
           <lb ed="#V" n="81"/>hominem ad gratiam. Et praeterea nullo modo ante gratiam quodcumque 
           <lb ed="#V" n="82"/>velle potest esse bonum bonitate meritoria de condigno. Magis 


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve09v2_kzz7yh-f114928.xml`.

## Applied changes

- p. 161v l. 21: intelligem → intelligere: infinitive ending -re misread as -m
- p. 161v l. 26: extranimam → extra animam: two words run together; bomna → bona: m/n misread
- p. 161v l. 27: Inteltilius → Intellectus: garbled OCR of standard scholastic term
- p. 161v l. 29: conseqenti → consequenti: not in word list (OCR transform matched)
- p. 161v l. 33: intelligem → intelligere: infinitive ending -re misread as -m
- p. 161v l. 34: Ido → Ideo: missing letter e
- p. 161v l. 36: obiecum → obiectum: missing ct; intellilus → intellectus: garbled OCR; obiecitum → obiectum: extra syllable
- p. 161v l. 40: intellilus → intellectus: garbled OCR
- p. 161v l. 42: obiecum → obiectum: missing ct
- p. 161v l. 44: intellilus → intellectus: garbled OCR
- p. 161v l. 48: consuctionem → coniunctionem: garbled OCR (cf. coninctionem on next line and coniunctionem on line 50)
- p. 161v l. 49: coninctionem → coniunctionem: 3+ consecutive consonants — likely garbled OCR
- p. 161v l. 58: seper → semper: n/m misread
- p. 161v l. 60: pomsmo → potentia: garbled OCR; context 'una autem potentia non potest simul moueri'
- p. 161v l. 65: seper → semper: n/m misread
- p. 161v l. 67: sequaeretur → sequeretur: spurious ae insertion
- p. 161v l. 69: sen → seu: m/u misread; getriali → generali: garbled OCR
- p. 161v l. 79: opoertet → oportet: extra e inserted

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_