### PR TITLE
Transcription corrections: cod-ve09v2_kzz7yh-f115544.xml (35 changes)

### DIFF
--- a/kzz7yh-f115544/cod-ve09v2_kzz7yh-f115544.xml
+++ b/kzz7yh-f115544/cod-ve09v2_kzz7yh-f115544.xml
@@ -165,7 +165,7 @@
           </p>
           <p xml:id="kzz7yh-f115544-d1e285">
             ¶ Argumenta 
-            <lb ed="#V" n="81"/>ad partem aliam procedunt de intentione 2o dicta.
+            <lb ed="#V" n="81"/>ad partem aliam procedunt de intentione 2o modo dicta.
           </p>
         </div>
         <div xml:id="kzz7yh-f115544-Dd1e291">

--- a/kzz7yh-f115544/cod-ve09v2_kzz7yh-f115544.xml
+++ b/kzz7yh-f115544/cod-ve09v2_kzz7yh-f115544.xml
@@ -103,11 +103,11 @@
             <lb ed="#V" n="41"/>Contra <ref xml:id="kzz7yh-f115544-Rd1e194">philosophus. 2 ethi. ca. 6</ref> dicit quod quaedam confestim 
             nomina<lb ed="#V" n="42" break="no"/>ta ordinata sunt cum malitia puta gaudium de 
             <lb ed="#V" n="43"/>malo inuerecundia inuidia et in operationibus adulterium furtum. Et 
-            <lb ed="#V" n="44"/>stati. q. post subdit. Non est igrati vnquam circa hoc dirigem: sed semper 
+            <lb ed="#V" n="44"/>stati. q. post subdit. Non est igitur vnquam circa hoc dirigere: sed semper 
             pec<lb ed="#V" n="45" break="no"/>care.
           </p>
           <p xml:id="kzz7yh-f115544-d1e183">
-            ¶ Item secundum Hu. de scuom vic. in libro de arra sponse non 
+            ¶ Item secundum Hu. de sancto vic. in libro de arra sponse non 
             mul<lb ed="#V" n="46" break="no"/>tum post principium: amor transformat amantem in amatum: ergo nullo modo 
             <lb ed="#V" n="47"/>potest voluntas velle malum: quin sit malum quaecumque intentione fiat. 
           </p>
@@ -117,7 +117,7 @@
           </p>
           <p xml:id="kzz7yh-f115544-d1e197">
             <lb ed="#V" n="50"/>Respondeo quod intentio potest dicem motum voluntatem
-            or<lb ed="#V" n="51" break="no"/>dinantis actum exteriorem in finem: vniversal ipsum 
+            or<lb ed="#V" n="51" break="no"/>dinantis actum exteriorem in finem: vel ipsum 
             <lb ed="#V" n="52"/>finem intentum. Si accipiatur primus: sic omnis actus exterior bona intentione 
             <lb ed="#V" n="53"/>factus est meritorius. Nam ille motus voluntatis ordinantis actum 
             <lb ed="#V" n="54"/>exteriorem in finem numquam est bonus: nisi sit ordo rectus: et ad hoc quod 
@@ -139,7 +139,7 @@
             <lb ed="#V" n="63"/>¶ Ad secundum dicendum: quod minor non est vera: 
             <lb ed="#V" n="64"/>nisi de intentione primo modo dicta: qui enim vellet mentiri: propter  
             delibera<lb ed="#V" n="65" break="no"/>tionem innocentis: talis actus voluntatis non esset bonus quamuis 
-            inten<lb ed="#V" n="66" break="no"/>deret bonu fines.
+            inten<lb ed="#V" n="66" break="no"/>deret bonum finem.
           </p>
           <p xml:id="kzz7yh-f115544-d1e245">
             ¶ Ad 3m dicendum: quod quamuis potentior sit bo¬ 
@@ -165,7 +165,7 @@
           </p>
           <p xml:id="kzz7yh-f115544-d1e285">
             ¶ Argumenta 
-            <lb ed="#V" n="81"/>ad partem aliam procedunt de intentione 2oo dicta.
+            <lb ed="#V" n="81"/>ad partem aliam procedunt de intentione 2o dicta.
           </p>
         </div>
         <div xml:id="kzz7yh-f115544-Dd1e291">
@@ -252,7 +252,7 @@
             inten<lb ed="#V" n="125" break="no"/>tionis addat aliquam bonitatem vltra 
             <lb ed="#V" n="126"/>bonitatem ipsius habitus et videtur quod non <ref xml:id="kzz7yh-f115544-Rd1e464">3. Zach. 4.</ref> 
             exe<lb ed="#V" n="127" break="no"/>quabit gratiam gratiae: ergo videtur quod secundum quantitatem habitus gratiae 
-            <lb ed="#V" n="128"/>erit quantitas glie <!--word?-->.
+            <lb ed="#V" n="128"/>erit quantitas glorie <!--word?-->.
           </p>
           <p xml:id="kzz7yh-f115544-d1e434">
             ¶ Item tantum deus acceptat opera quantum 
@@ -418,8 +418,8 @@
             acci<lb ed="#V" n="100" break="no"/>dentalis: vel respectu praemii substantialis: si primo modo tunc dico quod 
             <lb ed="#V" n="101"/>actus exteriores al iquam rationem meriti superaddunt intentioni 
             inte<lb ed="#V" n="102" break="no"/>riori: praemium enim accidentale est gaudium quod habent sancti de bono 
-            crea<lb ed="#V" n="103" break="no"/>to: qui autem plurles bonos actus exteriores fecerunt: ceteris 
-            pari<lb ed="#V" n="104" break="no"/>bus plus gaudent de bono creato quam alii qui pautiores 
+            crea<lb ed="#V" n="103" break="no"/>to: qui autem plures bonos actus exteriores fecerunt: ceteris 
+            pari<lb ed="#V" n="104" break="no"/>bus plus gaudent de bono creato quam alii qui <sic>pautiores</sic> 
             <lb ed="#V" n="105"/>actus exteriores fecerunt. Hoc autem praemium duplex est quoddam 
             <lb ed="#V" n="106"/>commune et quoddam priuilegiatum: commune autem debetur operanti: propter opera 
             <lb ed="#V" n="107"/>sua non rationem habentia victorie excellentis. Priuilegiatum autem 
@@ -440,13 +440,13 @@
             aureo<lb ed="#V" n="122" break="no"/>la scilicet virginum Martyrum et doctorum. Si autem loquamur de 
             me<lb ed="#V" n="123" break="no"/>rito respectum praemii substantialis. Sic videtur quod actus exteriores: vel 
             opera<lb ed="#V" n="124" break="no"/>non addunt aliquam rationem meriti: vltra bonum actum voluntatis 
-            <lb ed="#V" n="125"/>interiorem: nisi dispositiue: inquantum scilicet elemosyne date 
+            <lb ed="#V" n="125"/>interiorem: nisi dispositiue: inquantum scilicet <sic>elemosyne</sic> date 
             mltipli<lb ed="#V" n="126" break="no"/>cant apud deum intercessores pro dante. Propter quod dicitur Thob. 
-            <lb ed="#V" n="127"/>12. quod elemosyna a morte liberat: et ipsa est qui purgat peccata: 
+            <lb ed="#V" n="127"/>12. quod <sic>elemosyna</sic> a morte liberat: et ipsa est qui purgat peccata: 
             <lb ed="#V" n="128"/>et facit inuenire vitam aeternam: et per sapientem dicitur puer. 13 quod 
             redem<lb ed="#V" n="129" break="no"/>ptio anime diuitis diuitie eius: et imquantum actus exteriores excitant 
             <lb ed="#V" n="130"/>actum voluntatis interiorem ad bonum: et inquantum mediante 
-            excita<lb ed="#V" n="131" break="no"/>tione actuum interiorum valetium ad habitus interiores gratiae 
+            excita<lb ed="#V" n="131" break="no"/>tione actuum interiorum <sic>valetium</sic> ad habitus interiores gratiae 
             <lb ed="#V" n="132"/>radicationem et conseruationem: cui habitui et interioribus 
             <lb ed="#V" n="133"/>actibus eius debetur premium substantiale. 
           </p>
@@ -456,7 +456,7 @@
             <lb ed="#V" n="136"/>interiori plus meretur quantum ad praemium accidentale: et quantum ad praes<pb ed="#V" n="163-v"/><cb ed="#P" n="a"/><lb ed="#V" n="1" break="no"/>mium 
             substantiale dispositiue modo praedicto. Sed quando pauper ex maiori 
             <lb ed="#V" n="2"/>habitum gratiae: vel ex intensiori motu intentionis gratuite dat paruam 
-            <lb ed="#V" n="3"/>elemosynam et diues ex minori hbientu gratiae: et minori deuotione 
+            <lb ed="#V" n="3"/>elemosynam et diues ex minori habitu gratiae: et minori deuotione 
             <lb ed="#V" n="4"/>interioris actus voluntatis dat magnam elemosynam: tunc dico 
             <lb ed="#V" n="5"/>simpliciter omnibus pensatis quod magis meretur ille pauper quam ille 
             di<lb ed="#V" n="6" break="no"/>ues: et sic fuit in illa vidua.
@@ -479,7 +479,7 @@
             sba<lb ed="#V" n="17" break="no"/>le praemium quam desideratum non habitum ceteris paribus. Non sic enim 
             <lb ed="#V" n="18"/>dicendum est de sacramento: sicut de aliis actibus exterioribus: vt deo 
             <lb ed="#V" n="19"/>dante declarabitur in quarto: tamen si haberi non potest in effectu: non propter 
-            <lb ed="#V" n="20"/>hoc perdit a dultus vitam eternam: qui sibimet subuenit ipsum 
+            <lb ed="#V" n="20"/>hoc perdit a adultus vitam eternam: qui sibimet subuenit ipsum 
             desi<lb ed="#V" n="21" break="no"/>derando in affectu. Nec plus voluit dicere <ref xml:id="kzz7yh-f115544-Rd1e914">Aug. in loco 
               <lb ed="#V" n="22"/>praeallegato</ref>.
           </p>

--- a/kzz7yh-f115544/cod-ve09v2_kzz7yh-f115544.xml
+++ b/kzz7yh-f115544/cod-ve09v2_kzz7yh-f115544.xml
@@ -479,7 +479,7 @@
             sba<lb ed="#V" n="17" break="no"/>le praemium quam desideratum non habitum ceteris paribus. Non sic enim 
             <lb ed="#V" n="18"/>dicendum est de sacramento: sicut de aliis actibus exterioribus: vt deo 
             <lb ed="#V" n="19"/>dante declarabitur in quarto: tamen si haberi non potest in effectu: non propter 
-            <lb ed="#V" n="20"/>hoc perdit a adultus vitam eternam: qui sibimet subuenit ipsum 
+            <lb ed="#V" n="20"/>hoc perdit adultus vitam eternam: qui sibimet subuenit ipsum 
             desi<lb ed="#V" n="21" break="no"/>derando in affectu. Nec plus voluit dicere <ref xml:id="kzz7yh-f115544-Rd1e914">Aug. in loco 
               <lb ed="#V" n="22"/>praeallegato</ref>.
           </p>

--- a/kzz7yh-f115544/cod-ve09v2_kzz7yh-f115544.xml
+++ b/kzz7yh-f115544/cod-ve09v2_kzz7yh-f115544.xml
@@ -85,13 +85,13 @@
             <lb ed="#V" n="31"/><quote xml:id="kzz7yh-f115544-Qd1e149" source="http://scta.info/resource/mt7_18@1-7">non potest arbor bona fructus malos facere</quote>. Sed secundum 
             <ref xml:id="kzz7yh-f115544-Rd1e152">glo<lb ed="#V" n="32" break="no"/>sam</ref> super <ref xml:id="kzz7yh-f115544-Rd1e158">illud verbum ibidem</ref>: <quote xml:id="kzz7yh-f115544-Qd1e160" source="http://scta.info/resource/mt7_19@1-2">omnis arbor</quote> etc. <quote xml:id="kzz7yh-f115544-Qd1e163">Uoluntas 
               vni<lb ed="#V" n="33" break="no"/>uscuiusque est arbor bona: vel mala</quote>: ergo ex bona voluntate: sit 
-            bo<lb ed="#V" n="34" break="no"/>nus actus. Sed intentio est velle: ergo omne opsmus bonum est quod sit bona 
+            bo<lb ed="#V" n="34" break="no"/>nus actus. Sed intentio est velle: ergo omne opus bonum est quod sit bona 
             intem<lb ed="#V" n="35" break="no"/>tione.
           </p>
           <p xml:id="kzz7yh-f115544-d1e153">
             ¶ Item bonitas est in actum exteriori ex bonitate actus 
             inte<lb ed="#V" n="36" break="no"/>rioris. Sed actus interior bonus est ex intentione boni finis: ergo actus 
-            <lb ed="#V" n="37"/>exterior bonous est si ex bona intentione sit.
+            <lb ed="#V" n="37"/>exterior bonus est si ex bona intentione sit.
           </p>
           <p xml:id="kzz7yh-f115544-d1e160">
             ¶ Item potentior est 
@@ -113,7 +113,7 @@
           </p>
           <p xml:id="kzz7yh-f115544-d1e190">
             <lb ed="#V" n="48"/>¶ Item potentior est lex divina quam quaecumque intentio nostra: ergo exterior 
-            <lb ed="#V" n="49"/>actus per legem dinam prohitus: quacumque intetione fiat: non potest fieri bon. 
+            <lb ed="#V" n="49"/>actus per legem diuinam prohibitus: quacumque intentione fiat: non potest fieri bon. 
           </p>
           <p xml:id="kzz7yh-f115544-d1e197">
             <lb ed="#V" n="50"/>Respondeo quod intentio potest dicem motum voluntatem
@@ -149,9 +149,9 @@
             <lb ed="#V" n="68"/>aliquid sit bonum quam ad hoc quod aliquid sit malum: quia sic dicit Dio. 
             <lb ed="#V" n="69"/>de di. no. ca. 8. magis prope finem quam prope medium: bonum 
             confi<lb ed="#V" n="70" break="no"/>stit ex integra et tota causa: malum vero ex particularibus defectibus. 
-            <lb ed="#V" n="71"/>Idon actus de se bonus fieri potest malus per intentionem malam: et 
+            <lb ed="#V" n="71"/>Ideo actus de se bonus fieri potest malus per intentionem malam: et 
             ma<lb ed="#V" n="72" break="no"/>lus non potest fieri bonus: propter quancumque finem intentum. Unde Ber. de 
-            <lb ed="#V" n="73"/>praecepto et dispen 38 ca. bonum prorsus condemnat intentio 
+            <lb ed="#V" n="73"/>praecepto et dispensatione 38 ca. bonum prorsus condemnat intentio 
             par<lb ed="#V" n="74" break="no"/>ua et malum non penitus excusat recta.
           </p>
           <p xml:id="kzz7yh-f115544-d1e269">
@@ -205,14 +205,14 @@
           <p xml:id="kzz7yh-f115544-d1e347">
             <lb ed="#V" n="100"/>Respondeo quod agentem tantum mereri quantum 
             inten<lb ed="#V" n="101" break="no"/>dit mereri per bonitatem sui actus 
-            du<lb ed="#V" n="102" break="no"/>pliciter potest intelligi. vno modo: ita quod actus tantum valeat admeritum 
+            du<lb ed="#V" n="102" break="no"/>pliciter potest intelligi. vno modo: ita quod actus tantum valeat ad meritum 
             <lb ed="#V" n="103"/>quantum agens ipsum estimat valere. Et sic non est verum. Aliqui 
             <lb ed="#V" n="104"/>enim superbus hypocrita intendit actum suum multum valere: ad 
             <lb ed="#V" n="105"/>meritum: cum tamen parum valeat.
           </p>
           <p xml:id="kzz7yh-f115544-d1e363">
             ¶ Alio modo quod quanta est 
-            boni<lb ed="#V" n="106" break="no"/>tas actus intentionis: tantum actus exterior valeat admeritum: et 
+            boni<lb ed="#V" n="106" break="no"/>tas actus intentionis: tantum actus exterior valeat ad meritum: et 
             <lb ed="#V" n="107"/>sic dico quod verum est: ipsa autem intentio sepe maior est in 
             boni<lb ed="#V" n="108" break="no"/>tate in illo qui suum actum non tantum estimat valere quam in illo quid 
             <lb ed="#V" n="109"/>actum suum magis estimat valere. 
@@ -238,7 +238,7 @@
           </p>
           <p xml:id="kzz7yh-f115544-d1e407">
             ¶ Argumenta ad 
-            <lb ed="#V" n="121"/>partem aliam nihil plus coneludunt: nisi quod non semper tantum vale: 
+            <lb ed="#V" n="121"/>partem aliam nihil plus concludunt: nisi quod non semper tantum vale: 
             <lb ed="#V" n="122"/>actus exterior quantum agens ipsum valere intendit ad 
             me<lb ed="#V" n="123" break="no"/>ritum. Et hoc est verum.
           </p>
@@ -262,7 +262,7 @@
             <lb ed="#V" n="132"/>eius: ergo non est bonitas in homine: nisi secundum quantitatem habitus gratiae. 
           </p>
           <p xml:id="kzz7yh-f115544-d1e445">
-            <lb ed="#V" n="133"/>¶ Item si non est bonitas gratiein vno: nisi propter aliud non 
+            <lb ed="#V" n="133"/>¶ Item si non est bonitas gratiae in vno: nisi propter aliud non 
             <lb ed="#V" n="134"/>plus est de bonitate in duobus: quam in vno tantum. Sed in inten¬ 
             <!--00339.xml-->
             <pb ed="#V" n="163-r"/>
@@ -270,7 +270,7 @@
             <lb ed="#V" n="1"/>tione interiori: non est aliqua bonitas: nisi propter habitum gratiae: 
             loquem<lb ed="#V" n="2" break="no"/>do de bonitate remunerabili a deo: de qua hoc loquimur: quia 
             <lb ed="#V" n="3"/>si intentio procedit non ex gratia: non est a deo remunerabilis: ergo 
-            <lb ed="#V" n="4"/>intentio actualis nullam bonitatem addit super hitum gratiae: vt videtur. 
+            <lb ed="#V" n="4"/>intentio actualis nullam bonitatem addit super habitum gratiae: vt videtur. 
           </p>
           <p xml:id="kzz7yh-f115544-d1e467">
             <lb ed="#V" n="5"/>Contra per actus voluntatis elicitos ex gratia: mereri 
@@ -291,11 +291,11 @@
             <lb ed="#V" n="15"/>actualis intentio 
             su<lb ed="#V" n="16" break="no"/>pra bonitatem habitus gratiae: nullam superaddit bonitatem remune 
             <lb ed="#V" n="17"/>rabilem a deo quantum ad principium essentiale: vnde si moriantur duo 
-            inequa<lb ed="#V" n="18" break="no"/>li hieitu gratiae: quamuis vnus ex sua gratia plurles hunisset bonas 
+            inequa<lb ed="#V" n="18" break="no"/>li habitu gratiae: quamuis vnus ex sua gratia plurales habuisset bonas 
             inten<lb ed="#V" n="19" break="no"/>taiones actuales quam alius equale habebunt principium essentiale quod consistit in 
             <lb ed="#V" n="20"/>clara dei visione et perfecta eius finitione. Hoc enim praemium 
-            mensura<lb ed="#V" n="21" break="no"/>ri dicunt secundum hitus gratiae quantitatem: quia tamen valet quantum ad habitus gratiae 
-            <lb ed="#V" n="22"/>radicationem et conseruationem: et disponit ad eius augmtationem: 
+            mensura<lb ed="#V" n="21" break="no"/>ri dicunt secundum habitus gratiae quantitatem: quia tamen valet quantum ad habitus gratiae 
+            <lb ed="#V" n="22"/>radicationem et conseruationem: et disponit ad eius augmentationem: 
             <lb ed="#V" n="23"/>ideo ex consiti valere dicitur ad praemium substantiale: superaddit etiam aliquam 
             bo<lb ed="#V" n="24" break="no"/>nitatem per comparatione ad praemium accidentale de quo fiet 
             memn<lb ed="#V" n="25" break="no"/>tio in sequenti quaestione
@@ -317,8 +317,8 @@
           </p>
           <p xml:id="kzz7yh-f115544-d1e546">
             <lb ed="#V" n="35"/>¶ Preterea actus est finis ipsius habitus et nobilior eo: vnde et 
-            <lb ed="#V" n="36"/>habitus glalie ad actum glurie ordinatur: signo aliquid de praemio 
-            essen<lb ed="#V" n="37" break="no"/>tiali respondeat ipsi hitui gratiae: videtur etiam quod respondeat aliquid de praemio 
+            <lb ed="#V" n="36"/>habitus gloriae ad actum gloriae ordinatur: signo aliquid de praemio 
+            essen<lb ed="#V" n="37" break="no"/>tiali respondeat ipsi habitui gratiae: videtur etiam quod respondeat aliquid de praemio 
             <lb ed="#V" n="38"/>essentiali ipsi intentioni interiori per gratiam elicite: irrationabile enim 
             <lb ed="#V" n="39"/>videretur quod quantum ad praemium essentiale remuneraretur homo 
             pro<lb ed="#V" n="40" break="no"/>hitu gratiae et non pro voluntatis actibus interioribus ex gratia 
@@ -331,9 +331,9 @@
             essen<lb ed="#V" n="44" break="no"/>tiale superaddit habitui gratie. Ita quod praemium essentiale respondet 
             <lb ed="#V" n="45"/>ipsi habitui gratiae: et actibus voluntatis interioribus ex ipso 
             hitu<lb ed="#V" n="46" break="no"/>elicitis: propter enim actus tales datur anime post expletionem poenitentie: 
-            ma<lb ed="#V" n="47" break="no"/>ior habitus luminis glurie: et maius augmentum habitus 
+            ma<lb ed="#V" n="47" break="no"/>ior habitus luminis gloriae: et maius augmentum habitus 
             charita<lb ed="#V" n="48" break="no"/>tis: quam si cum solo habitum gratiae: sine praedictis actibus a corpore 
-            re<lb ed="#V" n="49" break="no"/>cessisset: et ex conseqenti sequitur quod deum clarius videt et perfectius 
+            re<lb ed="#V" n="49" break="no"/>cessisset: et ex consequenti sequitur quod deum clarius videt et perfectius 
             <lb ed="#V" n="50"/>eo fruitur quam si praedictos actus per habitum sue gratiae non elicisset. 
           </p>
           <p xml:id="kzz7yh-f115544-d1e587">
@@ -365,7 +365,7 @@
             <lb ed="#V" n="69"/>dice quamuis in ea praefuerit in virtate. Plus autem valet 
             boni<lb ed="#V" n="70" break="no"/>tas secundum quod est in actu: quam secundum quod est in potentia. Simili modo 
             <lb ed="#V" n="71"/>potest dici de actibus voluntatis interioribus et gratuitis per 
-            com<lb ed="#V" n="72" break="no"/>parationem ad suam radicem quae est hitus gratie.
+            com<lb ed="#V" n="72" break="no"/>parationem ad suam radicem quae est habitus gratie.
           </p>
         </div>
         <div xml:id="kzz7yh-f115544-Dd1e648">
@@ -383,7 +383,7 @@
             <lb ed="#V" n="80"/>misit qui miserunt in:gazophylatium.
           </p>
           <p xml:id="kzz7yh-f115544-d1e672">
-            ¶ Item de beatio 
+            ¶ Item de beato 
             Mar<lb ed="#V" n="81" break="no"/>tino creatura. O beatissima anima quam et si gladius 
             persecutio<lb ed="#V" n="82" break="no"/>nis non abstulit: palmam tamen martyrii non amisit: ergo 
             exte<lb ed="#V" n="83" break="no"/>rior passio martyrii nullum superaddit meritum bone 
@@ -398,35 +398,35 @@
           <p xml:id="kzz7yh-f115544-d1e694">
             <lb ed="#V" n="89"/>Contra <ref xml:id="kzz7yh-f115544-Rd1e743">glosa</ref> super illud <ref xml:id="kzz7yh-f115544-Rd1e745">Gal 6.</ref> tempore suo meremus non 
             <lb ed="#V" n="90"/>deficientes dicit quod quantum seruiremus in 
-            ope<lb ed="#V" n="91" break="no"/>ribus tantum meremus in fructibus: ibi autem loqutur de exteriori 
+            ope<lb ed="#V" n="91" break="no"/>ribus tantum meremus in fructibus: ibi autem loquitur de exteriori 
             ope<lb ed="#V" n="92" break="no"/>ratione: vt videtur.
           </p>
           <p xml:id="kzz7yh-f115544-d1e706">
-            ¶ Item quaedam sunt opera praeuilegiata: vt 
+            ¶ Item quaedam sunt opera priuilegiata: vt 
             <lb ed="#V" n="93"/>doctrina martyrium virginitas per quae homo si habentur in opere 
             <lb ed="#V" n="94"/>meretur aureolam: non autem si habentur sola intentione.
           </p>
           <p xml:id="kzz7yh-f115544-d1e713">
             ¶ Item 
             <lb ed="#V" n="95"/>Apost. 2. cor. 9. loquens de exteriori operatione dicit quod qui 
-            perce<lb ed="#V" n="96" break="no"/>seminat perce et metet: quod non esset verum: nisi exteriores actus 
-            <lb ed="#V" n="97"/>superadderent aliquam rationem bomoni meriti vltra intentionem interiorem. 
+            perce<lb ed="#V" n="96" break="no"/>seminat parce et metet: quod non esset verum: nisi exteriores actus 
+            <lb ed="#V" n="97"/>superadderent aliquam rationem boni meriti vltra intentionem interiorem. 
           </p>
           <p xml:id="kzz7yh-f115544-d1e722">
             <lb ed="#V" n="98"/>Respondeo quod ad praesens possumus loqui de 
-            meri<lb ed="#V" n="99" break="no"/>to dupliter scilicet vel respectu praemii 
-            acci<lb ed="#V" n="100" break="no"/>dentalis: vel respectu praemii substantialis: si primo modo tuc dico quod 
+            meri<lb ed="#V" n="99" break="no"/>to dupliciter scilicet vel respectu praemii 
+            acci<lb ed="#V" n="100" break="no"/>dentalis: vel respectu praemii substantialis: si primo modo tunc dico quod 
             <lb ed="#V" n="101"/>actus exteriores al iquam rationem meriti superaddunt intentioni 
             inte<lb ed="#V" n="102" break="no"/>riori: praemium enim accidentale est gaudium quod habent sancti de bono 
             crea<lb ed="#V" n="103" break="no"/>to: qui autem plurles bonos actus exteriores fecerunt: ceteris 
             pari<lb ed="#V" n="104" break="no"/>bus plus gaudent de bono creato quam alii qui pautiores 
             <lb ed="#V" n="105"/>actus exteriores fecerunt. Hoc autem praemium duplex est quoddam 
-            <lb ed="#V" n="106"/>commune et quoddam praeuilegiatum: commune autem debetur operanti: propter opera 
+            <lb ed="#V" n="106"/>commune et quoddam priuilegiatum: commune autem debetur operanti: propter opera 
             <lb ed="#V" n="107"/>sua non rationem habentia victorie excellentis. Priuilegiatum autem 
             <lb ed="#V" n="108"/>quod dicitur aureola est gaudium de operibus a se factis rationem habentibus 
             vi<lb ed="#V" n="109" break="no"/>ctorie excellentis: per quod apparebit exterius quidam decor 
             in<lb ed="#V" n="110" break="no"/>corpore qui praedictum interius gaudium declarabit exterius. Unde 
-            <lb ed="#V" n="111"/>et illud peremium dicitur principalius esse in anima: quamuis aliqua perfectio 
+            <lb ed="#V" n="111"/>et illud praemium dicitur principalius esse in anima: quamuis aliqua perfectio 
             ex<lb ed="#V" n="112" break="no"/>hoc exterius redundet in corpore. Ista autem opera habentia rationem 
             excel<lb ed="#V" n="113" break="no"/>lentis victorie: quibus debetur aureola: ad tria genera reducuntur. 
             <lb ed="#V" n="114"/>Tres enim hebemus inimicos: carnem quae contra nos pugnat per 
@@ -441,9 +441,9 @@
             me<lb ed="#V" n="123" break="no"/>rito respectum praemii substantialis. Sic videtur quod actus exteriores: vel 
             opera<lb ed="#V" n="124" break="no"/>non addunt aliquam rationem meriti: vltra bonum actum voluntatis 
             <lb ed="#V" n="125"/>interiorem: nisi dispositiue: inquantum scilicet elemosyne date 
-            mltipli<lb ed="#V" n="126" break="no"/>cant aptode deum intercessores pro dante. Propter quod dicitur Thob. 
+            mltipli<lb ed="#V" n="126" break="no"/>cant apud deum intercessores pro dante. Propter quod dicitur Thob. 
             <lb ed="#V" n="127"/>12. quod elemosyna a morte liberat: et ipsa est qui purgat peccata: 
-            <lb ed="#V" n="128"/>et facit inuenire vitam erernam: et per sapientem dicitur puer. 13 quod 
+            <lb ed="#V" n="128"/>et facit inuenire vitam aeternam: et per sapientem dicitur puer. 13 quod 
             redem<lb ed="#V" n="129" break="no"/>ptio anime diuitis diuitie eius: et imquantum actus exteriores excitant 
             <lb ed="#V" n="130"/>actum voluntatis interiorem ad bonum: et inquantum mediante 
             excita<lb ed="#V" n="131" break="no"/>tione actuum interiorum valetium ad habitus interiores gratiae 
@@ -455,7 +455,7 @@
             <lb ed="#V" n="135"/>supposita equalitate in habitu et actu 
             <lb ed="#V" n="136"/>interiori plus meretur quantum ad praemium accidentale: et quantum ad praes<pb ed="#V" n="163-v"/><cb ed="#P" n="a"/><lb ed="#V" n="1" break="no"/>mium 
             substantiale dispositiue modo praedicto. Sed quando pauper ex maiori 
-            <lb ed="#V" n="2"/>hitum gratiae: vel ex intensiori motu intentionis gratuite dat peruam 
+            <lb ed="#V" n="2"/>habitum gratiae: vel ex intensiori motu intentionis gratuite dat paruam 
             <lb ed="#V" n="3"/>elemosynam et diues ex minori hbientu gratiae: et minori deuotione 
             <lb ed="#V" n="4"/>interioris actus voluntatis dat magnam elemosynam: tunc dico 
             <lb ed="#V" n="5"/>simpliciter omnibus pensatis quod magis meretur ille pauper quam ille 
@@ -466,17 +466,17 @@
             <lb ed="#V" n="7"/>intelligitur de palma substantiali quae aurea dicitur. Sicut enim in linea 
             circu<lb ed="#V" n="8" break="no"/>lari: principium fini coniungitur et econuerso: et propter eius perfectionem quod sibi 
             <lb ed="#V" n="9"/>additur accidentale est: ita per palmam substantialem creatura rationalis: ita 
-            <lb ed="#V" n="10"/>perfecte coniungitur suo princtia per cognitionem et amorem quod omne praemium 
-            <lb ed="#V" n="11"/>aliud isti superadditum accidentale est: ad quod signandu praemium 
-            acci<lb ed="#V" n="12" break="no"/>dentale praieuilegiatum aureola dicitur quod est diminutiuum auree: hoc 
+            <lb ed="#V" n="10"/>perfecte coniungitur suo principio per cognitionem et amorem quod omne praemium 
+            <lb ed="#V" n="11"/>aliud isti superadditum accidentale est: ad quod signandum praemium 
+            acci<lb ed="#V" n="12" break="no"/>dentale priuilegiatum aureola dicitur quod est diminutiuum auree: hoc 
             <lb ed="#V" n="13"/>autem duo praemia signata fuerunt Exo. 25. vbi dicitur facies illi labium 
             <lb ed="#V" n="14"/>aureum per circuitum: et ipsi labio coronam in interrasilem: altera. 4: 
             <lb ed="#V" n="15"/>digitis: et super illam alteram coronam aureolam
           </p>
           <p xml:id="kzz7yh-f115544-d1e854">
             ¶ Ad 3m dicendum: quod 
-            <lb ed="#V" n="16"/>de lege communi sacramentum desideratum et hitum: plus confert est ad 
-            sba<lb ed="#V" n="17" break="no"/>le praemium quam desideratum non hitum ceteris paribus. Non sic enim 
+            <lb ed="#V" n="16"/>de lege communi sacramentum desideratum et habitum: plus confert est ad 
+            sba<lb ed="#V" n="17" break="no"/>le praemium quam desideratum non habitum ceteris paribus. Non sic enim 
             <lb ed="#V" n="18"/>dicendum est de sacramento: sicut de aliis actibus exterioribus: vt deo 
             <lb ed="#V" n="19"/>dante declarabitur in quarto: tamen si haberi non potest in effectu: non propter 
             <lb ed="#V" n="20"/>hoc perdit a dultus vitam eternam: qui sibimet subuenit ipsum 


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve09v2_kzz7yh-f115544.xml`.

## Applied changes

- p. 162v l. 34: opsmus → opus: garbled OCR; context 'omne opus bonum est quod sit bona intentione'
- p. 162v l. 37: bonous → bonus: extra o inserted
- p. 162v l. 49: dinam → diuinam: missing ui; prohitus → prohibitus: missing bi; intetione → intentione: missing n (not t/r transposition)
- p. 162v l. 71: Idon → Ideo: garbled; transitional word in context
- p. 162v l. 73: dispen → dispensatione: abbreviated title 'De praecepto et dispensatione' by Bernard
- p. 162v l. 102: admeritum → ad meritum: two words run together
- p. 162v l. 106: admeritum → ad meritum: two words run together
- p. 162v l. 121: coneludunt → concludunt: extra e inserted
- p. 162v l. 133: gratiein → gratiae in: two words run together
- p. 163r l. 4: hitum → habitum: missing ab (systematic pattern throughout: hitus/hitum/hitui all = habitus/habitum/habitui)
- p. 163r l. 18: hieitu → habitu: missing ab (systematic pattern); plurles → plurales: missing a; hunisset → habuisset: garbled OCR of pluperfect
- p. 163r l. 21: hitus → habitus: missing ab (systematic pattern throughout)
- p. 163r l. 22: augmtationem → augmentationem: missing en
- p. 163r l. 36: glalie → gloriae: garbled OCR; glurie → gloriae: garbled OCR
- p. 163r l. 37: hitui → habitui: missing ab (systematic pattern throughout)
- p. 163r l. 47: glurie → gloriae: garbled OCR
- p. 163r l. 49: conseqenti → consequenti: not in word list (OCR transform matched)
- p. 163r l. 72: hitus → habitus: missing ab (systematic pattern throughout)
- p. 163r l. 80: beatio → beato: extra i; context 'de beato Martino'
- p. 163r l. 91: loqutur → loquitur: missing i (not loquatur — 3rd person indicative present, not subjunctive)
- p. 163r l. 92: praeuilegiata → priuilegiata: wrong prefix vowel prae→pri
- p. 163r l. 96: perce → parce: e/a misread; biblical citation 2 Cor 9:6 'qui parce seminat parce et metet'
- p. 163r l. 97: bomoni → boni: extra mo inserted
- p. 163r l. 99: dupliter → dupliciter: missing ci
- p. 163r l. 100: tuc → tunc: missing n
- p. 163r l. 106: praeuilegiatum → priuilegiatum: wrong prefix vowel prae→pri
- p. 163r l. 111: peremium → praemium: garbled ae diphthong and extra e
- p. 163r l. 126: aptode → apud: garbled OCR; context 'multiplicant apud deum intercessores pro dante'
- p. 163r l. 128: erernam → aeternam: garbled ae diphthong at start
- p. 163v l. 2: hitum → habitum: missing ab (systematic pattern); peruam → paruam: e/a misread (paruam = small)
- p. 163v l. 10: princtia → principio: garbled OCR; context 'coniungitur suo principio per cognitionem et amorem'
- p. 163v l. 11: signandu → signandum: missing final m on gerund
- p. 163v l. 12: praieuilegiatum → priuilegiatum: wrong prefix praie→pri
- p. 163v l. 16: hitum → habitum: missing ab (systematic pattern throughout)
- p. 163v l. 17: hitum → habitum: missing ab (systematic pattern throughout)

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_