### PR TITLE
Transcription corrections: cod-ve09v2_kzz7yh-f117877.xml (13 changes)

### DIFF
--- a/kzz7yh-f117877/cod-ve09v2_kzz7yh-f117877.xml
+++ b/kzz7yh-f117877/cod-ve09v2_kzz7yh-f117877.xml
@@ -131,7 +131,7 @@
             <lb ed="#V" n="116"/>SEcundo queritur vtrum ad meritum sufficiat 
             <lb ed="#V" n="117"/>intentio secundum habitum. Et videtur quod 
             <lb ed="#V" n="118"/>sic. Quia aliter ille qui incipit facere aliquam 
-            peregrina<lb ed="#V" n="119" break="no"/>tionem pro deo nihil meretur in aliqua parte illius itinerus 
+            peregrina<lb ed="#V" n="119" break="no"/>tionem pro deo nihil meretur in aliqua parte illius itineris 
             <lb ed="#V" n="120"/>in qua actualiter de deo non cogitaret: quod falsum estia.
           </p>
           <p xml:id="kzz7yh-f117877-d1e233">
@@ -139,7 +139,7 @@
             <lb ed="#V" n="121"/>volutas non mouet se respectu eorum que sunt ad finem nisi 
             <lb ed="#V" n="122"/>in virtute finis. Sed homo volendo ea que sunt ad finem: non 
             <lb ed="#V" n="123"/>semper actu cogitat de fine: ergo habitualis intentio finis 
-            <lb ed="#V" n="124"/>sinfficit ad mouendum voluntatem respectu eorum: que sunt ad 
+            <lb ed="#V" n="124"/>sufficit ad mouendum voluntatem respectu eorum: que sunt ad 
             <!--00345.xml-->
             <pb ed="#V" n="166-r"/>
             <cb ed="#P" n="a"/>
@@ -161,7 +161,7 @@
           </p>
           <p xml:id="kzz7yh-f117877-d1e278">
             ¶ Item secundum Ber. libo de libei arbitrii parum ante 
-            <lb ed="#V" n="11"/>finem. In his tribus interior renouatio consistit: videliet 
+            <lb ed="#V" n="11"/>finem. In his tribus interior renouatio consistit: videlicet 
             recti<lb ed="#V" n="12" break="no"/>tudine intentionis puritate affectionis recordatione bone 
             <lb ed="#V" n="13"/>operationis. Sed affectio et recordatio pro actibus accipiuntur 
             <lb ed="#V" n="14"/>ibi: ergo similiter et intentio: sed merendo renouamur interius: 
@@ -169,7 +169,7 @@
           </p>
           <p xml:id="kzz7yh-f117877-d1e291">
             ¶ Item si ad 
-            me<lb ed="#V" n="16" break="no"/>rendum sufficeret sola intentio secundum habitum: tunc opismus meritorium 
+            me<lb ed="#V" n="16" break="no"/>rendum sufficeret sola intentio secundum habitum: tunc opus meritorium 
             <lb ed="#V" n="17"/>posset esse quod non procederet ex intentione: quia illud quod non est 
             <lb ed="#V" n="18"/>in actu: non potest esse causa eius: quod est in actu. 
           </p>
@@ -187,7 +187,7 @@
             prin<lb ed="#V" n="29" break="no"/>cipii operationis explicite: ita quod explicite intendat actionem 
             <lb ed="#V" n="30"/>inchoare et consumare: sed respectu totius continuationis 
             opera<lb ed="#V" n="31" break="no"/>tionis: non remanet in actum explicito: sed implicito. Sicut 
-            <lb ed="#V" n="32"/>homo in volendo quicquid est ad finem actualiter. Implicite tamen vuli 
+            <lb ed="#V" n="32"/>homo in volendo quicquid est ad finem actualiter. Implicite tamen vult 
             <lb ed="#V" n="33"/>ipsum finem: et sic dicunt aliqui esse necessarium ad hoc quod tota 
             operatio<lb ed="#V" n="34" break="no"/>sit meritoria et quod tota intentio sit in actum explicito vel 
             implici<lb ed="#V" n="35" break="no"/>to per totam operationem a principio vsque ad finem. 
@@ -201,10 +201,10 @@
             inten<lb ed="#V" n="41" break="no"/>dit perfectionem illius peregrinationis actualiter: implicite tanen. 
           </p>
           <p xml:id="kzz7yh-f117877-d1e355">
-            <lb ed="#V" n="42"/>¶ Ad secundum dicendum:r quod volens ea que sunt ad finem vult in 
+            <lb ed="#V" n="42"/>¶ Ad secundum dicendum quod volens ea que sunt ad finem vult in 
             vir<lb ed="#V" n="43" break="no"/>tute finis: autem quia an hoc finem voluit actu et experlicite. Aut quoa 
             <lb ed="#V" n="44"/>in volendo quicquid est ad finem vult finem actualiter implicite vel 
-            <lb ed="#V" n="45"/>explicite sic intelligens conclusionem actualiter intelligit princium 
+            <lb ed="#V" n="45"/>explicite sic intelligens conclusionem actualiter intelligit principium 
             <lb ed="#V" n="46"/>implicite vel explicite.
           </p>
           <p xml:id="kzz7yh-f117877-d1e368">
@@ -232,7 +232,7 @@
           </p>
           <p xml:id="kzz7yh-f117877-d1e402">
             ¶ Item operatio est 
-            ma<lb ed="#V" n="55" break="no"/>la propter defectum vnius circumnstantie debite. Sed in omni operatione 
+            ma<lb ed="#V" n="55" break="no"/>la propter defectum vnius circumstantie debite. Sed in omni operatione 
             <lb ed="#V" n="56"/>que sit sine fide rectificante intentionem deficit vna 
             circunstan<lb ed="#V" n="57" break="no"/>tia debita si relatio in finem debitum: ergo omnis talis operatio est mala. 
           </p>
@@ -258,9 +258,9 @@
             <lb ed="#V" n="69"/>originalis: quod debitum remissum est in baptizatis per baptismum 
             <lb ed="#V" n="70"/>et ideo manent obligati ad rectitudinem originalis iustitie: per 
             <lb ed="#V" n="71"/>quam vires inferiores erant plene subdite superioribus: et 
-            su<lb ed="#V" n="72" break="no"/>periores se habentes in rectitudine ad deum: et quia nullum opue 
+            su<lb ed="#V" n="72" break="no"/>periores se habentes in rectitudine ad deum: et quia nullum opus 
             <lb ed="#V" n="73"/>eorum habet rectitudinem debitam qui processissent ex originali 
-            iusti<lb ed="#V" n="74" break="no"/>tia. Idon omnes actus eorum dicunt esse peccatum.
+            iusti<lb ed="#V" n="74" break="no"/>tia. Ideo omnes actus eorum dicunt esse peccatum.
           </p>
           <p xml:id="kzz7yh-f117877-d1e460">
             ¶ Sed hoc opinio nimis 
@@ -269,7 +269,7 @@
             <lb ed="#V" n="77"/>suis rectitudinem habere per comparationem ad finem proximum: qui 
             <lb ed="#V" n="78"/>ordinabilis est ad finem vltimum: quamuis actu non ordinetur et 
             <lb ed="#V" n="79"/>talem operationem faciendo non videntur facere contra iustitiam: quia talis 
-            <lb ed="#V" n="80"/>rectitudo est quaedam inchoatio rectitudis simpliciter. Et ideo 
+            <lb ed="#V" n="80"/>rectitudo est quaedam inchoatio rectitudinis simpliciter. Et ideo 
             quam<lb ed="#V" n="81" break="no"/>uis talis actus non possit vere dici meritorius saltem de condigno 
             <lb ed="#V" n="82"/>non est tamen peccatum.
           </p>
@@ -280,13 +280,13 @@
             <lb ed="#V" n="85"/>autem mortaliter peccat faciendo illud quod non potest compati se cum 
             <lb ed="#V" n="86"/>illa re ad quam habendam est de necessitate obligatus. Sed 
             nul<lb ed="#V" n="87" break="no"/>lus inordinatus motus posset stare cum originali iustitia. 
-            Infi<lb ed="#V" n="88" break="no"/>delium autem in quibus per baptismum fuit remissum loriginale 
+            Infi<lb ed="#V" n="88" break="no"/>delium autem in quibus per baptismum fuit remissum originale 
             <lb ed="#V" n="89"/>peccatum: sicut sunt heretici: non omnis motus inordinatus est peccatum 
             <lb ed="#V" n="90"/>mortale: quia non sunt obligati ad rectitudinem originalis iu 
             <lb ed="#V" n="91"/>stitie. In vtrisque tamen possunt esse aliquae operationes: quae nec peccata sunt 
             <lb ed="#V" n="92"/>mortalia: nec venialia: sed magis sunt dispositiones: quamuis 
             val<lb ed="#V" n="93" break="no"/>de remote: ad hoc vt deus per fidem eos illuminet: eo modo quo 
-            <lb ed="#V" n="94"/>dicimus hominem se ad bonum disponere qui secndum regulam luminis 
+            <lb ed="#V" n="94"/>dicimus hominem se ad bonum disponere qui secundum regulam luminis 
             <lb ed="#V" n="95"/>naturalis rectius quam potest operatur.
           </p>
           <p xml:id="kzz7yh-f117877-d1e511">

--- a/kzz7yh-f117877/cod-ve09v2_kzz7yh-f117877.xml
+++ b/kzz7yh-f117877/cod-ve09v2_kzz7yh-f117877.xml
@@ -109,7 +109,7 @@
             <lb ed="#V" n="101"/>dico quod non sufficit ad meritum intentio sine opere exteriori: quia 
             <lb ed="#V" n="102"/>tunc non potest esse intentio sufficiens: nec recta: nisi homo faciat opus 
             <lb ed="#V" n="103"/>exterius: quod praeceptum est. Quia sicut dicit Greg. in quadam hom. 
-            <lb ed="#V" n="104"/>super illud Io. 14. Siquis diligit me etc. et legitur in die Pentecosten. 
+            <lb ed="#V" n="104"/>super illud Io. 14. Si quis diligit me etc. et legitur in die Pentecosten. 
             <lb ed="#V" n="105"/>numquam est amor dei ociosus: operatur enim magna si est. Si autem 
             <lb ed="#V" n="106"/>operari renuit: amor non est: et secundum hunc modum procedunt 
             arguon<lb ed="#V" n="107" break="no"/>ad primam partem. Si autem homo non habeat facultatem operandi: tunc 

--- a/kzz7yh-f117877/cod-ve09v2_kzz7yh-f117877.xml
+++ b/kzz7yh-f117877/cod-ve09v2_kzz7yh-f117877.xml
@@ -99,7 +99,7 @@
           </p>
           <p xml:id="kzz7yh-f117877-d1e167">
             ¶ Item Ber. de 
-            <lb ed="#V" n="96"/>libei arbitrii non multum ante finem libro dicit quod sola interdum 
+            <lb ed="#V" n="96"/>libero arbitrio non multum ante finem libro dicit quod sola interdum 
             bo<lb ed="#V" n="97" break="no"/>na voluntas sufficit et intelligit quo ad meritum: quod non esset 
             <lb ed="#V" n="98"/>verum: si numquam sufficeret intentio recta sine exteriori opere. 
           </p>
@@ -109,7 +109,7 @@
             <lb ed="#V" n="101"/>dico quod non sufficit ad meritum intentio sine opere exteriori: quia 
             <lb ed="#V" n="102"/>tunc non potest esse intentio sufficiens: nec recta: nisi homo faciat opus 
             <lb ed="#V" n="103"/>exterius: quod praeceptum est. Quia sicut dicit Greg. in quadam hom. 
-            <lb ed="#V" n="104"/>super illud Io. 14. Siqus diligit me etc. et legitur in die pecenth. 
+            <lb ed="#V" n="104"/>super illud Io. 14. Siquis diligit me etc. et legitur in die Pentecosten. 
             <lb ed="#V" n="105"/>numquam est amor dei ociosus: operatur enim magna si est. Si autem 
             <lb ed="#V" n="106"/>operari renuit: amor non est: et secundum hunc modum procedunt 
             arguon<lb ed="#V" n="107" break="no"/>ad primam partem. Si autem homo non habeat facultatem operandi: tunc 
@@ -160,7 +160,7 @@
             inten<lb ed="#V" n="10" break="no"/>tio secundum habitum.
           </p>
           <p xml:id="kzz7yh-f117877-d1e278">
-            ¶ Item secundum Ber. libo de libei arbitrii parum ante 
+            ¶ Item secundum Ber. libo de libero arbitrio parum ante 
             <lb ed="#V" n="11"/>finem. In his tribus interior renouatio consistit: videlicet 
             recti<lb ed="#V" n="12" break="no"/>tudine intentionis puritate affectionis recordatione bone 
             <lb ed="#V" n="13"/>operationis. Sed affectio et recordatio pro actibus accipiuntur 
@@ -202,7 +202,7 @@
           </p>
           <p xml:id="kzz7yh-f117877-d1e355">
             <lb ed="#V" n="42"/>¶ Ad secundum dicendum quod volens ea que sunt ad finem vult in 
-            vir<lb ed="#V" n="43" break="no"/>tute finis: autem quia an hoc finem voluit actu et experlicite. Aut quoa 
+            vir<lb ed="#V" n="43" break="no"/>tute finis: autem quia an hoc finem voluit actu et experlicite. Aut quia 
             <lb ed="#V" n="44"/>in volendo quicquid est ad finem vult finem actualiter implicite vel 
             <lb ed="#V" n="45"/>explicite sic intelligens conclusionem actualiter intelligit principium 
             <lb ed="#V" n="46"/>implicite vel explicite.
@@ -308,7 +308,7 @@
             <lb ed="#V" n="105"/>Ad primum dicendum quod auctoritas illa Apostoli aut 
             intelli<lb ed="#V" n="106" break="no"/>genda est cum reduplicatione sub hoc 
             sen<lb ed="#V" n="107" break="no"/>su. Omne quod non est ex fide: inquantum non ex fide: aut quod omnis <!--word--> talis 
-            actio<lb ed="#V" n="108" break="no"/>dicitur esse peccatum: quia semper est cum peccato. Ul secndum vnam Glo. ibidem ibi 
+            actio<lb ed="#V" n="108" break="no"/>dicitur esse peccatum: quia semper est cum peccato. Uel secundum vnam Glo. ibidem ibi 
             ac<lb ed="#V" n="109" break="no"/>cipitur non esse ex fide pro esse contra fidem.
           </p>
           <p xml:id="kzz7yh-f117877-d1e550">


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve09v2_kzz7yh-f117877.xml`.

## Applied changes

- p. 165v l. 119: itinerus → itineris: incorrect genitive of iter; correct form is itineris
- p. 165v l. 124: sinfficit → sufficit: garbled spelling
- p. 166r l. 11: videliet → videlicet: missing letter c
- p. 166r l. 16: opismus → opus: garbled word; context is 'tunc opus meritorium posset esse'
- p. 166r l. 32: vuli → vult: missing letter t
- p. 166r l. 42: dicendum:r → dicendum: spurious ':r' appended
- p. 166r l. 45: princium → principium: missing letters 'ipi'
- p. 166r l. 55: circumnstantie → circumstantie: extraneous n
- p. 166r l. 72: opue → opus: garbled form of opus
- p. 166r l. 74: Idon → Ideo: misread o as n
- p. 166r l. 80: rectitudis → rectitudinis: missing letters 'ini'
- p. 166r l. 88: loriginale → originale: spurious leading l (misread from preceding word)
- p. 166r l. 94: secndum → secundum: missing letter u

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_