### PR TITLE
Transcription corrections: cod-ve09v2_kzz7yh-f118353.xml (21 changes)

### DIFF
--- a/kzz7yh-f118353/cod-ve09v2_kzz7yh-f118353.xml
+++ b/kzz7yh-f118353/cod-ve09v2_kzz7yh-f118353.xml
@@ -177,7 +177,8 @@
             ¶ Ad 2m quod vt concludere quod omne peccatum veniale 
             <lb ed="#V" n="56"/>possit vitari et in vniversali: dicendum quod in processu eius est fallatia: sicut 
             <lb ed="#V" n="57"/>si argueretur sic. Iste potest vitare ne deiiciatur ab isto homine signato 
-            <lb ed="#V" n="58"/><lb ed="#V" n="59" break="no"/>uisim: sic potest vitare ne deiiciatur ab omnibus simul. Sic dico quod non 
+            <lb ed="#V" n="58"/>vt ab herode: et etiam ne deiiciatur a lisia: et sic de pluribus aliis 
+            di<lb ed="#V" n="59" break="no"/>uisim: sic potest vitare ne deiiciatur ab omnibus simul. Sic dico quod non 
             <lb ed="#V" n="60"/>valet argumentum homo potest vitare quodlibet peccatum 
             <lb ed="#V" n="61"/>veniale diuisim: ergo potest simul omnia vitare. 
           </p>

--- a/kzz7yh-f118353/cod-ve09v2_kzz7yh-f118353.xml
+++ b/kzz7yh-f118353/cod-ve09v2_kzz7yh-f118353.xml
@@ -109,7 +109,7 @@
           <p xml:id="kzz7yh-f118353-d1e188">
             <lb ed="#V" n="5"/>Contra <ref xml:id="kzz7yh-f118353-Rd1e206">Aug. in libro de vera relig.</ref> prope medium locum 
             <lb ed="#V" n="6"/>inter principium et medium libro dicit quod si voluntate 
-            <lb ed="#V" n="7"/>non malefacimus nemo obiungandus omnio: aut <!--should be mouendus?-->moueudus est: 
+            <lb ed="#V" n="7"/>non malefacimus nemo obiungandus omnino: aut mouendus est: 
             <lb ed="#V" n="8"/>quibus sublatis christiana lex disciplina omnis religionis auferatur 
             <lb ed="#V" n="9"/>necesse est: voluntate ergo peccatur.
           </p>
@@ -177,8 +177,7 @@
             ¶ Ad 2m quod vt concludere quod omne peccatum veniale 
             <lb ed="#V" n="56"/>possit vitari et in vniversali: dicendum quod in processu eius est fallatia: sicut 
             <lb ed="#V" n="57"/>si argueretur sic. Iste potest vitare ne deiiciatur ab isto homine signato 
-            <lb ed="#V" n="58"/>vt ab herode: et est ne deiiciatur a lisia: et sic de pluribus aliis 
-            di<lb ed="#V" n="59" break="no"/>uisim: sic potest vitare ne deiiciatur ab omnibus simul. Sic dico quod non 
+            <lb ed="#V" n="58"/><lb ed="#V" n="59" break="no"/>uisim: sic potest vitare ne deiiciatur ab omnibus simul. Sic dico quod non 
             <lb ed="#V" n="60"/>valet argumentum homo potest vitare quodlibet peccatum 
             <lb ed="#V" n="61"/>veniale diuisim: ergo potest simul omnia vitare. 
           </p>
@@ -218,7 +217,7 @@
           <p xml:id="kzz7yh-f118353-d1e382">
             ¶ Item secundum philosophum. 2. Top. 
             <lb ed="#V" n="78"/>opposita nata sunt fieri circa idem. Sed peccatum opponitur 
-            <lb ed="#V" n="79"/>actui virtuoso. Actus autem virtuosus tantum non est in volutate: sie 
+            <lb ed="#V" n="79"/>actui virtuoso. Actus autem virtuosus tantum non est in voluntate: sicut 
             <lb ed="#V" n="80"/>in subiecto: sed est in intellectu. Unde philosophus. 1. libro ethi. ca. vltimo 
             di<lb ed="#V" n="81" break="no"/>uidit virtutes in intellectuales et moraliter: ergo non omne peccatum est 
             <lb ed="#V" n="82"/>in voluntate sicut in subiecto: sed est aliquod in intellectu. 
@@ -267,10 +266,10 @@
           </p>
           <p xml:id="kzz7yh-f118353-d1e472">
             ¶ Ad 
-            <lb ed="#V" n="112"/>secundum dicendum: quod maior falsa est: si vniverliter accipiatur: honoratus enim 
+            <lb ed="#V" n="112"/>secundum dicendum: quod maior falsa est: si vniversaliter accipiatur: honoratus enim 
             de<lb ed="#V" n="113" break="no"/>nominatur ab honore: qui tamen secundum philosophum. I ethi. ca. 6. magis esse videtur in 
             <lb ed="#V" n="114"/>honorantibus quam inhonorato: agens etiam denominatur ab exteriori 
-            <lb ed="#V" n="115"/>actione: quiae tamen secundum philosophum. 3. phy. est in passo. sicut in subianto: ita 
+            <lb ed="#V" n="115"/>actione: quae tamen secundum philosophum. 3. phy. est in passo. sicut in subiecto: ita 
             <lb ed="#V" n="116"/>dico quod potest voluntas dici peccatrix propter peccatum quod non est in 
             <lb ed="#V" n="117"/>ea: sicut in subiecto: quia est ab ea tamquam a mouente: et est alia 
             poten<lb ed="#V" n="118" break="no"/>tia: sicut a voluntate mota.
@@ -351,10 +350,10 @@
             <lb ed="#V" n="20"/>et sic dico quod quantum ad suum completum esse solam respicit 
             volun<lb ed="#V" n="21" break="no"/>tatem. Nemo enim miser est ex sola lesione. Sed ex hoc quod leditur et 
             <lb ed="#V" n="22"/>scit se ledi et non vltra se ledi: vnde miseria proprie loquendo non potest 
-            <lb ed="#V" n="23"/>esse nisi in creatura rationali vnivesal intellectuali.
+            <lb ed="#V" n="23"/>esse nisi in creatura rationali vel intellectuali.
           </p>
           <p xml:id="kzz7yh-f118353-d1e619">
-            ¶ 4uo 
+            ¶ 4o 
             propriissi<lb ed="#V" n="24" break="no"/>me inquantum est nocumentum nature: et instrumentum divinae iustitie: siue inquantum 
             <lb ed="#V" n="25"/>est passio et vltio: et sic dico quod pena solam respicit voluntatem: 
             <lb ed="#V" n="26"/>deus enim non vlciscitur se: nisi de voluntate: vnde quamuis affligantur 
@@ -362,7 +361,7 @@
             volunta<lb ed="#V" n="28" break="no"/>te in afflictione membrorum vnde Anselmus libro de concep. vergi. cap. 4. 
             <lb ed="#V" n="29"/>sic aiti. miratur forte aliquis cur pro culpa voluntatis membra 
             pu<lb ed="#V" n="30" break="no"/>niuntur et sensus: verum non ita est: non enim punitur nisi voluntas: 
-            <lb ed="#V" n="31"/>nam nihil est alicus pena: nisi quod est contra voluntatem: et nulla res 
+            <lb ed="#V" n="31"/>nam nihil est alicuius pena: nisi quod est contra voluntatem: et nulla res 
             <lb ed="#V" n="32"/>penam sentit: nisi quae habet voluntatem: membra autem et sensus per se 
             <lb ed="#V" n="33"/>nihil volunt: sicut igitur voluntas in membris et sensibus operatur: 
             <lb ed="#V" n="34"/>ita in ipsis illa torquetur aut delectatur. 
@@ -372,7 +371,7 @@
             pro<lb ed="#V" n="36" break="no"/>prie loquendo non est pena: nisi inquantum <!--word-->
             <lb ed="#V" n="37"/>talis afflictio per deordinationem voluntatis primi parentis 
             <lb ed="#V" n="38"/>est exorta: inquantum tamen pena dicitur afflictio causata ex sensu lesionis 
-            <lb ed="#V" n="39"/>quam refugit sensibitur appetitus quae durante statu innocentie: non 
+            <lb ed="#V" n="39"/>quam refugit sensibilis appetitus quae durante statu innocentie: non 
             <lb ed="#V" n="40"/>fuisset sic pena est.
           </p>
           <p xml:id="kzz7yh-f118353-d1e662">

--- a/kzz7yh-f118353/cod-ve09v2_kzz7yh-f118353.xml
+++ b/kzz7yh-f118353/cod-ve09v2_kzz7yh-f118353.xml
@@ -75,7 +75,7 @@
           <p xml:id="kzz7yh-f118353-d1e129">
             Quaestio I. 
             <lb ed="#V" n="122"/>PRimo ostendo quod non omne peccatum 
-            <lb ed="#V" n="123"/>sit volantarium 
+            <lb ed="#V" n="123"/>sit voluntarium 
             <lb ed="#V" n="124"/>omne ex deliberatione voluntatum potest vitari. 
             <lb ed="#V" n="125"/>Sed non omnia peccata possunt vitari. dicit enim 
             <lb ed="#V" n="126"/>beatus <ref xml:id="kzz7yh-f118353-Rd1e148">Ioan. in prima <!--word?-->cantee. cap. I.</ref> Si dixerimus: quoniam peccatum non 
@@ -116,7 +116,7 @@
           <p xml:id="kzz7yh-f118353-d1e201">
             ¶ Item demonstrato quo 
             <lb ed="#V" n="10"/>cumque peccato: ita potest dici voluntarium quod per voluntatem potest 
-            vi<lb ed="#V" n="11" break="no"/>tari vel potuit praecaueri: ergo videtur quod omnia simul ita sunt volutaria: 
+            vi<lb ed="#V" n="11" break="no"/>tari vel potuit praecaueri: ergo videtur quod omnia simul ita sunt voluntaria: 
             <lb ed="#V" n="12"/>quod per voluntatem possunt vitari vel potuerunt praecaueri. 
           </p>
           <p xml:id="kzz7yh-f118353-d1e210">
@@ -124,9 +124,9 @@
             <lb ed="#V" n="14"/>intelligi. Uno modo a voluntate vt a 
             <lb ed="#V" n="15"/>causa prima et remota quae fuit voluntas alterius persone ab illa persona: 
             <lb ed="#V" n="16"/>in qua est peccatum: et sic peccatum originale voluntarium dici potest 
-            <lb ed="#V" n="17"/>vnde <ref xml:id="kzz7yh-f118353-Rd1e242">Aug. 1. li. retrac. ca. 12.</ref> Illud quod in peruulis dicitur originale 
+            <lb ed="#V" n="17"/>vnde <ref xml:id="kzz7yh-f118353-Rd1e242">Aug. 1. li. retrac. ca. 12.</ref> Illud quod in paruulis dicitur originale 
             <lb ed="#V" n="18"/>peccatum: cum ad hoc non vtantur arbitrio voluntatis non absurdum 
-            <lb ed="#V" n="19"/>vocatur: etia voluntarium: quia ex prima hominis mala voluntate contractum: 
+            <lb ed="#V" n="19"/>vocatur: etiam voluntarium: quia ex prima hominis mala voluntate contractum: 
             <lb ed="#V" n="20"/>factum est quodam modo hereditarium.
           </p>
           <p xml:id="kzz7yh-f118353-d1e230">
@@ -142,9 +142,9 @@
           <p xml:id="kzz7yh-f118353-d1e248">
             ¶ Alio 
             <lb ed="#V" n="28"/>modo potest intelligi peccatum esse voluntarium a voluntate: vt a causa 
-            pro<lb ed="#V" n="29" break="no"/>xima et immediata quae est propositia peccantis voluntas: ita vt possit 
+            pro<lb ed="#V" n="29" break="no"/>xima et immediata quae est propria peccantis voluntas: ita vt possit 
             <lb ed="#V" n="30"/>vitari: vel praecaueri eorum quodlibet in particulari: sed non in vniversali: et 
-            <lb ed="#V" n="31"/>sic peccatum veniale est voluntarium: demtrato enim quolibet venia 
+            <lb ed="#V" n="31"/>sic peccatum veniale est voluntarium: demonstrato enim quolibet venia 
             <lb ed="#V" n="32"/>li peccato singulari vere potest dici: quod homo potest illud vitare: aut quod 
             <lb ed="#V" n="33"/>potuit praecauere: non tamen est possibile de lege communi: quod homo in statu 
             <lb ed="#V" n="34"/>nature lapse vitam pertranseat: habens vsum libe. arbitri absque omni peccato 
@@ -159,7 +159,7 @@
             homo<lb ed="#V" n="42" break="no"/>vitare ne vnquam incidat in aliquod veniale peccatum: quamuis 
             quod<lb ed="#V" n="43" break="no"/>licet signatum possit ab ipso vitari vel praecaueri: sicut in naui 
             existen<lb ed="#V" n="44" break="no"/>te in mari in locis pluribus perforata: posset nauta obturare: 
-            <lb ed="#V" n="45"/>quodlibet singulare foramen sibi demtratum: non tamen omnia sunt: et ideo 
+            <lb ed="#V" n="45"/>quodlibet singulare foramen sibi demonstratum: non tamen omnia sunt: et ideo 
             <lb ed="#V" n="46"/>quamuis posset prohibere introitum aqua per vnum foramen: non tamen 
             <lb ed="#V" n="47"/>posset prohibere omnem aque introitum: quia dum vnum 
             <lb ed="#V" n="48"/>obturaret aqua per alia intraret. 
@@ -219,9 +219,9 @@
             ¶ Item secundum philosophum. 2. Top. 
             <lb ed="#V" n="78"/>opposita nata sunt fieri circa idem. Sed peccatum opponitur 
             <lb ed="#V" n="79"/>actui virtuoso. Actus autem virtuosus tantum non est in volutate: sie 
-            <lb ed="#V" n="80"/>in subieato: sed est in intellectu. Unde philosophus. 1. libro ethi. ca. vltimo 
+            <lb ed="#V" n="80"/>in subiecto: sed est in intellectu. Unde philosophus. 1. libro ethi. ca. vltimo 
             di<lb ed="#V" n="81" break="no"/>uidit virtutes in intellectuales et moraliter: ergo non omne peccatum est 
-            <lb ed="#V" n="82"/>in voluntate sicut in subieanto: sed est aliquod in intellectu. 
+            <lb ed="#V" n="82"/>in voluntate sicut in subiecto: sed est aliquod in intellectu. 
           </p>
           <p xml:id="kzz7yh-f118353-d1e395">
             <lb ed="#V" n="83"/>Respondeo secundum quosdam quod omne quod est principium 
@@ -250,10 +250,10 @@
             <lb ed="#V" n="100"/>potentie potest esse subiectum illius actus qui est peccatum. Idem dico 
             si<lb ed="#V" n="101" break="no"/>loquamur de peccato: quantum ad deordinationem actus: hoc 
             exce<lb ed="#V" n="102" break="no"/>pto: quia actus deordinatus potest esse in alia potentia a 
-            volunta<lb ed="#V" n="103" break="no"/>te: sicut in subieto immediato: deordinatio autem actus est in ipso 
+            volunta<lb ed="#V" n="103" break="no"/>te: sicut in subiecto immediato: deordinatio autem actus est in ipso 
             <lb ed="#V" n="104"/>actu: sicut in immediato subito: et mediante ipso actu est in 
             po<lb ed="#V" n="105" break="no"/>tentia: sicut in subieto. Si autem loquamur 3o modo: sic dico quod omne 
-            <lb ed="#V" n="106"/>peccatum est in sola voluntate: sicut in subieanto: quia ratio 
+            <lb ed="#V" n="106"/>peccatum est in sola voluntate: sicut in subiecto: quia ratio 
             culpabili<lb ed="#V" n="107" break="no"/>tatis actus deordinati est in sola voluntate: sicut in subito. 
           </p>
           <p xml:id="kzz7yh-f118353-d1e457">
@@ -272,7 +272,7 @@
             <lb ed="#V" n="114"/>honorantibus quam inhonorato: agens etiam denominatur ab exteriori 
             <lb ed="#V" n="115"/>actione: quiae tamen secundum philosophum. 3. phy. est in passo. sicut in subianto: ita 
             <lb ed="#V" n="116"/>dico quod potest voluntas dici peccatrix propter peccatum quod non est in 
-            <lb ed="#V" n="117"/>ea: sicut in subto: quia est ab ea tamquam a mouente: et est alia 
+            <lb ed="#V" n="117"/>ea: sicut in subiecto: quia est ab ea tamquam a mouente: et est alia 
             poten<lb ed="#V" n="118" break="no"/>tia: sicut a voluntate mota.
           </p>
           <p xml:id="kzz7yh-f118353-d1e490">
@@ -318,8 +318,8 @@
             <!--00347.xml-->
             <pb ed="#V" n="167-r"/>
             <cb ed="#P" n="a"/> <!--I think this extra line needs to be deleted-->
-            <lb ed="#V" n="1"/>Contra <ref xml:id="kzz7yh-f118353-Rd1e604">secundo libro de articum fidei propotione. 15.</ref> Dicitur 
-            volun<lb ed="#V" n="2" break="no"/>tati hominis quantum in ipsa est peremium et penam equum
+            <lb ed="#V" n="1"/>Contra <ref xml:id="kzz7yh-f118353-Rd1e604">secundo libro de articulis fidei propotione. 15.</ref> Dicitur 
+            volun<lb ed="#V" n="2" break="no"/>tati hominis quantum in ipsa est praemium et penam equum
             <lb ed="#V" n="3" break="no"/>est compensari super quod verbum dicit commentum: quod praemium et pena 
             <lb ed="#V" n="4"/>secundum magis et minus inferenda sunt prout voluntas in bono vel 
             <lb ed="#V" n="5"/>malo fuerit intensa: ergo videtur quod praemium et pena solam respiciant 
@@ -329,18 +329,18 @@
             ¶ Item Alanus. 
             <lb ed="#V" n="7"/>73 propositione de maximis theologie dicit penes voluntatem 
             <lb ed="#V" n="8"/>esse omne meritum. Sed praemium et pena respiciunt meritum et 
-            de<lb ed="#V" n="9" break="no"/>meritum: ergo solius voluntatis est proprium peremiari et puniri. 
+            de<lb ed="#V" n="9" break="no"/>meritum: ergo solius voluntatis est proprium praemiari et puniri. 
           </p>
           <p xml:id="kzz7yh-f118353-d1e581">
             <lb ed="#V" n="10"/>Respondeo quod de pena possumus loquens <!--word--> 4r. scilicet 
             communissi<lb ed="#V" n="11" break="no"/>me: prout accipitur pro quaecumque lesiua 
-            pas<lb ed="#V" n="12" break="no"/>sione cum apprehensione eiusde: et sic pena non respicit solam 
+            pas<lb ed="#V" n="12" break="no"/>sione cum apprehensione eiusdem: et sic pena non respicit solam 
             volun<lb ed="#V" n="13" break="no"/>tatem. Sic enim est pena in brutis animalibus. Certum est enim quod 
             sen<lb ed="#V" n="14" break="no"/>sibiliter affliguntur. Sed sic non dicitur pena a puniendo: quia 
             afflictio<lb ed="#V" n="15" break="no"/>nem illam non demeruerunt.
           </p>
           <p xml:id="kzz7yh-f118353-d1e597">
-            ¶ Alio modo possumus loqui de pecea 
+            ¶ Alio modo possumus loqui de pena 
             <lb ed="#V" n="16"/>communiter scilicet prout se extendit ad omnem dolorem qui non potuisset esse 
             <lb ed="#V" n="17"/>in statum innocentie: et sic pena est in membris corporis humani: 
             <lb ed="#V" n="18"/>Dolent enim et dolor in eis durante statu innocentie esse non 
@@ -350,12 +350,12 @@
             ¶ 3o modo proprie scilicet pro lesione: per quam lesus miser efficitur: 
             <lb ed="#V" n="20"/>et sic dico quod quantum ad suum completum esse solam respicit 
             volun<lb ed="#V" n="21" break="no"/>tatem. Nemo enim miser est ex sola lesione. Sed ex hoc quod leditur et 
-            <lb ed="#V" n="22"/>scit se ledi et non vltra se ledi: vnde miseuntia proprie loquendo non potest 
+            <lb ed="#V" n="22"/>scit se ledi et non vltra se ledi: vnde miseria proprie loquendo non potest 
             <lb ed="#V" n="23"/>esse nisi in creatura rationali vnivesal intellectuali.
           </p>
           <p xml:id="kzz7yh-f118353-d1e619">
             ¶ 4uo 
-            propriissi<lb ed="#V" n="24" break="no"/>me inquantum est nocumium nature: et insttrum divinae iustitie: siue iquantum 
+            propriissi<lb ed="#V" n="24" break="no"/>me inquantum est nocumentum nature: et instrumentum divinae iustitie: siue inquantum 
             <lb ed="#V" n="25"/>est passio et vltio: et sic dico quod pena solam respicit voluntatem: 
             <lb ed="#V" n="26"/>deus enim non vlciscitur se: nisi de voluntate: vnde quamuis affligantur 
             <lb ed="#V" n="27"/>corporis membra: non tamen deus vlciscitur se de membris: sed de 
@@ -364,11 +364,11 @@
             pu<lb ed="#V" n="30" break="no"/>niuntur et sensus: verum non ita est: non enim punitur nisi voluntas: 
             <lb ed="#V" n="31"/>nam nihil est alicus pena: nisi quod est contra voluntatem: et nulla res 
             <lb ed="#V" n="32"/>penam sentit: nisi quae habet voluntatem: membra autem et sensus per se 
-            <lb ed="#V" n="33"/>nihil volunt: sicut igiater voluntas in membris et sensibus operatur: 
+            <lb ed="#V" n="33"/>nihil volunt: sicut igitur voluntas in membris et sensibus operatur: 
             <lb ed="#V" n="34"/>ita in ipsis illa torquetur aut delectatur. 
           </p>
           <p xml:id="kzz7yh-f118353-d1e645">
-            <lb ed="#V" n="35"/>Ad primum in opositum dicendum: quod afflictio peruulorum 
+            <lb ed="#V" n="35"/>Ad primum in opositum dicendum: quod afflictio paruulorum 
             pro<lb ed="#V" n="36" break="no"/>prie loquendo non est pena: nisi inquantum <!--word-->
             <lb ed="#V" n="37"/>talis afflictio per deordinationem voluntatis primi parentis 
             <lb ed="#V" n="38"/>est exorta: inquantum tamen pena dicitur afflictio causata ex sensu lesionis 


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve09v2_kzz7yh-f118353.xml`.

## Applied changes

- p. 166r l. 123: volantarium → voluntarium: a/u transposition
- p. 166v l. 11: volutaria → voluntaria: missing n
- p. 166v l. 17: peruulis → paruulis: e/a misread
- p. 166v l. 19: etia → etiam: missing final m
- p. 166v l. 29: propositia → propria: garbled; context is 'propria peccantis voluntas'
- p. 166v l. 31: demtrato → demonstrato: missing letters 'ons'
- p. 166v l. 45: demtratum → demonstratum: missing letters 'ons'
- p. 166v l. 80: subieato → subiecto: garbled; ea → ec misread
- p. 166v l. 82: subieanto → subiecto: garbled form of subiecto
- p. 166v l. 103: subieto → subiecto: missing c
- p. 166v l. 106: subieanto → subiecto: garbled form of subiecto
- p. 166v l. 117: subto → subiecto: garbled form of subiecto
- p. 167r l. 1: articum → articulis: garbled; context is 'libro de articulis fidei'
- p. 167r l. 2: peremium → praemium: garbled; context is praemium et poenam
- p. 167r l. 9: peremiari → praemiari: garbled form of praemiari (to be rewarded)
- p. 167r l. 12: eiusde → eiusdem: missing final m
- p. 167r l. 15: pecea → pena: garbled; context is 'loqui de pena communiter'
- p. 167r l. 22: miseuntia → miseria: garbled; context is 'miseria proprie loquendo non potest esse nisi in creatura rationali'
- p. 167r l. 24: nocumium → nocumentum: garbled; insttrum → instrumentum: garbled; iquantum → inquantum: missing n
- p. 167r l. 33: igiater → igitur: garbled form of igitur
- p. 167r l. 35: peruulorum → paruulorum: e/a misread

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_