### PR TITLE
Transcription corrections: cod-ve09v2_kzz7yh-f119594.xml (10 changes)

### DIFF
--- a/kzz7yh-f119594/cod-ve09v2_kzz7yh-f119594.xml
+++ b/kzz7yh-f119594/cod-ve09v2_kzz7yh-f119594.xml
@@ -182,7 +182,7 @@
           </p>
           <p xml:id="kzz7yh-f119594-d1e319">
             <lb ed="#V" n="116"/>Contra <ref xml:id="kzz7yh-f119594-Rd1e342">Apoc. cap. 18.</ref> dicitur quantum se glorificauit: et in 
-            <lb ed="#V" n="117"/>delitiis suis tantum date illi tormentum et luctum: 
+            <lb ed="#V" n="117"/><sic>delitiis</sic> suis tantum date illi tormentum et luctum: 
             <lb ed="#V" n="118"/>Sed magis est delectatio in deordinato actum exteriori et 
             <lb ed="#V" n="119"/>interiori simul: quam in interiori tantum: ergo maiorem meretur penam per 
             <lb ed="#V" n="120"/>vtrumque eorum simul quam per interiorem tantum.
@@ -194,7 +194,7 @@
           </p>
           <p xml:id="kzz7yh-f119594-d1e340">
             ¶ Item <ref xml:id="kzz7yh-f119594-Rd1e365">Aug. 
-              <lb ed="#V" n="123"/>lib. 1. de libe. arberi</ref> ante medium dicit nihil esse iustum in lege 
+              <lb ed="#V" n="123"/>lib. 1. de libero arbitrio</ref> ante medium dicit nihil esse iustum in lege 
             tem<lb ed="#V" n="124" break="no"/>porali atque legitimum: quod non ex eterna lege sibi homines 
             deri<lb ed="#V" n="125" break="no"/>uauerunt. Sed secundum temporalem legem iuste magis punitur homo propter 
             ma<lb ed="#V" n="126" break="no"/>lum voluntatis actum interiorem et exteriorem simul: quam propter 

--- a/kzz7yh-f119594/cod-ve09v2_kzz7yh-f119594.xml
+++ b/kzz7yh-f119594/cod-ve09v2_kzz7yh-f119594.xml
@@ -63,7 +63,7 @@
           <lb ed="#V" n="43"/>peccatum.
         </p>
         <p xml:id="kzz7yh-f119594-d1e112">
-          ¶ 2o vtrum plius demereatur peccans per vtrumque illorum actuum 
+          ¶ 2o vtrum plus demereatur peccans per vtrumque illorum actuum 
           <lb ed="#V" n="44"/>quam per actum voluntatis interiorem tantum. 
         </p>
         <div xml:id="kzz7yh-f119594-Dd1e117">
@@ -83,18 +83,18 @@
             ¶ Item multiplicato inferiori 
             multi<lb ed="#V" n="52" break="no"/>plicatur superius. Sed peccatum est superius ad actionem malam: omnis enim 
             <lb ed="#V" n="53"/>actio mala semper est peccatum: sed non conuertitur: peccatum enim 
-            omissio<lb ed="#V" n="54" break="no"/>nis non est actio mala: ergo cum inordinatus actus exterior et inordima 
+            omissio<lb ed="#V" n="54" break="no"/>nis non est actio mala: ergo cum inordinatus actus exterior et inordina 
             <lb ed="#V" n="55"/>tus actus interior sint due actiones male videtur quod sint duo 
             pec<lb ed="#V" n="56" break="no"/>cata.
           </p>
           <p xml:id="kzz7yh-f119594-d1e152">
-            ¶ Item multiplicato subiento multiplicatur accidens: sed actus 
+            ¶ Item multiplicato subiecto multiplicatur accidens: sed actus 
             <lb ed="#V" n="57"/>est subiectum deordinationis: ergo cum actus exterior et interior sint 
             <lb ed="#V" n="58"/>duo actus: videtur quod in eis sint due deordinationes: et 
             <lb ed="#V" n="59"/>ex consequenti duo peccata vt videtur. 
           </p>
           <p xml:id="kzz7yh-f119594-d1e161">
-            <lb ed="#V" n="60"/>Contra <ref xml:id="kzz7yh-f119594-Rd1e174">philosophus. 3.</ref> Topi vbi vnum propter alterum nihil magis 
+            <lb ed="#V" n="60"/>Contra <ref xml:id="kzz7yh-f119594-Rd1e174">philosophus. 3.</ref> Topicorum vbi vnum propter alterum nihil magis 
             <lb ed="#V" n="61"/>eligendum vtraque quam vnum: ergo a simili: nec magis 
             <lb ed="#V" n="62"/>culpandum. Sed actus exterior non est peccatum nisi propter actum 
             inte<lb ed="#V" n="63" break="no"/>riorem: ergo illi duo actus non sunt nisi vnum peccatum.
@@ -111,9 +111,9 @@
           </p>
           <p xml:id="kzz7yh-f119594-d1e191">
             <lb ed="#V" n="69"/>Respondeo quod de interiori actu voluntatis et 
-            <lb ed="#V" n="70"/>exteriori possumus loque dupliciter. Aut 
+            <lb ed="#V" n="70"/>exteriori possumus loqui dupliciter. Aut 
             <lb ed="#V" n="71"/>comparando exteriorem actum ad actum voluntatis a quo non 
-            <lb ed="#V" n="72"/>catur: et sic planum est quod non sunt vnum peccatum. Aliud enim peccatum 
+            <lb ed="#V" n="72"/>causatur: et sic planum est quod non sunt vnum peccatum. Aliud enim peccatum 
             <lb ed="#V" n="73"/>est fornicari ab actu volendi fornicationem qui fornicationis 
             <lb ed="#V" n="74"/>illius causa non fuit. Uel comparando actum exteriorem ad actum 
             vo<lb ed="#V" n="75" break="no"/>luntatis interiorem a quo caustur. Et sic dico quod formaliter sunt 
@@ -140,7 +140,7 @@
             <lb ed="#V" n="92"/>in esse moris: vnde et in eis non est nisi vna moralis malitia. 
           </p>
           <p xml:id="kzz7yh-f119594-d1e251">
-            <lb ed="#V" n="93"/>¶ Ad tertium dicendum: quod in duobus subientis quantum ad esse nature potest 
+            <lb ed="#V" n="93"/>¶ Ad tertium dicendum: quod in duobus subiectis quantum ad esse nature potest 
             <lb ed="#V" n="94"/>esse vna moralis malitia: non tamen eam primo Sed in vno primo et per se 
             <lb ed="#V" n="95"/>in alio autem ex sui comparatione ad aliud. Sic dico quod moralis 
             <lb ed="#V" n="96"/>malitia primo et per se est in actu deordinato voluntatis 
@@ -162,7 +162,7 @@
             <lb ed="#V" n="102"/>SEcundo queritur vtrum peccans plus
             de<lb ed="#V" n="103" break="no"/>mereatur per vtrumque illorum actuum 
             <lb ed="#V" n="104"/>quam per actum voluntatis interiorem tantum. Et videtur quod 
-            <lb ed="#V" n="105"/>non <ref xml:id="kzz7yh-f119594-Rd1e307">Glo.</ref> super illud pslamum. Et enim iniquitates in corde
+            <lb ed="#V" n="105"/>non <ref xml:id="kzz7yh-f119594-Rd1e307">Glo.</ref> super illud psalmum. Et enim iniquitates in corde
             <lb ed="#V" n="106"/>dicit quod si vis et non potes deus factum reputat.
           </p>
           <p xml:id="kzz7yh-f119594-d1e295">
@@ -189,7 +189,7 @@
           </p>
           <p xml:id="kzz7yh-f119594-d1e333">
             ¶ Item <ref xml:id="kzz7yh-f119594-Rd1e356">Aug. 13. de tri. c. 5.</ref> 
-            <lb ed="#V" n="121"/>mala enim voluntate vel sola quisque miser efficitur. Sed misernior 
+            <lb ed="#V" n="121"/>mala enim voluntate vel sola quisque miser efficitur. Sed miserior 
             <lb ed="#V" n="122"/>potestate qua desiderium male voluntatis impletur.
           </p>
           <p xml:id="kzz7yh-f119594-d1e340">
@@ -245,7 +245,7 @@
             <lb ed="#V" n="23"/>Sed damnati bene habent aliquam penam accidentalem: quia plura damna 
             intu<lb ed="#V" n="24" break="no"/>lerunt: et pluribus nocuerunt et plus delectati sunt quam si opera 
             <lb ed="#V" n="25"/>exteriora facere non potuissent. Essentialis enim pena 
-            mensu<lb ed="#V" n="26" break="no"/>ratur secndum intensionem dei conceptum vel minus intensum: non sic autem 
+            mensu<lb ed="#V" n="26" break="no"/>ratur secundum intensionem dei conceptum vel minus intensum: non sic autem 
             <lb ed="#V" n="27"/>est de accidentali pena.
           </p>
           <p xml:id="kzz7yh-f119594-d1e447">


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve09v2_kzz7yh-f119594.xml`.

## Applied changes

- p. 168r l. 43: plius → plus: spurious l
- p. 168r l. 54: inordima → inordina: m/n misread in stem before line break (inordinatus)
- p. 168r l. 56: subiento → subiecto: garbled form of subiecto
- p. 168r l. 60: Topi → Topicorum: abbreviated reference to Aristotle's Topica; full form is Topicorum
- p. 168r l. 70: loque → loqui: missing final i; not an l/I misread — should be loqui (infinitive)
- p. 168r l. 72: catur → causatur: missing letters 'au'; context is 'actum ad actum voluntatis a quo non causatur'
- p. 168r l. 93: subientis → subiectis: garbled form of subiectis (in two subjects)
- p. 168r l. 105: pslamum → psalmum: transposed letters
- p. 168r l. 121: misernior → miserior: extraneous n
- p. 168v l. 26: secndum → secundum: missing letter u

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_