### PR TITLE
Transcription corrections: cod-ve09v2_kzz7yh-f119957.xml (14 changes)

### DIFF
--- a/kzz7yh-f119957/cod-ve09v2_kzz7yh-f119957.xml
+++ b/kzz7yh-f119957/cod-ve09v2_kzz7yh-f119957.xml
@@ -121,7 +121,7 @@
             <lb ed="#V" n="65"/>lex humana aliquid prohibet fieri et statuit: vt illud prohibitum 
             <lb ed="#V" n="66"/>faciens aliqua pena determinata puniatur. Si aliquis illud 
             prohi<lb ed="#V" n="67" break="no"/>bitum commiserit remanet obligatus ad penam: quamuis actus 
-            com<lb ed="#V" n="68" break="no"/>missionis transerit quousque pro lllo peccato fuerit satisfactum. 
+            com<lb ed="#V" n="68" break="no"/>missionis transerit quousque pro illo peccato fuerit satisfactum. 
             <!--00350.xml-->
             <cb ed="#P" n="b"/>
           </p>
@@ -139,7 +139,7 @@
             <lb ed="#V" n="76"/>quae peccauerit puniatur cum hoc quod est istum peccasse est casa 
             obliga<lb ed="#V" n="77" break="no"/>tionis istius ad penam: et hoc statutum manet: et istum peccasse: etiam 
             <lb ed="#V" n="78"/>manet obiectiue in legislatoris cognitione: hoc enim adeo cognitum 
-            <lb ed="#V" n="79"/>est. Ad asdicunt aliuo quod obligatio ad penam non est aliqud 
+            <lb ed="#V" n="79"/>est. Ad 2m dicunt aliqui quod obligatio ad penam non est aliquid 
             <lb ed="#V" n="80"/>positiuum: dicit. n. pena priuationem alicuius naturalis boni: vt de. 
             <lb ed="#V" n="81"/>lectationis et quietis
           </p>
@@ -243,7 +243,7 @@
             <lb ed="#V" n="3"/>principium: frui est amore inhaerere alicui rei propter seipsam: ergo amare 
             <lb ed="#V" n="4"/>creaturam ex deliberatione: propter seipsam mortale peccatum est. Sic 
             <lb ed="#V" n="5"/>autem amat eam omnis extra deliberatione peccans: quia amorem suum non 
-            <lb ed="#V" n="6"/>refert in deum: nec actu: sec habitum: quia si amorem suum in deum 
+            <lb ed="#V" n="6"/>refert in deum: nec actu: nec habitum: quia si amorem suum in deum 
             <lb ed="#V" n="7"/>referret amando creaturam non peccaret. Restat ergo quod omnis ex 
             <lb ed="#V" n="8"/>deliberatione peccans mortaliter peccat: quia creaturam propter seipsam 
             <lb ed="#V" n="9"/>amat finem sui amoris statuendo in ea
@@ -254,16 +254,16 @@
             deor<lb ed="#V" n="11" break="no"/>dinationes quas non facerent si faciendo mortaliter peccare 
             crede<lb ed="#V" n="12" break="no"/>rent. Est est irrationalis: quia non tantum cadit deordinatus voluntatis 
             <lb ed="#V" n="13"/>actus a ratione peccati mortalis propter imperfectionem actus: sicut sunt 
-            deor<lb ed="#V" n="14" break="no"/>dinati actus voluntatis procedentes ex surreptione. Sed etiam prter 
+            deor<lb ed="#V" n="14" break="no"/>dinati actus voluntatis procedentes ex surreptione. Sed etiam propter 
             <lb ed="#V" n="15"/>conditionem actionis exterioris volite: quae non est contra vnum de. x. 
             prime<lb ed="#V" n="16" break="no"/>ceptis: nec implicite: nec explicite: nec directe: nec indirecte 
             <lb ed="#V" n="17"/>sicut interdum comedere fructus ad satisfaciendum sensibili 
             ap<lb ed="#V" n="18" break="no"/>petitui: quorum comestionem scit homo corpori suo non prodesse: 
             <lb ed="#V" n="19"/>nec tamen grauiter nocere: hoc enim regulare est quod numquam homo 
             mor<lb ed="#V" n="20" break="no"/>taliter peccat: nisi omittendo vel committendo sit transgressor 
-            prae<lb ed="#V" n="21" break="no"/>ceptis directe vivel per equalentiam cui praecepto de necessitate 
-            obe<lb ed="#V" n="22" break="no"/>dire tenetur. Ron autem pro contraria opinione non cogit: frui enim creatu 
-            <lb ed="#V" n="23"/>ra est ei amoreaiherere propter seipsam tamquam: propter finem vltimum: et 
+            prae<lb ed="#V" n="21" break="no"/>ceptis directe vel per equivalentiam cui praecepto de necessitate 
+            obe<lb ed="#V" n="22" break="no"/>dire tenetur. Ratio autem pro contraria opinione non cogit: frui enim creatu 
+            <lb ed="#V" n="23"/>ra est ei amore inherere propter seipsam tamquam: propter finem vltimum: et 
             <lb ed="#V" n="24"/>principalem. Sic autem numquam a materia nisi quando eius amor diuino 
             amo<lb ed="#V" n="25" break="no"/>ri praeponitur: multi autem amant aliquando ex deliberatione creaturam 
             <lb ed="#V" n="26"/>qui quamuis illum amorem non referant in deum: nec actu nec habitu: 
@@ -277,7 +277,7 @@
             <lb ed="#V" n="34"/>rem non propter amicum: quem tamen plus diligit incomparabiliter quam illam rem. 
           </p>
           <p xml:id="kzz7yh-f119957-d1e498">
-            <lb ed="#V" n="35"/>¶ Uater ergo mihi dicendum ad quaestionem: quod non omne peccatum ex 
+            <lb ed="#V" n="35"/>¶ Videtur ergo mihi dicendum ad quaestionem: quod non omne peccatum ex 
             delibera<lb ed="#V" n="36" break="no"/>tione commissum obligat peccantem ad penam eternam per se: quia sic 
             <lb ed="#V" n="37"/>solum peccatum mortale obligat ad illam: vt declarabo. Sed non omne 
             <lb ed="#V" n="38"/>peccatum ex deliberatione commissum est mortale: vt iam probatum est. 
@@ -290,7 +290,7 @@
             mor<lb ed="#V" n="45" break="no"/>tale hominem obligat ad penam eternam. Sed hoc obligatio in penam 
             <lb ed="#V" n="46"/>temporalem commutatur: si ille qui peccauit ad deum reuertatur per 
             condi<lb ed="#V" n="47" break="no"/>gnam poenitentiam: quia talis poenitentia: gratia gratum faciente formatur: peccatum 
-            <lb ed="#V" n="48"/>autem veniale quia volutatem non auertit a deo: quamuis sit ad 
+            <lb ed="#V" n="48"/>autem veniale quia voluntatem non auertit a deo: quamuis sit ad 
             <lb ed="#V" n="49"/>auersionem quaedam dispositio loquendo de dispositione quae non est 
             necessita<lb ed="#V" n="50" break="no"/>tis: ideo non excludit gratiam gratum facientem ab illo in quo est. 
             <lb ed="#V" n="51"/>Et quia per gratiam gratum facientem ille qui peccauit 
@@ -338,7 +338,7 @@
             <lb ed="#V" n="80"/>non moueatur nisi partialiter adhuc potest remanere in 
             <lb ed="#V" n="81"/>termino a quo: quamuis per illam extensionem propinquior 
             <lb ed="#V" n="82"/>sit separationi a termino a quo primum exemplum competit peccato 
-            <lb ed="#V" n="83"/>mortali: et secundum peccato veniali. Dicas ergo quod Ber. prsimallega 
+            <lb ed="#V" n="83"/>mortali: et secundum peccato veniali. Dicas ergo quod Ber. praeallega 
             <lb ed="#V" n="84"/>ta auctoritas aut intelligi debet de mortali peccato: aut hec 
             <lb ed="#V" n="85"/>praepositio contra extenditur non tantummodo ad 
             deordina<lb ed="#V" n="86" break="no"/>tionem: que est contra mandatum: sed est ad deordinationem 

--- a/kzz7yh-f119957/cod-ve09v2_kzz7yh-f119957.xml
+++ b/kzz7yh-f119957/cod-ve09v2_kzz7yh-f119957.xml
@@ -89,7 +89,7 @@
             <lb ed="#V" n="46"/>¶ Item obligatio ad penam est aliqua relatio positiua: sed talis 
             <lb ed="#V" n="47"/>relatio non manet nisi manente aliquo fundamento eius positiuo est 
             <lb ed="#V" n="48"/>Cum ergo actu peccati transeunte nihil in homine remaneat 
-            positi<lb ed="#V" n="49" break="no"/>uum: quod sit illius obligationis fundamentum videetur quod ipso 
+            positi<lb ed="#V" n="49" break="no"/>uum: quod sit illius obligationis fundamentum videtur quod ipso 
             tran<lb ed="#V" n="50" break="no"/>seunte nulla remaneat ad penam obligatio.
           </p>
           <p xml:id="kzz7yh-f119957-d1e164">
@@ -99,7 +99,7 @@
             <lb ed="#V" n="53"/>non posset non manere: quod falsum est. 
           </p>
           <p xml:id="kzz7yh-f119957-d1e174">
-            <lb ed="#V" n="54"/>Contra nullus iuste punitur nis debitor pene: sec 
+            <lb ed="#V" n="54"/>Contra nullus iuste punitur nisi debitor pene: sed 
             pec<lb ed="#V" n="55" break="no"/>cator post actum peccati iuste punitur: ergo et post 
             ac<lb ed="#V" n="56" break="no"/>tum peccati remanet debitor pene.
           </p>
@@ -117,7 +117,7 @@
             <lb ed="#V" n="61"/>enim diuina peccatum prohibet et immobiliter statuit: vt qui 
             pecca<lb ed="#V" n="62" break="no"/>uerit puniatur: et ideo quamuis actus peccati transierit ille qui 
             pec<lb ed="#V" n="63" break="no"/>cauit remanet obligatus ad penam: per diuine legis statutum 
-            <lb ed="#V" n="64"/>qousque pro illo peccato fuerit satisfactum. Sicut videmus quod cum 
+            <lb ed="#V" n="64"/>quousque pro illo peccato fuerit satisfactum. Sicut videmus quod cum 
             <lb ed="#V" n="65"/>lex humana aliquid prohibet fieri et statuit: vt illud prohibitum 
             <lb ed="#V" n="66"/>faciens aliqua pena determinata puniatur. Si aliquis illud 
             prohi<lb ed="#V" n="67" break="no"/>bitum commiserit remanet obligatus ad penam: quamuis actus 
@@ -140,8 +140,8 @@
             obliga<lb ed="#V" n="77" break="no"/>tionis istius ad penam: et hoc statutum manet: et istum peccasse: etiam 
             <lb ed="#V" n="78"/>manet obiectiue in legislatoris cognitione: hoc enim adeo cognitum 
             <lb ed="#V" n="79"/>est. Ad asdicunt aliuo quod obligatio ad penam non est aliqud 
-            <lb ed="#V" n="80"/>positluum: dicit. n. pena priuationem alicuius namlis boni: vt de. 
-            <lb ed="#V" n="81"/>lectationis et quetis
+            <lb ed="#V" n="80"/>positiuum: dicit. n. pena priuationem alicuius naturalis boni: vt de. 
+            <lb ed="#V" n="81"/>lectationis et quietis
           </p>
           <p xml:id="kzz7yh-f119957-d1e256">
             ¶ Sed hoc solutio non videtur sufficere: pena enim 
@@ -240,19 +240,19 @@
             <cb ed="#P" n="a"/>
             <lb ed="#V" n="1"/>re fruendo: sed vtendo: ex quo sequitur quod frui creatura morta 
             <lb ed="#V" n="2"/>le peccatum est: secundum autem Aug. I. de doc. christiana non multum post 
-            <lb ed="#V" n="3"/>principium: frui est amore imherere alicui rei propter seipsam: ergo amare 
+            <lb ed="#V" n="3"/>principium: frui est amore inhaerere alicui rei propter seipsam: ergo amare 
             <lb ed="#V" n="4"/>creaturam ex deliberatione: propter seipsam mortale peccatum est. Sic 
             <lb ed="#V" n="5"/>autem amat eam omnis extra deliberatione peccans: quia amorem suum non 
             <lb ed="#V" n="6"/>refert in deum: nec actu: sec habitum: quia si amorem suum in deum 
             <lb ed="#V" n="7"/>referret amando creaturam non peccaret. Restat ergo quod omnis ex 
             <lb ed="#V" n="8"/>deliberatione peccans mortaliter peccat: quia creaturam propter seipsam 
-            <lb ed="#V" n="9"/>amat finem suf amoris statuendo in ea
+            <lb ed="#V" n="9"/>amat finem sui amoris statuendo in ea
           </p>
           <p xml:id="kzz7yh-f119957-d1e441">
             ¶ Sed hoc opi. minus est 
             <lb ed="#V" n="10"/>dura: multi enim ex deliberatione faciunt multas leues 
             deor<lb ed="#V" n="11" break="no"/>dinationes quas non facerent si faciendo mortaliter peccare 
-            crede<lb ed="#V" n="12" break="no"/>rent. Est est irrationalis: quia non tantum cadit deordinatus voluntat 
+            crede<lb ed="#V" n="12" break="no"/>rent. Est est irrationalis: quia non tantum cadit deordinatus voluntatis 
             <lb ed="#V" n="13"/>actus a ratione peccati mortalis propter imperfectionem actus: sicut sunt 
             deor<lb ed="#V" n="14" break="no"/>dinati actus voluntatis procedentes ex surreptione. Sed etiam prter 
             <lb ed="#V" n="15"/>conditionem actionis exterioris volite: quae non est contra vnum de. x. 
@@ -270,16 +270,16 @@
             <lb ed="#V" n="27"/>eo quod res illa amata in deum referibilis non est propter eius 
             deordi<lb ed="#V" n="28" break="no"/>nationem: sicut est mendacium leue dictum causa solatii: qui tamen illam 
             <lb ed="#V" n="29"/>creaturam minus diligunt: quam deum: quia si propter hoc scirent se a diuino 
-            <lb ed="#V" n="30"/>amore sepaerandos ab amore illius creature recederent: quamuis ergo 
+            <lb ed="#V" n="30"/>amore separandos ab amore illius creature recederent: quamuis ergo 
             <lb ed="#V" n="31"/>talem creaturam diligant propter se: non tamen ipsum constituunt 
             principalio<lb ed="#V" n="32" break="no"/>rem finem in appetitu suo: quam ipsum deum: quia eius amorem amori 
             di<lb ed="#V" n="33" break="no"/>uino non praeponunt. Contingere enim potest quod aliquis diligat aliquam 
-            <lb ed="#V" n="34"/>rem non propter amicum: quem tamen plus diligit icomparabiliter quam illam rem. 
+            <lb ed="#V" n="34"/>rem non propter amicum: quem tamen plus diligit incomparabiliter quam illam rem. 
           </p>
           <p xml:id="kzz7yh-f119957-d1e498">
             <lb ed="#V" n="35"/>¶ Uater ergo mihi dicendum ad quaestionem: quod non omne peccatum ex 
             delibera<lb ed="#V" n="36" break="no"/>tione commissum obligat peccantem ad penam eternam per se: quia sic 
-            <lb ed="#V" n="37"/>solum peccatum mortale obligat ad illam: vt declrabo. Sed non omne 
+            <lb ed="#V" n="37"/>solum peccatum mortale obligat ad illam: vt declarabo. Sed non omne 
             <lb ed="#V" n="38"/>peccatum ex deliberatione commissum est mortale: vt iam probatum est. 
             <lb ed="#V" n="39"/>Quod autem solum peccatum mortale obliget ad penam eternam. 
             De<lb ed="#V" n="40" break="no"/>claro sic. Peccatum enim mortale excludit a peccatore gratiam 
@@ -291,7 +291,7 @@
             <lb ed="#V" n="46"/>temporalem commutatur: si ille qui peccauit ad deum reuertatur per 
             condi<lb ed="#V" n="47" break="no"/>gnam poenitentiam: quia talis poenitentia: gratia gratum faciente formatur: peccatum 
             <lb ed="#V" n="48"/>autem veniale quia volutatem non auertit a deo: quamuis sit ad 
-            <lb ed="#V" n="49"/>auersionem quaedam dispotmio loquendo de dispositione quae non est 
+            <lb ed="#V" n="49"/>auersionem quaedam dispositio loquendo de dispositione quae non est 
             necessita<lb ed="#V" n="50" break="no"/>tis: ideo non excludit gratiam gratum facientem ab illo in quo est. 
             <lb ed="#V" n="51"/>Et quia per gratiam gratum facientem ille qui peccauit 
             suf<lb ed="#V" n="52" break="no"/>ficienter potest satisfacere pro peccato: ideo propter 
@@ -337,7 +337,7 @@
             <lb ed="#V" n="79"/>quo. Sed cum se extendendo versus terminum ad quem 
             <lb ed="#V" n="80"/>non moueatur nisi partialiter adhuc potest remanere in 
             <lb ed="#V" n="81"/>termino a quo: quamuis per illam extensionem propinquior 
-            <lb ed="#V" n="82"/>sit separationi a termino a quo primum exipium competit peccato 
+            <lb ed="#V" n="82"/>sit separationi a termino a quo primum exemplum competit peccato 
             <lb ed="#V" n="83"/>mortali: et secundum peccato veniali. Dicas ergo quod Ber. prsimallega 
             <lb ed="#V" n="84"/>ta auctoritas aut intelligi debet de mortali peccato: aut hec 
             <lb ed="#V" n="85"/>praepositio contra extenditur non tantummodo ad 
@@ -350,7 +350,7 @@
             di<lb ed="#V" n="89" break="no"/>citur: quod peccatum mortale non excedit veniale in infinitum etc. 
             <lb ed="#V" n="90"/>Dico quod quamuis actus peccati mortalis inquantum est quaedam 
             <lb ed="#V" n="91"/>natura non excedit actum peccati venialis in infinitum: tamen si conside 
-            <lb ed="#V" n="92"/>rentur in esse moris: mortale in infinitum excedit veiale: quia per 
+            <lb ed="#V" n="92"/>rentur in esse moris: mortale in infinitum excedit veniale: quia per 
             <lb ed="#V" n="93"/>mortale peccatum: bonum creatum quod finitum est bono increato quod 
             <lb ed="#V" n="94"/>est infinitum praeponitur: non autem per veniale peccatum: et ideo in genere 
             <lb ed="#V" n="95"/>moris distant in infinitum.


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve09v2_kzz7yh-f119957.xml`.

## Applied changes

- p. 168v l. 49: videetur → videtur: double-e typo
- p. 168v l. 54: nis → nisi: missing i (split across break without break="no"); sec → sed: common abbreviation misread
- p. 168v l. 64: qousque → quousque: not in word list (OCR transform matched)
- p. 168v l. 80: positluum → positiuum: l/i misread; namlis → naturalis: garbled (missing letters)
- p. 168v l. 81: lectationis: not in Latin word list — review needed; quetis → quietis: not in word list (OCR transform matched)
- p. 169r l. 3: imherere → inhaerere: m/nh misread; frui est amore inhaerere alicui rei
- p. 169r l. 9: suf → sui: f/i misread; context: finem sui amoris statuendo in ea
- p. 169r l. 12: voluntat → voluntatis: truncated word (missing -is); deordinatus: valid in this text's usage
- p. 169r l. 30: sepaerandos → separandos: spurious ae diphthong inserted
- p. 169r l. 34: icomparabiliter → incomparabiliter: missing n after i
- p. 169r l. 37: declrabo → declarabo: missing a (garbled consonant cluster)
- p. 169r l. 49: dispotmio → dispositio: garbled (t/ti swap, m inserted); context: quaedam dispositio loquendo de dispositione
- p. 169r l. 82: exipium → exemplum: garbled; context: primum exemplum competit peccato mortali
- p. 169r l. 92: veiale → veniale: missing n

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_