### PR TITLE
Transcription corrections: cod-ve09v2_kzz7yh-f120532.xml (9 changes)

### DIFF
--- a/kzz7yh-f120532/cod-ve09v2_kzz7yh-f120532.xml
+++ b/kzz7yh-f120532/cod-ve09v2_kzz7yh-f120532.xml
@@ -96,7 +96,7 @@
             <lb ed="#V" n="123"/>debitum: nullam videtur dicere conuersionem. 
           </p>
           <p xml:id="kzz7yh-f120532-d1e169">
-            <lb ed="#V" n="124"/>Contra <ref xml:id="kzz7yh-f120532-Rd1e179">Aug. 12 de ciui. ca. 8.</ref> qui puerse amat cuius 
+            <lb ed="#V" n="124"/>Contra <ref xml:id="kzz7yh-f120532-Rd1e179">Aug. 12 de ciui. ca. 8.</ref> qui peruerse amat cuius 
             <lb ed="#V" n="125"/>libet nature bonum: et si adipiscatur: ipse est in 
             bo<lb ed="#V" n="126" break="no"/>no malus: et miser meliore priuatus: ergo videtur quod simul 
             <lb ed="#V" n="127"/>sunt in peccato: et inordinatus amor creature et recessus a 
@@ -126,16 +126,16 @@
             <lb ed="#V" n="7"/>praesupponit amorem: ergo cum in contemptu dei: sit auersio a 
             <lb ed="#V" n="8"/>deo: et in haec quod creatura seipsam diligit conuertat se ad 
             crea<lb ed="#V" n="9" break="no"/>turam: omne peccatum quod in actu consistit compraehendit auersionem 
-            <lb ed="#V" n="10"/>a deo et conuersionem ad creaturam tamquam sibi intrinsecama vel 
+            <lb ed="#V" n="10"/>a deo et conuersionem ad creaturam tamquam sibi intrinsecam vel 
             tan<lb ed="#V" n="11" break="no"/>quam ab eodem praesuppositam.
           </p>
           <p xml:id="kzz7yh-f120532-d1e235">
-            ¶ Preterea Glo. super illud pslamum 
+            ¶ Preterea Glo. super illud psalmum 
             <lb ed="#V" n="12"/>Incensa igitur et suffossa. sententialiter dicit quod omne 
             pec<lb ed="#V" n="13" break="no"/>catum procedit: vel ex amore male inflammante vel ex timore 
             <lb ed="#V" n="14"/>male humiliante. Quodlibet ergo peccatum: aut est 
             amor<lb ed="#V" n="15" break="no"/>male inflammans: aut timor male humilians: aut ex istorum 
-            <lb ed="#V" n="16"/>altero procedens. Sed timor male humilians presuppotesit 
+            <lb ed="#V" n="16"/>altero procedens. Sed timor male humilians praesupponit 
             <lb ed="#V" n="17"/>amorem male inflammantem: omnis enim qui inordinate timet: 
             <lb ed="#V" n="18"/>aut ideo timet inordinate: ne sibi auferatur quod inordinate 
             <lb ed="#V" n="19"/>amat: aut ne sibi inferatur quod inordinate odit. Inordinatum 
@@ -149,7 +149,7 @@
             <lb ed="#V" n="27"/>innordinatam conuersionem ad creaturam vel ipsam intra se 
             con<lb ed="#V" n="28" break="no"/>prehendit. Per inordinatam autem conuersionem ad creaturam 
             <lb ed="#V" n="29"/>est aliqua auersio a deo: ergo in quolibet peccato quod in actu 
-            consi<lb ed="#V" n="30" break="no"/>stit est conuersio ad creaturam vel praesuppoteositur ab eodem: et 
+            consi<lb ed="#V" n="30" break="no"/>stit est conuersio ad creaturam vel praesupponitur ab eodem: et 
             auer<lb ed="#V" n="31" break="no"/>sio a deo per quam in illa conuersione est formalis. ratio peccati. 
           </p>
           <p xml:id="kzz7yh-f120532-d1e281">
@@ -181,7 +181,7 @@
             ¶ Alii autem dicunt: quod non 
             de<lb ed="#V" n="47" break="no"/>necessitate presupponit aliquam conuersionem ad creaturam 
             <lb ed="#V" n="48"/>actualem. Ad videndum autem que istarum opinionum 
-            <lb ed="#V" n="49"/>sit rationablior recurras ad illam questionem superius 
+            <lb ed="#V" n="49"/>sit rationabilior recurras ad illam questionem superius 
             <lb ed="#V" n="50"/>positam distin. 35 secet verum omne peccatum aliud ab 
             ori<lb ed="#V" n="51" break="no"/>ginali consistit in aliquo actu. 
           </p>
@@ -208,7 +208,7 @@
             <lb ed="#V" n="63"/>eodem actu peccati auersio a deo quam conuersio ad creaturam. 
           </p>
           <p xml:id="kzz7yh-f120532-d1e375">
-            <lb ed="#V" n="64"/>¶ Item si intellectus non potest simul intelligere. a. et bro prius 
+            <lb ed="#V" n="64"/>¶ Item si intellectus non potest simul intelligere. a. et b. prius 
             ordi<lb ed="#V" n="65" break="no"/>ne nature dimittit intelligere. a. quam intelligat. b ergo a simili cum 
             <lb ed="#V" n="66"/>voluntas non possit simul instituere creaturam et creatorem pro 
             prin<lb ed="#V" n="67" break="no"/>cipali sine: oportet quod prius ordine nature dimittat creatorem: quam 
@@ -242,7 +242,7 @@
             <lb ed="#V" n="86"/>ad creaturam per inordinatum amorem: causa est recessus eius a deo. 
             <lb ed="#V" n="87"/>Sed praedictus inordinatus amor inquantum tendit in creaturam est 
             con<lb ed="#V" n="88" break="no"/>uersio: et inquantum per ipsum voluntas recedit a deo est auersio. 
-            <lb ed="#V" n="89"/>Prius ergo oedine nature in eodem actu peccati est 
+            <lb ed="#V" n="89"/>Prius ergo ordine nature in eodem actu peccati est 
             conuersio<lb ed="#V" n="90" break="no"/>ad creaturam quam auersio a deo. 
           </p>
           <p xml:id="kzz7yh-f120532-d1e449">
@@ -268,7 +268,7 @@
             ¶ Ad 3m dicendum quod illud argumentum 
             <lb ed="#V" n="105"/>bene concludit: quod si voluntas esset conuersa ad deum vno motu: et 
             <lb ed="#V" n="106"/>auertatur par alium motum: primo ordine nature est desitio primi actus quam 
-            <lb ed="#V" n="107"/>alterius actus poteo: hoc autem est sermo non de conuersione et auersione secundum quod 
+            <lb ed="#V" n="107"/>alterius actus positio: hoc autem est sermo non de conuersione et auersione secundum quod 
             <lb ed="#V" n="108"/>consistunt in duobus motibus: sed secundum quod sunt in vno actu qui secundum 
             compara<lb ed="#V" n="109" break="no"/>tionem est conuersio ad creatura: et secundum aliam auersio a creatore.
           </p>


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve09v2_kzz7yh-f120532.xml`.

## Applied changes

- p. 169r l. 124: puerse → peruerse: garbled (missing er, vowel shift); qui peruerse amat cuiuslibet nature bonum
- p. 169v l. 10: intrinsecama → intrinsecam: spurious extra a appended
- p. 169v l. 11: pslamum → psalmum: sl/ls transposition
- p. 169v l. 16: presuppotesit → praesupponit: garbled (eos inserted, wrong ending); humilians: valid Latin
- p. 169v l. 30: praesuppoteositur → praesupponitur: garbled (eos inserted spuriously)
- p. 169v l. 49: rationablior → rationabilior: not in word list (OCR transform matched)
- p. 169v l. 64: bro → b.: OCR garbled the letter-label variable 'b.' used alongside 'a.' in the scholastic argument
- p. 169v l. 89: oedine → ordine: garbled vowels (oe/or swap); context: Prius ergo ordine nature in eodem actu peccati
- p. 169v l. 107: poteo → positio: garbled; context: desitio primi actus quam alterius actus positio (cessation vs. positing)

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_