### PR TITLE
Transcription corrections: cod-ve09v2_kzz7yh-f120933.xml (14 changes)

### DIFF
--- a/kzz7yh-f120933/cod-ve09v2_kzz7yh-f120933.xml
+++ b/kzz7yh-f120933/cod-ve09v2_kzz7yh-f120933.xml
@@ -165,7 +165,7 @@
             ve<lb ed="#V" n="38" break="no"/>niale: quandoque secundum speciem differunt: vt quando sunt respectu 
             di<lb ed="#V" n="39" break="no"/>uersorum obiectorum formalium. Quandoque autem secundum speciem non 
             <lb ed="#V" n="40"/>differunt: vt quado sunt respectu eiusdem obiecti in specie. 
-            <lb ed="#V" n="41"/>Sed differunt secundum imperfectionem actus: et secundum perfectio 
+            <lb ed="#V" n="41"/>Sed differunt secundum imperfectionem actus: et secundum 
             perfectio<lb ed="#V" n="42" break="no"/>nem: vnde velle fornicari ex deliberatione: et velle 
             forni<lb ed="#V" n="43" break="no"/>cari ex surreptione non sunt actus voluntatis differentes 
             <lb ed="#V" n="44"/>secundum speciem: nec in genere nature: nec in genere moris. Sed in 
@@ -189,13 +189,13 @@
             re<lb ed="#V" n="56" break="no"/>ponuntur in specie. Sed quia propter finem efficiens elicit de. 
             <lb ed="#V" n="57"/>terminatam essentiam actus: seu 
             operati<lb ed="#V" n="58" break="no"/>specie reponitur: quia tamen agens 
-            n<lb ed="#V" n="59" break="no"/>formiter operatur: ideo agentia naturaliter 
+            n<lb ed="#V" n="59" break="no"/>formiter operatur: ideo agentia naturalia specie diuersa producunt
             <lb ed="#V" n="60"/>diuersos actus naturales in specie: vnde tales actus specie differunt: 
             <lb ed="#V" n="61"/>et per efficientem: et per finem: vt calefactio et frigefactio: et 
             <lb ed="#V" n="62"/>sic de aliis. Agens autem voluntarium potest agere 
             diuer<lb ed="#V" n="63" break="no"/>sas actiones: vnde in voluntariis actibus non attenditur 
-            <lb ed="#V" n="64"/>distinctio secundum speciem: penes causam 
-            ager<lb ed="#V" n="65" break="no"/>finem: qui est formale obiectum voluntati 
+            di<lb ed="#V" n="64" break="no"/>stinctio secundum speciem: penes causam agentem: sed penes proximum 
+            <lb ed="#V" n="65"/>finem: qui est formale obiectum voluntati 
             <lb ed="#V" n="66"/>tum cum dicitur: quod res non distinguuntur specie secundum materiam etc. Dico 
             <lb ed="#V" n="67"/>quod sicut per obiectum materiale actus non reponitur in specie: sed 
             <lb ed="#V" n="68"/>per formale: ita per obiecta materialia non distinguuntur secundum spe¬ 

--- a/kzz7yh-f120933/cod-ve09v2_kzz7yh-f120933.xml
+++ b/kzz7yh-f120933/cod-ve09v2_kzz7yh-f120933.xml
@@ -72,7 +72,7 @@
           <head xml:id="kzz7yh-f120933-Hd1e128" type="question-title">Utrum peccata distinguantur secundum speciem per obiecta</head>
           <p xml:id="kzz7yh-f120933-d1e126">
             Questio 
-            <lb ed="#V" n="115"/>PRimo ostendo quod peccata non distiguuntur secundum 
+            <lb ed="#V" n="115"/>PRimo ostendo quod peccata non distinguuntur secundum 
             <lb ed="#V" n="116"/>speciem per obiecta. Quia formale in peccato 
             <lb ed="#V" n="117"/>est auersio. Sed per omnia peccata a deo auertentia est 
             <lb ed="#V" n="118"/>auersio ab eodem obiecto scilicet deo: ergo non distinguuntur 
@@ -93,10 +93,10 @@
           <p xml:id="kzz7yh-f120933-d1e159">
             ¶ Item ab eodem habet res 
             <lb ed="#V" n="127"/>speciem a quo habet esse: sed peccata habent esse ex suis causis: ergo est ab e 
-            <lb ed="#V" n="128"/>speciem fortiuntur: ergo distinguuntur secundum speciem per suas causas et non per¬ 
+            <lb ed="#V" n="128"/>speciem sortiuntur: ergo distinguuntur secundum speciem per suas causas et non per¬ 
           </p>
           <p xml:id="kzz7yh-f120933-d1e167">
-            <lb ed="#V" n="129"/>¶ Item obitecm in peccato est sicut materialis causa: sed secundum philosophum. 10. 
+            <lb ed="#V" n="129"/>¶ Item obiectum in peccato est sicut materialis causa: sed secundum philosophum. 10. 
             met<lb ed="#V" n="130" break="no"/>res non distinguuntur speciem secundum materiam: sed secundum formam: ergo 
             pec<lb ed="#V" n="131" break="no"/>ta non distinguuntur speciem secundum obiecta. 
           </p>
@@ -153,7 +153,7 @@
             quodli<lb ed="#V" n="29" break="no"/>bet peccatum mortale auertitur homo
             <lb ed="#V" n="30"/>a deo: vnde ipsa auersio generaliter dicta est. q. forma 
             ge<lb ed="#V" n="31" break="no"/>neraliter omnium mortalium peccatorum inquantum peccata 
-            <lb ed="#V" n="32"/>sunt. Sed carentia formalis obiecti debiti est. q. spercialis 
+            <lb ed="#V" n="32"/>sunt. Sed carentia formalis obiecti debiti est. q. specialis 
             for<lb ed="#V" n="33" break="no"/>ma ipsius peccati sub ratione: qua peccatum est talis speciei 
             <lb ed="#V" n="34"/>et dico. q. forma: quia secundum rei veriratem priuatio forma non 
             <lb ed="#V" n="35"/>est: vnde nec peccatum sub ratione: qua peccatum est 
@@ -174,7 +174,7 @@
           </p>
           <p xml:id="kzz7yh-f120933-d1e311">
             ¶ Ad tertium dicendum: quod et si 
-            concubi<lb ed="#V" n="47" break="no"/>tus coniugalis et fornicarius sint eiusdem speciei: quatum ad 
+            concubi<lb ed="#V" n="47" break="no"/>tus coniugalis et fornicarius sint eiusdem speciei: quantum ad 
             <lb ed="#V" n="48"/>esse nature. Diuersarum tamen specierum sunt: quantum adesse 
             mo<lb ed="#V" n="49" break="no"/>ris: et primo modo est eorum idem obiectum in speci non 
             secun<lb ed="#V" n="50" break="no"/>do modo.
@@ -198,7 +198,7 @@
             ager<lb ed="#V" n="65" break="no"/>finem: qui est formale obiectum voluntati 
             <lb ed="#V" n="66"/>tum cum dicitur: quod res non distinguuntur specie secundum materiam etc. Dico 
             <lb ed="#V" n="67"/>quod sicut per obiectum materiale actus non reponitur in specie: sed 
-            <lb ed="#V" n="68"/>per fomale: ita per obiecta materalia non distinguuntur secundum spe¬ 
+            <lb ed="#V" n="68"/>per formale: ita per obiecta materialia non distinguuntur secundum spe¬ 
             <!--00355.xml-->
             <cb ed="#P" n="b"/>
             <lb ed="#V" n="69"/>ciem: sed per formalia. Uidere enim albedinem et 
@@ -250,7 +250,7 @@
           <p xml:id="kzz7yh-f120933-d1e446">
             ¶ Item vnum falsum est alio falsius: vnde 
             <lb ed="#V" n="96"/>dicit philosophus. 4. metaph quod non similiter mentitus est: qui 
-            qua<lb ed="#V" n="97" break="no"/>tuor pente opinatus est: et qui mille. Si ingitur non similiter 
+            qua<lb ed="#V" n="97" break="no"/>tuor pente opinatus est: et qui mille. Si igitur non similiter 
             <lb ed="#V" n="98"/>palam: quia alter minus: ergo similiter vnum peccatum 
             <lb ed="#V" n="99"/>est altero grauius.
           </p>
@@ -274,8 +274,8 @@
             exesu<lb ed="#V" n="113" break="no"/>dens habitum que priuatio consistit in esse corrupto cum 
             <lb ed="#V" n="114"/>iusmodi mors est: que est vite priuatio non recipiat 
             ma<lb ed="#V" n="115" break="no"/>gis et minus: priuatio tamen que non totaliter habitum 
-            <lb ed="#V" n="116"/>excludit oppositum: que priuatio magis consislit in 
-            fie<lb ed="#V" n="117" break="no"/>ri corruptonis habitus oppositi: quam in esse corrupto: sicut 
+            <lb ed="#V" n="116"/>excludit oppositum: que priuatio magis consistit in 
+            fie<lb ed="#V" n="117" break="no"/>ri corruptionis habitus oppositi: quam in esse corrupto: sicut 
             <lb ed="#V" n="118"/>se habet infirmitas ad sanitatem recipit magis et minus. 
           </p>
           <p xml:id="kzz7yh-f120933-d1e503">
@@ -295,13 +295,13 @@
             imi<lb ed="#V" n="129" break="no"/>paria: cum tamen tunc nullum eorum aliquid de habitum 
             op<lb ed="#V" n="130" break="no"/>posito retineret: et esset eorum inequalitas per maiorem vel 
             <lb ed="#V" n="131"/>minorem elongationem ab illo medio indiuisibili: in quo esse 
-            <lb ed="#V" n="132"/>virtutis consisteret. Cui sententie multum videntur concordare auctortates 
+            <lb ed="#V" n="132"/>virtutis consisteret. Cui sententie multum videntur concordare auctoritates 
             <lb ed="#V" n="133"/>Aug. et philosophi in opponendo allegate ad hanc partem. Ite m 
           </p>
           <p xml:id="kzz7yh-f120933-d1e542">
             <lb ed="#V" n="134"/>Ad primum in oppositum dicendum: quod illud 
             <lb ed="#V" n="135"/>verbum Iacobi: qui peccat in vno 
-            <lb ed="#V" n="136"/>factus est omnium reus: sic intelligendum est secundum Gloseinus 
+            <lb ed="#V" n="136"/>factus est omnium reus: sic intelligendum est secundum Glossam 
             <!--00356.xml-->
             <pb ed="#V" n="170-v"/>
             <cb ed="#P" n="a"/>
@@ -314,7 +314,7 @@
             <lb ed="#V" n="4"/>quod quamuis sit vnus precipiens: non tamen intendit eque 
             in<lb ed="#V" n="5" break="no"/>tense obligare: per quodlibet preceptum: et sicut dicit Ber. 
             <lb ed="#V" n="6"/>de precepto et dispen 23 cap. non pari culpa negliguntur 
-            <lb ed="#V" n="7"/>que non pari cura precipiuntur: rec pari proinde 
+            <lb ed="#V" n="7"/>que non pari cura precipiuntur: nec pari proinde 
             puniun<lb ed="#V" n="8" break="no"/>tur.
           </p>
           <p xml:id="kzz7yh-f120933-d1e577">
@@ -322,7 +322,7 @@
             <lb ed="#V" n="9"/>virtus consistit non est indiuisibile: vt in tertio 
             declara<lb ed="#V" n="10" break="no"/>bitur: et sic esset in indiuisibili ad hoc secundum aliquos esse vnum 
             <lb ed="#V" n="11"/>peccatum grauius alio: per maiorem elongationem: et 
-            mi<lb ed="#V" n="12" break="no"/>norem ab illo punctali medio.
+            mi<lb ed="#V" n="12" break="no"/>norem ab illo punctuali medio.
           </p>
           <p xml:id="kzz7yh-f120933-d1e588">
             ¶ Ad tertium dicendum 
@@ -337,7 +337,7 @@
             ¶ Uel potest 
             di<lb ed="#V" n="19" break="no"/>ci secundum aliquos quod illud verbum philosophi: quamuis ponat exemplum 
             <lb ed="#V" n="20"/>de contrariis proprie dictis: intelligit tame de contrariis secundum 
-            <lb ed="#V" n="21"/>quod se extendut ad magis et minus: et ego dico quod si duo 
+            <lb ed="#V" n="21"/>quod se extendunt ad magis et minus: et ego dico quod si duo 
             pec<lb ed="#V" n="22" break="no"/>cata ita se haberent quod nihil participarent de conditionibus 
             <lb ed="#V" n="23"/>virtutis nisi actum volendi sub ratione boni in gnaturali: quod commune 
             <lb ed="#V" n="24"/>est: et actibus peccatorum: et actibus virtuosis: tamen vnum posset esse 

--- a/kzz7yh-f120933/cod-ve09v2_kzz7yh-f120933.xml
+++ b/kzz7yh-f120933/cod-ve09v2_kzz7yh-f120933.xml
@@ -155,7 +155,7 @@
             ge<lb ed="#V" n="31" break="no"/>neraliter omnium mortalium peccatorum inquantum peccata 
             <lb ed="#V" n="32"/>sunt. Sed carentia formalis obiecti debiti est. q. specialis 
             for<lb ed="#V" n="33" break="no"/>ma ipsius peccati sub ratione: qua peccatum est talis speciei 
-            <lb ed="#V" n="34"/>et dico. q. forma: quia secundum rei veriratem priuatio forma non 
+            <lb ed="#V" n="34"/>et dico. q. forma: quia secundum rei <sic>veriratem</sic> priuatio forma non 
             <lb ed="#V" n="35"/>est: vnde nec peccatum sub ratione: qua peccatum est 
             for<lb ed="#V" n="36" break="no"/>mam habet: nec speciem per se. Sed eo modo quo superius 
             <lb ed="#V" n="37"/>dictum est.
@@ -166,7 +166,7 @@
             di<lb ed="#V" n="39" break="no"/>uersorum obiectorum formalium. Quandoque autem secundum speciem non 
             <lb ed="#V" n="40"/>differunt: vt quado sunt respectu eiusdem obiecti in specie. 
             <lb ed="#V" n="41"/>Sed differunt secundum imperfectionem actus: et secundum perfectio 
-            <lb ed="#V" n="42"/>nem: vnde velle fornicari ex deliberatione: et velle 
+            perfectio<lb ed="#V" n="42" break="no"/>nem: vnde velle fornicari ex deliberatione: et velle 
             forni<lb ed="#V" n="43" break="no"/>cari ex surreptione non sunt actus voluntatis differentes 
             <lb ed="#V" n="44"/>secundum speciem: nec in genere nature: nec in genere moris. Sed in 
             <lb ed="#V" n="45"/>hoc differunt: quod vnus eorum est imperfectus volendi actus: 
@@ -180,7 +180,7 @@
             secun<lb ed="#V" n="50" break="no"/>do modo.
           </p>
           <p xml:id="kzz7yh-f120933-d1e322">
-            ¶ Ad quartum cum dicitur: quod peecati habent esse 
+            ¶ Ad quartum cum dicitur: quod peccata habent esse 
             ex<lb ed="#V" n="51" break="no"/>suis causis et c. dicendum quod materia et forma respiciunt rei 
             substan<lb ed="#V" n="52" break="no"/>tiam: et ideo substantie reponuntur in genere et specie per 
             ma<lb ed="#V" n="53" break="no"/>et formam. Agens autem et finis respiciunt actus seu 
@@ -189,12 +189,12 @@
             re<lb ed="#V" n="56" break="no"/>ponuntur in specie. Sed quia propter finem efficiens elicit de. 
             <lb ed="#V" n="57"/>terminatam essentiam actus: seu 
             operati<lb ed="#V" n="58" break="no"/>specie reponitur: quia tamen agens 
-            n<lb ed="#V" n="59" break="no"/>formiter omperatur: ideo agentia natural 
+            n<lb ed="#V" n="59" break="no"/>formiter operatur: ideo agentia naturaliter 
             <lb ed="#V" n="60"/>diuersos actus naturales in specie: vnde tales actus specie differunt: 
             <lb ed="#V" n="61"/>et per efficientem: et per finem: vt calefactio et frigefactio: et 
             <lb ed="#V" n="62"/>sic de aliis. Agens autem voluntarium potest agere 
             diuer<lb ed="#V" n="63" break="no"/>sas actiones: vnde in voluntariis actibus non attenditur 
-            <lb ed="#V" n="64"/>stinctio secundum speciem: penes causam 
+            <lb ed="#V" n="64"/>distinctio secundum speciem: penes causam 
             ager<lb ed="#V" n="65" break="no"/>finem: qui est formale obiectum voluntati 
             <lb ed="#V" n="66"/>tum cum dicitur: quod res non distinguuntur specie secundum materiam etc. Dico 
             <lb ed="#V" n="67"/>quod sicut per obiectum materiale actus non reponitur in specie: sed 
@@ -232,7 +232,7 @@
           <p xml:id="kzz7yh-f120933-d1e416">
             ¶ Item philosophus. 3. Top. albius est: quod est nigro 
             im<lb ed="#V" n="86" break="no"/>permixtius: ergo si peccatum esset peccato grauius esset 
-            <lb ed="#V" n="87"/>suo contrario(quod est virtus impermixtius. Sed hoc est 
+            <lb ed="#V" n="87"/>suo contrario (quod est virtus) impermixtius. Sed hoc est 
             fal<lb ed="#V" n="88" break="no"/>sum: nullum enim peccatum habet aliquam permixtionem 
             <lb ed="#V" n="89"/>cum virtute: ergo nullum est alio grauius.
           </p>
@@ -339,7 +339,7 @@
             <lb ed="#V" n="20"/>de contrariis proprie dictis: intelligit tame de contrariis secundum 
             <lb ed="#V" n="21"/>quod se extendunt ad magis et minus: et ego dico quod si duo 
             pec<lb ed="#V" n="22" break="no"/>cata ita se haberent quod nihil participarent de conditionibus 
-            <lb ed="#V" n="23"/>virtutis nisi actum volendi sub ratione boni in gnaturali: quod commune 
+            <lb ed="#V" n="23"/>virtutis nisi actum volendi sub ratione boni in generali: quod commune 
             <lb ed="#V" n="24"/>est: et actibus peccatorum: et actibus virtuosis: tamen vnum posset esse 
             <lb ed="#V" n="25"/>grauius alio et per magis et minus elongari a termino in quo 
             <lb ed="#V" n="26"/>virtus consistit.


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve09v2_kzz7yh-f120933.xml`.

## Applied changes

- p. 169v l. 115: distiguuntur → distinguuntur: missing n
- p. 169v l. 128: fortiuntur → sortiuntur: f/s misread at word start
- p. 169v l. 129: obitecm → obiectum: transposed letters (tecm → ctum)
- p. 170r l. 32: spercialis → specialis: spurious r inserted
- p. 170r l. 47: quatum → quantum: missing n; context: eiusdem speciei quatum ad esse nature → quantum ad esse nature
- p. 170r l. 68: fomale → formale: missing r; materalia → materialia: missing i (OCR transform matched)
- p. 170r l. 97: pente: valid Greek numeral (five), retained; ingitur → igitur: missing i at word start
- p. 170r l. 116: consislit → consistit: l/t transposition
- p. 170r l. 117: corruptonis → corruptionis: not in word list (OCR transform matched)
- p. 170r l. 132: auctortates → auctoritates: not in word list (OCR transform matched)
- p. 170r l. 136: Gloseinus → Glossam: garbled abbreviation for Glossam (interlinear gloss); context: secundum Glossam interlinealem
- p. 170v l. 7: rec → nec: r/n misread at word start; precipiuntur: valid Latin
- p. 170v l. 12: punctali → punctuali: missing u; context: ab illo punctuali medio
- p. 170v l. 21: extendut → extendunt: missing n before t

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_