### PR TITLE
Transcription corrections: cod-ve09v2_kzz7yh-f12173.xml (12 changes)

### DIFF
--- a/kzz7yh-f12173/cod-ve09v2_kzz7yh-f12173.xml
+++ b/kzz7yh-f12173/cod-ve09v2_kzz7yh-f12173.xml
@@ -61,7 +61,7 @@
         </p>
         <p xml:id="kzz7yh-f12173-d1e112">
           ¶ Primo vtrum angelus sit substantia vna 
-          <lb ed="#V" n="48"/>nuon formaliter per aliquid superadditum essentie sue. 
+          <lb ed="#V" n="48"/>numero formaliter per aliquid superadditum essentie sue. 
         </p>
         <p xml:id="kzz7yh-f12173-d1e117">
           <lb ed="#V" n="49"/>¶ Secundo vtrum in angelis sit numerus: qui est 
@@ -208,7 +208,7 @@
             da<lb ed="#V" n="136" break="no"/>torem ipsius esse: et negationem supradicte diuisibilitatis. 
           </p>
           <p xml:id="kzz7yh-f12173-d1e368">
-            <lb ed="#V" n="137"/>¶ Aduun 
+            <lb ed="#V" n="137"/>¶  
             <!--00049.xml-->
             <pb ed="#V" n="18-r"/>
             <cb ed="#P" n="a"/>

--- a/kzz7yh-f12173/cod-ve09v2_kzz7yh-f12173.xml
+++ b/kzz7yh-f12173/cod-ve09v2_kzz7yh-f12173.xml
@@ -208,7 +208,7 @@
             da<lb ed="#V" n="136" break="no"/>torem ipsius esse: et negationem supradicte diuisibilitatis. 
           </p>
           <p xml:id="kzz7yh-f12173-d1e368">
-            <lb ed="#V" n="137"/>¶  
+            <lb ed="#V" n="137"/>¶ Ad quantum
             <!--00049.xml-->
             <pb ed="#V" n="18-r"/>
             <cb ed="#P" n="a"/>

--- a/kzz7yh-f12173/cod-ve09v2_kzz7yh-f12173.xml
+++ b/kzz7yh-f12173/cod-ve09v2_kzz7yh-f12173.xml
@@ -55,7 +55,7 @@
       <div xml:id="kzz7yh-f12173"><!-- l2d3a4 -->
         <head xml:id="kzz7yh-f12173-Hd1e101">Articulus 4</head>
         <p xml:id="kzz7yh-f12173-d1e103">
-          <lb ed="#V" n="45"/>Consequenter queritur de quaerto 
+          <lb ed="#V" n="45"/>Consequenter queritur de quarto 
           princi<lb ed="#V" n="46" break="no"/>pali. Et circa hoc 
           quae<lb ed="#V" n="47" break="no"/>runtur duo.
         </p>
@@ -115,7 +115,7 @@
             nume<lb ed="#V" n="73" break="no"/>ro per aliquid super additum essentie sue. 
           </p>
           <p xml:id="kzz7yh-f12173-d1e201">
-            <lb ed="#V" n="74"/>Respondeo quod sicut vniersale potest dici: vel per 
+            <lb ed="#V" n="74"/>Respondeo quod sicut vniuersale potest dici: vel per 
             indiffe<lb ed="#V" n="75" break="no"/>rentiam in representando. Uel per 
             <lb ed="#V" n="76"/>indifferentiam in informando. Uel per indifferentiam in praedicando: 
             <lb ed="#V" n="77"/>vt habitum est superius: ita vnum numero tripliciter potest accipi. 
@@ -141,7 +141,7 @@
             <lb ed="#V" n="89"/>vna
           </p>
           <p xml:id="kzz7yh-f12173-d1e247">
-            ¶ Sed haoc opinio non videtur rationabilis. Unde et commen super. 4. 
+            ¶ Sed haec opinio non videtur rationabilis. Unde et commen super. 4. 
             <lb ed="#V" n="90"/>metha. reprehendit Auic. de hoc et dicit sic. Auicena autem 
             mul<lb ed="#V" n="91" break="no"/>tum peccauit in hoc: quod existimauit quod vnum et ens signant 
             dispositio<lb ed="#V" n="92" break="no"/>nes additas essentie rei: et mirum est de isto homine quomodo 
@@ -155,8 +155,8 @@
           </p>
           <p xml:id="kzz7yh-f12173-d1e271">
             ¶ Uidetur ergo mihi dicendum quod substantia 
-            <lb ed="#V" n="100"/>angeli est vna numero formaliter: non per aliquid reale superaddi 
-            <lb ed="#V" n="101"/>tum essentie sune: sed per essentiam suam: sub ratione qua 
+            <lb ed="#V" n="100"/>angeli est vna numero formaliter: non per aliquid reale 
+            superaddi<lb ed="#V" n="101" break="no"/>tum essentie sune: sed per essentiam suam: sub ratione qua 
             indiui<lb ed="#V" n="102" break="no"/>sibilis integritate sua salua. Hoc dico propter vnitatem speciei: 
             <lb ed="#V" n="103"/>natura enim humana vt intellecta preter vnitatem et 
             mul<lb ed="#V" n="104" break="no"/>titudinem: intelligitur non vt multiplicata: tamen vt 
@@ -165,7 +165,7 @@
             <lb ed="#V" n="107"/>non dicit aliquam rem positiuam: et sic vnitas numeralis ipsius 
             an<lb ed="#V" n="108" break="no"/>geli et sua essentia non differunt nisi ratione eo quod vnitas super 
             <lb ed="#V" n="109"/>essentiam non addit nisi indiuisibilitatem predictam. Unde commen. 
-            <lb ed="#V" n="110"/>super. 4. metha. loquens de ente et vno dicitu quod signt 
+            <lb ed="#V" n="110"/>super. 4. metha. loquens de ente et vno dicitur quod significant 
             ean<lb ed="#V" n="111" break="no"/>dem essentiam: sed modis diuersis: non dispositiones diuersas 
             <lb ed="#V" n="112"/>additas essentie: et aliquibus interpositis postea dicit: quod substantia 
             cu<lb ed="#V" n="113" break="no"/>iuslibet rei est vna essentialiter non per rem addita illi. 
@@ -244,7 +244,7 @@
             <lb ed="#V" n="14"/>SEcundo queritur vtrum in angelis sit 
             nume<lb ed="#V" n="15" break="no"/>rus qui est quantitas discreta. 
             <lb ed="#V" n="16"/>Et videtur quod sic. Quia in angelis est numerus. Sed secundum philosophum 
-            <lb ed="#V" n="17"/>in libro praedicamentorum nuerus dicitur discreta quantitas. 
+            <lb ed="#V" n="17"/>in libro praedicamentorum numerus dicitur discreta quantitas. 
             <lb ed="#V" n="18"/>ergo in angelis est numerus qui est quantitas discreta.
           </p>
           <p xml:id="kzz7yh-f12173-d1e437">
@@ -285,9 +285,9 @@
             <lb ed="#V" n="41"/>non tamen oportet quod illa sit quantitas discreta. 
           </p>
           <p xml:id="kzz7yh-f12173-d1e501">
-            <lb ed="#V" n="42"/>Respondeo quod nuerus qui est in angeuis sion est 
-            <lb ed="#V" n="43"/>quantitas discreta. Non enim opetet omnem 
-            <lb ed="#V" n="44"/>multitudinem quantitatem esse discretam. Sicut bene ostedunt 
+            <lb ed="#V" n="42"/>Respondeo quod numerus qui est in angelis non est 
+            <lb ed="#V" n="43"/>quantitas discreta. Non enim oportet omnem 
+            <lb ed="#V" n="44"/>multitudinem quantitatem esse discretam. Sicut bene ostendunt 
             <lb ed="#V" n="45"/>rationes adducte ad istam partem in opponendo.
           </p>
           <p xml:id="kzz7yh-f12173-d1e512">
@@ -305,7 +305,7 @@
           <p xml:id="kzz7yh-f12173-d1e534">
             <lb ed="#V" n="55"/>¶ Unde quia in angelis sunt vnitates substantiales scilicet ipsorum 
             <lb ed="#V" n="56"/>substantie sub ratione supradicta. Sunt est in eis alique 
-            qualita<lb ed="#V" n="57" break="no"/>tes: sed in nullo ipsorum est dimensionalis quantitas. Idtmon in 
+            qualita<lb ed="#V" n="57" break="no"/>tes: sed in nullo ipsorum est dimensionalis quantitas. Ideo in 
             an<lb ed="#V" n="58" break="no"/>gelis est numerus qui super angelorum substantiam: non addit 
             ali<lb ed="#V" n="59" break="no"/>quam rem positiuam: et ideo reducitur ad genus substantie. Et in eis 
             <lb ed="#V" n="60"/>etiam est numerus qui constituitur ex vnitatibus: que sunt 
@@ -328,7 +328,7 @@
             ¶ Ad secundum cum dicitur quod 
             nu<lb ed="#V" n="71" break="no"/>merus est significatiuus quantitatis numeratorum etc. Dico 
             <lb ed="#V" n="72"/>quod aut intelligendum est de numero causato ex diuisione 
-            continui<lb ed="#V" n="73" break="no"/>aut quantitate extendit ad omnem plualitatem: large vtendo nomine 
+            continui<lb ed="#V" n="73" break="no"/>aut quantitate extendit ad omnem pluralitatem: large vtendo nomine 
             <lb ed="#V" n="74"/>quantitatis.
           </p>
           <p xml:id="kzz7yh-f12173-d1e591">
@@ -344,7 +344,7 @@
             <lb ed="#V" n="80"/>tamen intellectam forte possent modo simili numerari.
           </p>
           <p xml:id="kzz7yh-f12173-d1e609">
-            ¶ Ad quartu 
+            ¶ Ad quartum 
             <lb ed="#V" n="81"/>dicendum quod passiones de quibus determinatur in arismetica non 
             <lb ed="#V" n="82"/>conueniunt vniuoce numero qui est in angelis: et 
             nume<lb ed="#V" n="83" break="no"/>ro qui est quantitas discreta. 


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve09v2_kzz7yh-f12173.xml`.

## Applied changes

- p. 17v l. 45: quaerto → quarto: spurious 'ae', should be quarto (fourth)
- p. 17v l. 74: vniersale → vniuersale: missing 'u'
- p. 17v l. 89: haoc → haec: garbled 'o' for 'e'
- p. 17v l. 101: 'superaddi' + 'tum' split across line break without break="no" on lb n=101
- p. 17v l. 110: dicitu → dicitur: missing 'r'; signt → significant: garbled/truncated word
- p. 18r l. 17: nuerus → numerus: transposed 'e' and 'r'
- p. 18r l. 42: nuerus → numerus: transposed letters; angeuis → angelis: garbled; sion → non: garbled
- p. 18r l. 43: opetet → oportet: missing 'or', garbled OCR
- p. 18r l. 44: ostedunt → ostendunt: missing 'n'
- p. 18r l. 57: Idtmon → Ideo: garbled OCR
- p. 18r l. 73: plualitatem → pluralitatem: missing 'r'
- p. 18r l. 80: quartu → quartum: missing final 'm'

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_