### PR TITLE
Transcription corrections: cod-ve09v2_kzz7yh-f122176.xml (13 changes)

### DIFF
--- a/kzz7yh-f122176/cod-ve09v2_kzz7yh-f122176.xml
+++ b/kzz7yh-f122176/cod-ve09v2_kzz7yh-f122176.xml
@@ -79,11 +79,11 @@
             Magi<lb ed="#V" n="80" break="no"/>ster in littera quod illis qui peccant in spiritum sanctum 
             ma<lb ed="#V" n="81" break="no"/>litia placet propter se. Sed peccatum ex malitia non est 
             ge<lb ed="#V" n="82" break="no"/>nus peccati distinctum: quia ex malitia possunt multa 
-            ge<lb ed="#V" n="83" break="no"/>nera peccatorum procedere: ergo peccatum in spiritum saecntum non est 
+            ge<lb ed="#V" n="83" break="no"/>nera peccatorum procedere: ergo peccatum in spiritum sanctum non est 
             ge<lb ed="#V" n="84" break="no"/>nus peccati distinctum ab aliis.
           </p>
           <p xml:id="kzz7yh-f122176-d1e149">
-            ¶ Item peccatum in spicrintum 
+            ¶ Item peccatum in spiritum 
             san<lb ed="#V" n="85" break="no"/>ctum dicitur: autem quia est contra personam spiritus sancti: 
             <lb ed="#V" n="86"/>aut quia est contra donum appropriatum spiritui sancto quod 
             <lb ed="#V" n="87"/>est charitas. Sed siue sic: siue sic: omne peccatum 
@@ -148,7 +148,7 @@
           </p>
           <p xml:id="kzz7yh-f122176-d1e270">
             ¶ Secundum 
-            <lb ed="#V" n="4"/>etiam dicitur in spiritum sanctu: quia qui sinaliter 
+            <lb ed="#V" n="4"/>etiam dicitur in spiritum sanctu: quia qui finaliter 
             mori<lb ed="#V" n="5" break="no"/>tur impenitens caret remissione peccati: qui est per 
             gra<lb ed="#V" n="6" break="no"/>tiam spiritus sancti.
           </p>
@@ -174,7 +174,7 @@
             con<lb ed="#V" n="22" break="no"/>tra patrem: quia sibi appropriatur potentia. Malitia 
             con<lb ed="#V" n="23" break="no"/>tra spiritum sanctum: quia sibi appropriatur bonitas. Et sic 
             <lb ed="#V" n="24"/>principium peccati in spiritum sanctu est directe contra 
-            ap<lb ed="#V" n="25" break="no"/>propriatum spiritui sancto. Raitione etiam oppositi dicitur 
+            ap<lb ed="#V" n="25" break="no"/>propriatum spiritui sancto. Ratione etiam oppositi dicitur 
             pec<lb ed="#V" n="26" break="no"/>catum in spiritum sanctum: quia ea que ab electiuo amore 
             <lb ed="#V" n="27"/>peccati retrahunt effectus sunt appropriati spiritui sancto. 
             <lb ed="#V" n="28"/>Dicendum ergo quod loquendo de peccato in spiritum 
@@ -185,7 +185,7 @@
             ¶ Tertio autem 
             mo<lb ed="#V" n="31" break="no"/>do dicit quandam speciem peccati scilicet infidelitatem. Cuius 
             <lb ed="#V" n="32"/>quasi quidam effectus videtur esse blasphemia: secundum illud 
-            <lb ed="#V" n="33"/>Apostouli primo Thim. primo. prius fui blasphemus et persecutor 
+            <lb ed="#V" n="33"/>Apostoli primo Thim. primo. prius fui blasphemus et persecutor 
             <lb ed="#V" n="34"/>et paucis interpositis subiungitur ignorans feci in 
             incre<lb ed="#V" n="35" break="no"/>dulitate.
           </p>
@@ -196,7 +196,7 @@
             <lb ed="#V" n="38"/>et etiam actus substracti. Unde conuenienter peccatum in 
             <lb ed="#V" n="39"/>spiritum sanctum: quarto modo dictum: sic potest 
             descri<lb ed="#V" n="40" break="no"/>bi: vt dicatur: quod est spirituale peccatum: ex sola electione 
-            pro<lb ed="#V" n="41" break="no"/>cedens contra aliquem effectum spiritui sancto appropstia 
+            pro<lb ed="#V" n="41" break="no"/>cedens contra aliquem effectum spiritui sancto appropria 
             <lb ed="#V" n="42"/>tum specialiter et directe inclinando retrahentem ab 
             ele<lb ed="#V" n="43" break="no"/>ctiuo amore cuiuscumque peccati: sicut specialius patebit cum 
             <lb ed="#V" n="44"/>in suas species distinguetur. 
@@ -266,7 +266,7 @@
           <p xml:id="kzz7yh-f122176-d1e488">
             ¶ Item <ref xml:id="kzz7yh-f122176-Rd1e507">Aug. in ench. 
               <lb ed="#V" n="87"/>cap. 47.</ref> dicit quod qui in ecclesia remitti peccata non 
-            cre<lb ed="#V" n="88" break="no"/>dens contennit tantam diuini muneris largitatem: et in 
+            cre<lb ed="#V" n="88" break="no"/>dens contemnit tantam diuini muneris largitatem: et in 
             <lb ed="#V" n="89"/>hac obstinatione mentis diem clausit extremum reus est 
             <lb ed="#V" n="90"/>irremissibili peccato in spiritum sanctum: in quo christus 
             <lb ed="#V" n="91"/>peccata dimittit: desperare ergo de remissione peccatorum 
@@ -283,7 +283,7 @@
             ¶ Item peccatum 
             <lb ed="#V" n="97"/>in spiritum sanctum procedit ex malitia: sed malitia: aut 
             <lb ed="#V" n="98"/>est peccatum: si est actus: aut ex actu causata: si est habit 
-            <lb ed="#V" n="99"/>ergo peccatum in spiritum saecntum semper presupponit aliud peccatum. 
+            <lb ed="#V" n="99"/>ergo peccatum in spiritum sanctum semper presupponit aliud peccatum. 
           </p>
           <p xml:id="kzz7yh-f122176-d1e525">
             <lb ed="#V" n="100"/>Contra <ref xml:id="kzz7yh-f122176-Rd1e552">Aug. primo libro retracta. capi. 18.</ref> repetens 
@@ -327,7 +327,7 @@
             <lb ed="#V" n="131"/>homo vehementer labitur in profundum: raro accidit 
             <lb ed="#V" n="132"/>quod ad talem malitiam deueniat homo nisi post aliud 
             actua<lb ed="#V" n="133" break="no"/>le et mortale peccatum: vnde Prouerb. 18 Impius cum in 
-            <lb ed="#V" n="134"/>profundum peccatorum venerit contennit: vbi dicit Glo. quod 
+            <lb ed="#V" n="134"/>profundum peccatorum venerit contemnit: vbi dicit Glo. quod 
             <lb ed="#V" n="135"/>longis peccatorum tenebris inuolutus semel de luce 
             despe<lb ed="#V" n="136" break="no"/>tat ex desperatione sibi peccandi frena relaxat: in quo satis 
             <!--00360.xml-->
@@ -339,16 +339,16 @@
             <!--TODO: Add paragraph break-->
             <lb ed="#V" n="4"/>Tria prima argumenta ad primam partem 
             proce<lb ed="#V" n="5" break="no"/>dunt de illis speciebus peccati in 
-            spi<lb ed="#V" n="6" break="no"/>ritum santtum que peccatum aliud pro materia respiciunt.
+            spi<lb ed="#V" n="6" break="no"/>ritum sanctum que peccatum aliud pro materia respiciunt.
           </p>
           <p xml:id="kzz7yh-f122176-d1e636">
             ¶ Ad 
             <lb ed="#V" n="7"/>quartum dicendum: quod peccatum in spiritum sanctum eo modo 
             <lb ed="#V" n="8"/>quo hic loquimur non dicitur esse ex malitia que sit habitus: 
-            <lb ed="#V" n="9"/>n ec que sit alius actus malus. Sed secundum quod accipitur 
+            <lb ed="#V" n="9"/>nec que sit alius actus malus. Sed secundum quod accipitur 
             ma<lb ed="#V" n="10" break="no"/>litia pro sola electione mala: quando scilicet voluntas aliquod 
-            ma<lb ed="#V" n="11" break="no"/>lum eligit: non per ignorantiam alicuus rei: que retrahet ab 
-            <lb ed="#V" n="12"/>illa electione: nec etiam per aliqam inclinationem passionis: 
+            ma<lb ed="#V" n="11" break="no"/>lum eligit: non per ignorantiam alicuius rei: que retrahet ab 
+            <lb ed="#V" n="12"/>illa electione: nec etiam per aliquam inclinationem passionis: 
             <lb ed="#V" n="13"/>Quando enim sic eligit aliquod malum spirituale directe 
             oppo<lb ed="#V" n="14" break="no"/>situm alicui effectui spiritus sancti: qui directe et specialiter 
             te<lb ed="#V" n="15" break="no"/>t ruhit ab electione peccati: tunc peccat in spiritum 

--- a/kzz7yh-f122176/cod-ve09v2_kzz7yh-f122176.xml
+++ b/kzz7yh-f122176/cod-ve09v2_kzz7yh-f122176.xml
@@ -351,7 +351,7 @@
             <lb ed="#V" n="12"/>illa electione: nec etiam per aliquam inclinationem passionis: 
             <lb ed="#V" n="13"/>Quando enim sic eligit aliquod malum spirituale directe 
             oppo<lb ed="#V" n="14" break="no"/>situm alicui effectui spiritus sancti: qui directe et specialiter 
-            te<lb ed="#V" n="15" break="no"/>t trahit ab electione peccati: tunc peccat in spiritum 
+            <lb ed="#V" n="15"/>trahit ab electione peccati: tunc peccat in spiritum 
             san<lb ed="#V" n="16" break="no"/>ctum.
           </p>
           <p xml:id="kzz7yh-f122176-d1e660">

--- a/kzz7yh-f122176/cod-ve09v2_kzz7yh-f122176.xml
+++ b/kzz7yh-f122176/cod-ve09v2_kzz7yh-f122176.xml
@@ -351,7 +351,7 @@
             <lb ed="#V" n="12"/>illa electione: nec etiam per aliquam inclinationem passionis: 
             <lb ed="#V" n="13"/>Quando enim sic eligit aliquod malum spirituale directe 
             oppo<lb ed="#V" n="14" break="no"/>situm alicui effectui spiritus sancti: qui directe et specialiter 
-            <lb ed="#V" n="15"/>trahit ab electione peccati: tunc peccat in spiritum 
+            re<lb ed="#V" n="15" break="no"/>trahit ab electione peccati: tunc peccat in spiritum 
             san<lb ed="#V" n="16" break="no"/>ctum.
           </p>
           <p xml:id="kzz7yh-f122176-d1e660">

--- a/kzz7yh-f122176/cod-ve09v2_kzz7yh-f122176.xml
+++ b/kzz7yh-f122176/cod-ve09v2_kzz7yh-f122176.xml
@@ -160,7 +160,7 @@
             dici<lb ed="#V" n="10" break="no"/>tur Io. 4. spiritus est deus scilicet quando aliquis blasphemat 
             <lb ed="#V" n="11"/>ipsum deum: sicut blasphemabant iudei naturam diuinam 
             <lb ed="#V" n="12"/>in christo: opera que per potentiam diuinam faciebat 
-            attri<lb ed="#V" n="13" break="no"/>buentes belebub principi demoniorum: vt habetur Matth. 12. 
+            attri<lb ed="#V" n="13" break="no"/>buentes blezebub principi demoniorum: vt habetur Matth. 12. 
           </p>
           <p xml:id="kzz7yh-f122176-d1e298">
             <lb ed="#V" n="14"/>¶ Quartum etiam dicitur in spiritum sanctum: et ratione 
@@ -351,7 +351,7 @@
             <lb ed="#V" n="12"/>illa electione: nec etiam per aliquam inclinationem passionis: 
             <lb ed="#V" n="13"/>Quando enim sic eligit aliquod malum spirituale directe 
             oppo<lb ed="#V" n="14" break="no"/>situm alicui effectui spiritus sancti: qui directe et specialiter 
-            te<lb ed="#V" n="15" break="no"/>t ruhit ab electione peccati: tunc peccat in spiritum 
+            te<lb ed="#V" n="15" break="no"/>t trahit ab electione peccati: tunc peccat in spiritum 
             san<lb ed="#V" n="16" break="no"/>ctum.
           </p>
           <p xml:id="kzz7yh-f122176-d1e660">


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve09v2_kzz7yh-f122176.xml`.

## Applied changes

- p. 171v l. 83: saecntum → sanctum: garbled OCR
- p. 171v l. 84: spicrintum → spiritum: garbled OCR
- p. 172r l. 4: sinaliter → finaliter: s/f misread at word start
- p. 172r l. 25: Raitione → Ratione: transposed letters
- p. 172r l. 33: Apostouli → Apostoli: extraneous u
- p. 172r l. 41: appropstia → appropria: garbled OCR (word split continues with 'tum' on line 42 with break=no)
- p. 172r l. 88: contennit → contemnit: n/m transposition
- p. 172r l. 99: saecntum → sanctum: garbled OCR
- p. 172r l. 134: contennit → contemnit: n/m transposition
- p. 172v l. 6: santtum → sanctum: doubled t, garbled OCR
- p. 172v l. 9: 'n ec' → 'nec': spurious space within word
- p. 172v l. 11: alicuus → alicuius: missing i
- p. 172v l. 12: aliqam → aliquam: missing u

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_