### PR TITLE
Transcription corrections: cod-ve09v2_kzz7yh-f122746.xml (11 changes)

### DIFF
--- a/kzz7yh-f122746/cod-ve09v2_kzz7yh-f122746.xml
+++ b/kzz7yh-f122746/cod-ve09v2_kzz7yh-f122746.xml
@@ -74,7 +74,7 @@
             Quaestio I. 
             <lb ed="#V" n="24"/>PRimo ostendo quod non sit inter
             <lb ed="#V" n="25"/>alia peccata magister
-            <lb ed="#V" n="26"/>graue Glosinus super illud psal. Nolite extollere in 
+            <lb ed="#V" n="26"/>graue Glos. super illud psal. Nolite extollere in 
             <lb ed="#V" n="27"/>altum cornu v. dicit quod maximum est vitium 
             ex<lb ed="#V" n="28" break="no"/>cusationis peccati: et tamen talis excusatio non est peccatum 
             <lb ed="#V" n="29"/>in spiritum sanctum.
@@ -166,7 +166,7 @@
             <lb ed="#V" n="91"/>annexam auersionem a spiritu sancto. Cum enim 
             homo<lb ed="#V" n="92" break="no"/>vult carnaliter copulari cum non sua non est aliquis motus 
             <lb ed="#V" n="93"/>per se refugiens castitatem: sed motus cui de necessitate 
-            <lb ed="#V" n="94"/>acccidit priuatio castitatis: semper amutem ceteris paribus 
+            <lb ed="#V" n="94"/><sic>acccidit</sic> priuatio castitatis: semper autem ceteris paribus 
             <lb ed="#V" n="95"/>grauius est illud malum quod est per se malum quam illud quod 
             <lb ed="#V" n="96"/>per accidens: et ideo dicit Greg. 25 libro. moter. ante medium 
             <lb ed="#V" n="97"/>locum: inter medium et finem: quod sicut nunquam grauius est 
@@ -242,12 +242,12 @@
           </p>
           <p xml:id="kzz7yh-f122746-d1e443">
             ¶ Item 
-            <lb ed="#V" n="8"/>Glosimnus super illud pslamum. Qui sanat omnes infirmitates 
+            <lb ed="#V" n="8"/>Glos. super illud psalmum. Qui sanat omnes infirmitates 
             tu<lb ed="#V" n="9" break="no"/>as. dicit quod omnipotenti medico nullus insanabilis 
             lan<lb ed="#V" n="10" break="no"/>guor occurrit.
           </p>
           <p xml:id="kzz7yh-f122746-d1e452">
-            ¶ Item Glosinus super illud psal. Dixit 
+            ¶ Item Glos. super illud psal. Dixit 
             do<lb ed="#V" n="11" break="no"/>minus ex basan conuertam. idest ad eos qui erant 
             despera<lb ed="#V" n="12" break="no"/>tissimi: et ita conuertam eos vel conuertar ad eos: ergo 
             despe<lb ed="#V" n="13" break="no"/>ratio que est peccatum in spiritum sanctum aliquando 
@@ -283,7 +283,7 @@
           <p xml:id="kzz7yh-f122746-d1e508">
             <lb ed="#V" n="31"/>Respondeo quod peccatum esse irremissibile 
             tri<lb ed="#V" n="32" break="no"/>pliciter potest intelligi: autem quia deus 
-            <lb ed="#V" n="33"/>illud non potest remittere: aute quia peccatum est in tali 
+            <lb ed="#V" n="33"/>illud non potest remittere: aut quia peccatum est in tali 
             sta<lb ed="#V" n="34" break="no"/>tu: quia non potest se ad remissionem disponere: autem quia 
             pec<lb ed="#V" n="35" break="no"/>catum talis conditionis est: quod excludit directe: et per se 
             ali<lb ed="#V" n="36" break="no"/>quem specialem effectum spiritus sancti: qui specialiter et 

--- a/kzz7yh-f122746/cod-ve09v2_kzz7yh-f122746.xml
+++ b/kzz7yh-f122746/cod-ve09v2_kzz7yh-f122746.xml
@@ -57,7 +57,7 @@
         <p xml:id="kzz7yh-f122746-d1e103">
           <lb ed="#V" n="19"/>COnsequenter queritur de secundo 
           <lb ed="#V" n="20"/>principali. Et 
-          cir<lb ed="#V" n="21" break="no"/>ca hoc querutur duo.
+          cir<lb ed="#V" n="21" break="no"/>ca hoc queruntur duo.
         </p>
         <p xml:id="kzz7yh-f122746-d1e112">
           ¶ Primo vtrum 
@@ -90,12 +90,12 @@
             <lb ed="#V" n="33"/>peccatum est graui: s: quanto plura bona corrumpit: sed in 
             <lb ed="#V" n="34"/>fidelitas corrumpit totius spiritualis edificii fundamentum scilicet 
             <lb ed="#V" n="35"/>fidem: et ex consequenti totum spirituale edificium: peccatum 
-            <lb ed="#V" n="36"/>autem in spiritum sanctum fidem informen non corrumpit: 
+            <lb ed="#V" n="36"/>autem in spiritum sanctum fidem informem non corrumpit: 
             <lb ed="#V" n="37"/>ergo grauius peccatum est infidelitas quam peccatum in 
             <lb ed="#V" n="38"/>spiritum sanctum.
           </p>
           <p xml:id="kzz7yh-f122746-d1e166">
-            ¶ Item Glo. super illud pslalmum. 
+            ¶ Item Glo. super illud psalmum. 
             Conuer<lb ed="#V" n="39" break="no"/>tentur ad vesperam. Nemo insanabilior est eo qui sibi 
             sa<lb ed="#V" n="40" break="no"/>nus videtur: sed peccans ex ignorantia: videtur sibi sanus 
             <lb ed="#V" n="41"/>nullum ergo peccatum est insanabilius: quam peccatum ex 
@@ -145,7 +145,7 @@
             <lb ed="#V" n="70"/>sunt peccata in spiritum sanctum: quanto autem aliquid 
             <lb ed="#V" n="71"/>specialius et vniuersalius retrahit ab electiuo amore 
             cuius<lb ed="#V" n="72" break="no"/>cumque peccati: tanto peccatum ei oppositum est grauius 
-            ra<lb ed="#V" n="73" break="no"/>tione generis peccati. Per istud etiam peccarum grauio 
+            ra<lb ed="#V" n="73" break="no"/>tione generis peccati. Per istud etiam peccatum grauio 
             <lb ed="#V" n="74"/>ri modo auertitur a deo peccans quam per aliquod aliud 
             ge<lb ed="#V" n="75" break="no"/>nus peccati: quia per istud peccatum peccator directe: et 
             <lb ed="#V" n="76"/>per se auertitur ab aliquo effectu speciali spiritus sancti: 
@@ -159,8 +159,8 @@
             <lb ed="#V" n="84"/>agnitam maxime fidei veritatem est illam veritatem 
             re<lb ed="#V" n="85" break="no"/>fugere. Inuidere fraterne gratie est gratiam diuinam 
             re<lb ed="#V" n="86" break="no"/>fugere. Propositum non penitendi est refugere 
-            peniten<lb ed="#V" n="87" break="no"/>tiam. Obstiuari est refugere peccati cautelam: per alia 
-            au<lb ed="#V" n="88" break="no"/>tem peccata non auertitur peccator a spitritu sancto in 
+            peniten<lb ed="#V" n="87" break="no"/>tiam. Obstinari est refugere peccati cautelam: per alia 
+            au<lb ed="#V" n="88" break="no"/>tem peccata non auertitur peccator a spiritu sancto in 
             ali<lb ed="#V" n="89" break="no"/>quo eius speciali effectu: nisi per accidens: inquantum scilicet 
             vo<lb ed="#V" n="90" break="no"/>luntas conuertitur ad aliquid tale: quod necessario habet 
             <lb ed="#V" n="91"/>annexam auersionem a spiritu sancto. Cum enim 
@@ -194,14 +194,14 @@
             ¶ Uel potest dici quod sicut preceptum de 
             dilectio<lb ed="#V" n="112" break="no"/>ne dei: non connumeratur aliis decem preceptis: eo quod radix 
             <lb ed="#V" n="113"/>est omnium aliorum preceptorum. Sicut enim dicit Gre. 
-            <lb ed="#V" n="114"/>in quadam homelis super illud verbum. Hoc est 
+            <lb ed="#V" n="114"/>in quadam homelia super illud verbum. Hoc est 
             prece<lb ed="#V" n="115" break="no"/>ptum meum. Precepta dominica vnum sunt in radice 
             di<lb ed="#V" n="116" break="no"/>lectionis. Ita potest dici quod odium dei radix est omnium 
             <lb ed="#V" n="117"/>peccatorum: per que peccator inordinate mouetur in deum 
             <lb ed="#V" n="118"/>sicut in obiectum ratione alicuius sui specialis effectus: 
             <lb ed="#V" n="119"/>et ideo cum dicitur peccatum in spiritum sanctum esse 
             <lb ed="#V" n="120"/>maximum non est hoc intelligendum per comparationem 
-            <lb ed="#V" n="121"/>ad radicem que est dei odium. Sed per comparatiouem 
+            <lb ed="#V" n="121"/>ad radicem que est dei odium. Sed per comparationem 
             <lb ed="#V" n="122"/>ad alia peccata: sicut enim preceptum de dilectione dei: 
             <lb ed="#V" n="123"/>maius est quolibet alio precepto: sic odium dei 
             simplici<lb ed="#V" n="124" break="no"/>ter maius peccatum est: quolibet alio peccato.
@@ -298,7 +298,7 @@
           </p>
           <p xml:id="kzz7yh-f122746-d1e537">
             ¶ 
-            Secun<lb ed="#V" n="42" break="no"/>do modo peccatum inispiritum sanctum secundum quod accipitur 
+            Secun<lb ed="#V" n="42" break="no"/>do modo peccatum in spiritum sanctum secundum quod accipitur 
             <lb ed="#V" n="43"/>pro quolibet mortali peccato: in quo decedit homo est 
             ir<lb ed="#V" n="44" break="no"/>remissibile: post hanc enim vitam homo est extra statum 
             <lb ed="#V" n="45"/>merendi: decedenti enim in peccato mortali decreuit deus 
@@ -314,7 +314,7 @@
             blas<lb ed="#V" n="55" break="no"/>phemie: que non remittitur: nec in hoc seculo: nec in 
             fu<lb ed="#V" n="56" break="no"/>turo: et post hoc dicit: quod hoc est in penitentia contra quam 
             <lb ed="#V" n="57"/>clamabant preco et iudex dicentes penitentia agite: et 
-            pau<lb ed="#V" n="58" break="no"/>cis interpositis postea subdit haoc omnino in penitentia non 
+            pau<lb ed="#V" n="58" break="no"/>cis interpositis postea subdit hoc omnino in penitentia non 
             <lb ed="#V" n="59"/>habet remissionem neque in hoc seculo: neque in futuro: quia 
             <lb ed="#V" n="60"/>penitentia impetrat remissionem in hoc seculo que valeat 
             <lb ed="#V" n="61"/>in futuro. Sed ista impenitentia vel impenitens cor 
@@ -361,7 +361,7 @@
             <lb ed="#V" n="90"/>Primum argumentum ad partem aliam 
             proce<lb ed="#V" n="91" break="no"/>dit secundum quod peccatum in spiritum 
             san<lb ed="#V" n="92" break="no"/>ctum accipitur pro quolibet mortali peccato in quo 
-            mo<lb ed="#V" n="93" break="no"/>ritur homo non penitens. Cuius opinmonis videtur Aug. 
+            mo<lb ed="#V" n="93" break="no"/>ritur homo non penitens. Cuius opinionis videtur Aug. 
             <lb ed="#V" n="94"/>fuisse: aut glosandum est non remittetur: idest de 
             difficili<lb ed="#V" n="95" break="no"/>remittetur non ex parte dei remittentis: sed ex parte 
             pec<lb ed="#V" n="96" break="no"/>catoris: se cum nimia difficultate disponentis.


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve09v2_kzz7yh-f122746.xml`.

## Applied changes

- p. 172v l. 21: querutur → queruntur: missing n
- p. 172v l. 36: informen → informem: n/m misread at word end
- p. 172v l. 38: pslalmum → psalmum: garbled OCR (transposed letters)
- p. 172v l. 73: peccarum → peccatum: garbled OCR (r/t confusion)
- p. 172v l. 87: Obstiuari → Obstinari: u/n misread
- p. 172v l. 88: spitritu → spiritu: transposed letters
- p. 172v l. 114: homelis → homelia: garbled ending (homilia/homelia = sermon)
- p. 172v l. 121: comparatiouem → comparationem: garbled OCR (ou/on confusion)
- p. 173r l. 42: inispiritum → in spiritum: two words merged without space
- p. 173r l. 58: haoc → hoc: extraneous a
- p. 173r l. 93: opinmonis → opinionis: garbled OCR (m/i confusion)

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_