### PR TITLE
Transcription corrections: cod-ve09v2_kzz7yh-f123364.xml (6 changes)

### DIFF
--- a/kzz7yh-f123364/cod-ve09v2_kzz7yh-f123364.xml
+++ b/kzz7yh-f123364/cod-ve09v2_kzz7yh-f123364.xml
@@ -121,7 +121,7 @@
           </p>
           <p xml:id="kzz7yh-f123364-d1e212">
             ¶ Item <ref xml:id="kzz7yh-f123364-Rd1e219">Ber. de precep. et dis. ca. 25.</ref> dicit quod 
-            nol<lb ed="#V" n="11" break="no"/>le obedire: aut est odiose pertinacie: aute contumacie non 
+            nol<lb ed="#V" n="11" break="no"/>le obedire: aut est odiose pertinacie: aut contumacie non 
             feren<lb ed="#V" n="12" break="no"/>de: quod est ipsum repugnare est et resistere spiritui sancto: et si 
             <lb ed="#V" n="13"/>vsque ad mortem perdurauerit blasphemia est non 
             remitten<lb ed="#V" n="14" break="no"/>da siue in hoc seculo siue in futuro gratie videtur quod 
@@ -244,11 +244,11 @@
             ¶ Ad sextum dicendum: quod 
             <lb ed="#V" n="101"/>sicut per vnam virtutem dantur danda et retinentur 
             reti<lb ed="#V" n="102" break="no"/>nenda: cui tamen opponuntur duo vitia specie diuersa: 
-            <lb ed="#V" n="103"/>secuet prodigalitas que dat danda et retinenda: et auaritia: que 
+            <lb ed="#V" n="103"/>scilicet prodigalitas que dat danda et retinenda: et auaritia: que 
             <lb ed="#V" n="104"/>vtraque retinet: ita per vnam virtutem que penitentia est 
             <lb ed="#V" n="105"/>dolet penitens de peccato preterito: et proponit cauere a 
             <lb ed="#V" n="106"/>futuro: et tamen isti virtuti opponuntur duo vitia 
-            specie<lb ed="#V" n="107" break="no"/>diuersa: secued propositum nunquam penitendi de peccato 
+            specie<lb ed="#V" n="107" break="no"/>diuersa: scilicet propositum nunquam penitendi de peccato 
             prete<lb ed="#V" n="108" break="no"/>rito: et propositum non cauendi a futuro. Uel potest dici: quod 
             <lb ed="#V" n="109"/>obstinatio et impenitentia: non tantum differunt in hoc quod 
             <lb ed="#V" n="110"/>vna sit respectu preteriti: et alia respectu futuri. Sed quia 
@@ -289,8 +289,8 @@
             <lb ed="#V" n="130"/>differt blasphemia et spiritus blasphemine: 
             blas<lb ed="#V" n="131" break="no"/>phemare enim est derogare diuine bonitati ex quacumque 
             <lb ed="#V" n="132"/>causa sibi attribuendo: quod non conuenit sibi: aut ei 
-            negan<lb ed="#V" n="133" break="no"/>do quod sibi conuenit. quandoque contingere potest ex ignoram 
-            <lb ed="#V" n="134"/>tia: quandoque ex infirmitate: sicut cum aliquis blasphemat 
+            negan<lb ed="#V" n="133" break="no"/>do quod sibi conuenit. quandoque contingere potest ex 
+            ignoram<lb ed="#V" n="134" break="no"/>tia: quandoque ex infirmitate: sicut cum aliquis blasphemat 
             <lb ed="#V" n="135"/>ex ira vel ex aliqua alia passione: quandoque ex electione: 
             <lb ed="#V" n="136"/>primo modo et secundo non est peccatum in spiritum sanctum: 
             <!--00363.xml-->

--- a/kzz7yh-f123364/cod-ve09v2_kzz7yh-f123364.xml
+++ b/kzz7yh-f123364/cod-ve09v2_kzz7yh-f123364.xml
@@ -97,7 +97,7 @@
           </p>
           <p xml:id="kzz7yh-f123364-d1e168">
             <lb ed="#V" n="134"/>¶ Item inuidia est vnum de septem capitalibus vitiis: 
-            <lb ed="#V" n="135"/>vt superius hapitum est. Sed capitale vitium non est 
+            <lb ed="#V" n="135"/>vt superius habitum est. Sed capitale vitium non est 
             <lb ed="#V" n="136"/>peccatum in spiritum sanctum: nec inuidentia fraterne 
             <!--00362.xml-->
             <pb ed="#V" n="173-v"/>
@@ -115,7 +115,7 @@
             <lb ed="#V" n="5"/>non cauendi a peccatis futuris. Sed hoc spectare videtur ad 
             <lb ed="#V" n="6"/>impenitentiam: sicut enim vere penitentie est peccata 
             preteri<lb ed="#V" n="7" break="no"/>ta plangere et proponere non committere plangenda: ita videtur quod 
-            <lb ed="#V" n="8"/>impenitens et praeterita non plangat et committere plangenda propositionat: 
+            <lb ed="#V" n="8"/>impenitens et praeterita non plangat et committere plangenda proponat: 
             <lb ed="#V" n="9"/>obstinatio ergo non videtur distincta species peccati ab 
             im<lb ed="#V" n="10" break="no"/>penitentia.
           </p>
@@ -129,10 +129,10 @@
             <lb ed="#V" n="16"/>sunt.
           </p>
           <p xml:id="kzz7yh-f123364-d1e228">
-            ¶ Item blasphemia est peccatum in spiritum sanctum vet 
+            ¶ Item blasphemia est peccatum in spiritum sanctum vt 
             ha<lb ed="#V" n="17" break="no"/>betur <ref xml:id="kzz7yh-f123364-Rd1e239">Matth. 12.</ref> nec tamen videtur comprehendi sub aliqua 
             <lb ed="#V" n="18"/>predictarum specierum: ergo videtur quod plures species sint peccati 
-            <lb ed="#V" n="19"/>in supiritum sanctum quam ille que enumerate sunt. 
+            <lb ed="#V" n="19"/>in spiritum sanctum quam ille que enumerate sunt. 
             <!--TODO: Add a paragraph here-->
             <lb ed="#V" n="20"/>In contrarium est communis opinio magistrorum qua praedicans 
             <lb ed="#V" n="21"/>sex species in spiritum sanctum enumerant: 
@@ -143,7 +143,7 @@
             <lb ed="#V" n="23"/>species ex dictis sanctorum habentur. Augu. enim in lib. de fide ad 
             <lb ed="#V" n="24"/>petrum ponit desperationem et presumptionem in enchi. 
             ob<lb ed="#V" n="25" break="no"/>stinationem in libo de verbis domini. Impenitentiam finalem in I 
-            <lb ed="#V" n="26"/>lib. de sermone domini in modote: fraterne gratiae inuidentiam in 
+            <lb ed="#V" n="26"/>lib. de sermone domini in monte: fraterne gratiae inuidentiam in 
             <lb ed="#V" n="27"/>lib. de vnico baptismo veritatis agnite impugnationem. 
           </p>
           <p xml:id="kzz7yh-f123364-d1e257">
@@ -266,8 +266,8 @@
             ¶ Ad vltimum dicendum: quod blasphemia 
             redu<lb ed="#V" n="117" break="no"/>citur ad impugnationem agnite veritatis. Blasphemia 
             <lb ed="#V" n="118"/>enim est derogatio contra aliquam bonitatem excellentem: 
-            <lb ed="#V" n="119"/>et quia diuina bonitas est excellentissima: Ideo sibi deroga 
-            <lb ed="#V" n="120"/>re est maxime blasphemare: derogatur autem ei: vel sibi 
+            <lb ed="#V" n="119"/>et quia diuina bonitas est excellentissima: Ideo sibi 
+            deroga<lb ed="#V" n="120" break="no"/>re est maxime blasphemare: derogatur autem ei: vel sibi 
             <lb ed="#V" n="121"/>attribuendo vel optando quod ei non conuenit vel sibi 
             negan<lb ed="#V" n="122" break="no"/>do quod ei conuenit: quod si fiat tantum per cogitationem 
             intel<lb ed="#V" n="123" break="no"/>lectus et motionem affectus dicitur blasphemia cordis. 

--- a/kzz7yh-f123364/cod-ve09v2_kzz7yh-f123364.xml
+++ b/kzz7yh-f123364/cod-ve09v2_kzz7yh-f123364.xml
@@ -290,7 +290,7 @@
             blas<lb ed="#V" n="131" break="no"/>phemare enim est derogare diuine bonitati ex quacumque 
             <lb ed="#V" n="132"/>causa sibi attribuendo: quod non conuenit sibi: aut ei 
             negan<lb ed="#V" n="133" break="no"/>do quod sibi conuenit. quandoque contingere potest ex 
-            ignoram<lb ed="#V" n="134" break="no"/>tia: quandoque ex infirmitate: sicut cum aliquis blasphemat 
+            ignoran<lb ed="#V" n="134" break="no"/>tia: quandoque ex infirmitate: sicut cum aliquis blasphemat 
             <lb ed="#V" n="135"/>ex ira vel ex aliqua alia passione: quandoque ex electione: 
             <lb ed="#V" n="136"/>primo modo et secundo non est peccatum in spiritum sanctum: 
             <!--00363.xml-->


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve09v2_kzz7yh-f123364.xml`.

## Applied changes

- p. 173r l. 135: hapitum → habitum: garbled OCR (p/b confusion)
- p. 173v l. 8: propositionat → proponat: garbled OCR of subjunctive form
- p. 173v l. 16: vet → vt: extraneous e (= ut)
- p. 173v l. 19: supiritum → spiritum: transposed letters
- p. 173v l. 26: modote → monte: garbled OCR (reference to 'sermone domini in monte')
- p. 173v l. 120: 'deroga' + 're' split across line break without break="no" on lb n=120

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_