### PR TITLE
Transcription corrections: cod-ve09v2_kzz7yh-f123971.xml (1 change)

### DIFF
--- a/kzz7yh-f123971/cod-ve09v2_kzz7yh-f123971.xml
+++ b/kzz7yh-f123971/cod-ve09v2_kzz7yh-f123971.xml
@@ -175,7 +175,7 @@
         <p xml:id="kzz7yh-f123971-d1e343">
           ¶ 
           Se<lb ed="#V" n="37" break="no"/>cundo inquirit incidentaliter de potentia que in diabolo est. ibi 
-          <lb ed="#V" n="38"/>HHic oritur quaestio
+          <lb ed="#V" n="38"/>Hic oritur quaestio
         </p>
         <p xml:id="kzz7yh-f123971-d1e350">
           ¶ Primo in tres.


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve09v2_kzz7yh-f123971.xml`.

## Applied changes

- p. 174v l. 38: HHic → Hic: doubled capital H is OCR duplication error

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_