### PR TITLE
Transcription corrections: cod-ve09v2_kzz7yh-f124277.xml (7 changes)

### DIFF
--- a/kzz7yh-f124277/cod-ve09v2_kzz7yh-f124277.xml
+++ b/kzz7yh-f124277/cod-ve09v2_kzz7yh-f124277.xml
@@ -125,7 +125,7 @@
             <lb ed="#V" n="84"/>est voluntas: non tamen dici potest quod in beato sit peccandi 
             poten<lb ed="#V" n="85" break="no"/>tia: sed potentia peccandi nominat: et ipsam voluntatem: et eius 
             <lb ed="#V" n="86"/>defectibilitatem per quam potest in actualem eius defectum 
-            pecca<lb ed="#V" n="87" break="no"/>ti: et ideo quamus ista non sit concedenda: potentia peccandi est 
+            pecca<lb ed="#V" n="87" break="no"/>ti: et ideo <sic>quamus</sic> ista non sit concedenda: potentia peccandi est 
             <lb ed="#V" n="88"/>potentia sine distinctione: tamen hoc est simpliciter concedenda: 
             volun<lb ed="#V" n="89" break="no"/>tas est potentia.
           </p>
@@ -137,7 +137,7 @@
             similitudi<lb ed="#V" n="93" break="no"/>nem illius boni: cuius est carentia. Ideo scire carentiam 
             bo<lb ed="#V" n="94" break="no"/>ni debiti est scire: omne etiam cognitum potest esse obiectum 
             vo<lb ed="#V" n="95" break="no"/>luntatis. Et ideo nolle carentiam illam est vere nolle: et 
-            vel<lb ed="#V" n="96" break="no"/>le illam per accidens caliter enim non potest voluntas ipsum 
+            vel<lb ed="#V" n="96" break="no"/>le illam per accidens (aliter enim non potest voluntas ipsum 
             <lb ed="#V" n="97"/>velle est velle: sed potentia respicit suum obiectum secundum esse 
             rea<lb ed="#V" n="98" break="no"/>le: et quia deformitas peccati: nullum habet esse reale: ideo talem 
             <lb ed="#V" n="99"/>posse deformitatem non est posse: sed non posse.
@@ -203,7 +203,7 @@
           <p xml:id="kzz7yh-f124277-d1e354">
             ¶ Argumenta ad partem aliam 
             proce<lb ed="#V" n="3" break="no"/>dunt de potentia peccandi: inquantum est principium essentie 
-            <lb ed="#V" n="4"/>actus substrcti deformitatis peccati: et sic verum est quod 
+            <lb ed="#V" n="4"/>actus <sic>substrcti</sic> deformitatis peccati: et sic verum est quod 
             bo<lb ed="#V" n="5" break="no"/>na est et a deo est.
           </p>
           <p xml:id="kzz7yh-f124277-d1e363">

--- a/kzz7yh-f124277/cod-ve09v2_kzz7yh-f124277.xml
+++ b/kzz7yh-f124277/cod-ve09v2_kzz7yh-f124277.xml
@@ -79,7 +79,7 @@
           </p>
           <p xml:id="kzz7yh-f124277-d1e135">
             ¶ Item in eodem libro parum post 
-            au<lb ed="#V" n="58" break="no"/>ctoritatem psallegatam: dicit Ansel. quod liberior est voluntas 
+            au<lb ed="#V" n="58" break="no"/>ctoritatem praeallegatam: dicit Ansel. quod liberior est voluntas 
             <lb ed="#V" n="59"/>que a rectitudine declinare nequit: quam que illam potest 
             dese<lb ed="#V" n="60" break="no"/>rere. Sed si potentia peccandi esset aliqua potentia per eam non 
             <lb ed="#V" n="61"/>esset voluntas minus libera: quia quanto voluntas est potentior: 
@@ -107,7 +107,7 @@
             <lb ed="#V" n="71"/>Respondeo potentia peccandi est potentia 
             defe<lb ed="#V" n="72" break="no"/>ctibilis: defectibilitas autem 
             dimi<lb ed="#V" n="73" break="no"/>nuit de ratione potentie. Unum ratione ipsius defectibilitatis: non 
-            <lb ed="#V" n="74"/>est potentia: sed magis in potentia. Raitione vero essentie: cui 
+            <lb ed="#V" n="74"/>est potentia: sed magis in potentia. Ratione vero essentie: cui 
             <lb ed="#V" n="75"/>praedicta defectibilitas est annexa potentia est.
           </p>
           <p xml:id="kzz7yh-f124277-d1e192">
@@ -120,8 +120,8 @@
             <lb ed="#V" n="79"/>Ad primum in oppositum ad partem aliam: 
             <lb ed="#V" n="80"/>dicendum quod non est idem quaerere: vtrum 
             <lb ed="#V" n="81"/>voluntas sit potentia: et vtrum potentia peccandi sit potentia: 
-            <lb ed="#V" n="82"/>quamuis voluntas sit ipsa potentia peccandi: quia in sign ficato 
-            vo<lb ed="#V" n="83" break="no"/>luntatis illa defectibilitas no includitur. Uoluntas enim beata 
+            <lb ed="#V" n="82"/>quamuis voluntas sit ipsa potentia peccandi: quia in significato 
+            vo<lb ed="#V" n="83" break="no"/>luntatis illa defectibilitas non includitur. Uoluntas enim beata 
             <lb ed="#V" n="84"/>est voluntas: non tamen dici potest quod in beato sit peccandi 
             poten<lb ed="#V" n="85" break="no"/>tia: sed potentia peccandi nominat: et ipsam voluntatem: et eius 
             <lb ed="#V" n="86"/>defectibilitatem per quam potest in actualem eius defectum 
@@ -132,13 +132,13 @@
           <p xml:id="kzz7yh-f124277-d1e227">
             ¶ Ad secundum dicendum: quod non est simile de 
             sci<lb ed="#V" n="90" break="no"/>re: et velle peccare: et posse peccare: quia scire respicit suum 
-            <lb ed="#V" n="91"/>obictum: quantum ad suum esse representatum intellectui: et quia 
+            <lb ed="#V" n="91"/>obiectum: quantum ad suum esse representatum intellectui: et quia 
             priua<lb ed="#V" n="92" break="no"/>tio boni debiti potest representari intellectui: per 
             similitudi<lb ed="#V" n="93" break="no"/>nem illius boni: cuius est carentia. Ideo scire carentiam 
-            bo<lb ed="#V" n="94" break="no"/>ni debiti est scire: omne etiam cognitum potest esse obisctum 
+            bo<lb ed="#V" n="94" break="no"/>ni debiti est scire: omne etiam cognitum potest esse obiectum 
             vo<lb ed="#V" n="95" break="no"/>luntatis. Et ideo nolle carentiam illam est vere nolle: et 
             vel<lb ed="#V" n="96" break="no"/>le illam per accidens caliter enim non potest voluntas ipsum 
-            <lb ed="#V" n="97"/>velle est velle: sed potentia respicit suum obicitum secundum esse 
+            <lb ed="#V" n="97"/>velle est velle: sed potentia respicit suum obiectum secundum esse 
             rea<lb ed="#V" n="98" break="no"/>le: et quia deformitas peccati: nullum habet esse reale: ideo talem 
             <lb ed="#V" n="99"/>posse deformitatem non est posse: sed non posse.
           </p>


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve09v2_kzz7yh-f124277.xml`.

## Applied changes

- p. 174v l. 58: psallegatam → praeallegatam: prae- prefix garbled to ps- by OCR
- p. 174v l. 74: Raitione → Ratione: ai transposition OCR error
- p. 174v l. 82: sign ficato → significato: OCR inserted space, dropping 'ific'
- p. 174v l. 83: no includitur → non includitur: missing final n in 'non'
- p. 174v l. 91: obictum → obiectum: missing 'e' (OCR drop)
- p. 174v l. 94: obisctum → obiectum: transposed/garbled letters (OCR error)
- p. 174v l. 97: obicitum → obiectum: garbled vowels (OCR error)

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_