### PR TITLE
Transcription corrections: cod-ve09v2_kzz7yh-f124844.xml (7 changes)

### DIFF
--- a/kzz7yh-f124844/cod-ve09v2_kzz7yh-f124844.xml
+++ b/kzz7yh-f124844/cod-ve09v2_kzz7yh-f124844.xml
@@ -80,7 +80,7 @@
             <lb ed="#V" n="118"/>etiam non vergunt: nisi in vtilitatem temporalem dominorum. 
             <lb ed="#V" n="119"/><ref xml:id="kzz7yh-f124844-Rd1e149">Apostolus Rom. 13.</ref> Omnis anima potestatibus sublimioribus 
             sub<lb ed="#V" n="120" break="no"/>dita sit. Sed secundum philosophum 2 li. Top. quod nullo addito dicitur: 
-            sim<lb ed="#V" n="121" break="no"/>pliciter dicitur: ergo videtur: quod subditt dominis temporalibus simpliciter 
+            sim<lb ed="#V" n="121" break="no"/>pliciter dicitur: ergo videtur: quod subditi dominis temporalibus simpliciter 
             obe<lb ed="#V" n="122" break="no"/>dire teneantur in omnibus.
           </p>
           <p xml:id="kzz7yh-f124844-d1e152">
@@ -134,10 +134,10 @@
             <lb ed="#V" n="18"/>scandalum esset necessarium obedire. Sed ad videndum 
             <lb ed="#V" n="19"/>vtrum imponere tallias de nouo que non vergunt: nisi in 
             <lb ed="#V" n="20"/>vtilitatem temporalem dominorum sub eorum contineatur 
-            pote<lb ed="#V" n="21" break="no"/>state distinguendum est de fubditis. Quia aut sunt serui: 
+            pote<lb ed="#V" n="21" break="no"/>state distinguendum est de subditis. Quia aut sunt serui: 
             <lb ed="#V" n="22"/>aut liberi. Si serui simpliciter: dico quod domini possunt eis de nouo 
             <lb ed="#V" n="23"/>tallias imponere: quamuis non virgant: nisi in vtilitatem 
-            do<lb ed="#V" n="24" break="no"/>minorum: et iserui tenentur obedire. Quia seruus et res eius sunt 
+            do<lb ed="#V" n="24" break="no"/>minorum: et serui tenentur obedire. Quia seruus et res eius sunt 
             <lb ed="#V" n="25"/>possessio dominorum. Unde philosophus. I. Poli. dicit quod seruus est 
             <lb ed="#V" n="26"/>res possessa: vnde si fugiat dominum: domino debet restitui. Extra 
             <lb ed="#V" n="27"/>de seruis non ordinandis: de seruorum. Si autem subditi sint 
@@ -156,7 +156,7 @@
             <lb ed="#V" n="40"/>exactiones sine auctoritate et consensu regum et principum 
             <lb ed="#V" n="41"/>statuere aliquo modo praesumat. Siquis autem contra hoc fecerit: et 
             <lb ed="#V" n="42"/>commonitus non destiterit: donec satisfaciat: communione 
-            ca<lb ed="#V" n="43" break="no"/>reat christiana. Hoc enim habeter infra de ver. signi. super 
+            ca<lb ed="#V" n="43" break="no"/>reat christiana. Hoc enim habetur infra de ver. signi. super 
             <lb ed="#V" n="44"/>quibusdam
           </p>
           <p xml:id="kzz7yh-f124844-d1e299">
@@ -306,7 +306,7 @@
             <pb ed="#V" n="176-r"/>
             <cb ed="#P" n="a"/>
             <lb ed="#V" n="1"/>charitate dei obediat. Sed talis monitio esset 
-            irrationa<lb ed="#V" n="2" break="no"/>lis: nisi esset mangis prelato obediendum: quam cuicumque 
+            irrationa<lb ed="#V" n="2" break="no"/>lis: nisi esset magis prelato obediendum: quam cuicumque 
             ho<lb ed="#V" n="3" break="no"/>mini alii.
           </p>
           <p xml:id="kzz7yh-f124844-d1e567">
@@ -342,7 +342,7 @@
             <lb ed="#V" n="24"/>autem eorum in quibus obligantur filii parentibus de 
             iu<lb ed="#V" n="25" break="no"/>re nature: et de iure diuino magis tenentur professi in 
             re<lb ed="#V" n="26" break="no"/>ligione obedire loco et tempore patri carnali quam suo 
-            prela<lb ed="#V" n="27" break="no"/>to precipienti contrarium. Pofessio enim in religione 
+            prela<lb ed="#V" n="27" break="no"/>to precipienti contrarium. Professio enim in religione 
             nul<lb ed="#V" n="28" break="no"/>lum absoluit ab obligatione diuini precepti: ad hoc enim 
             <lb ed="#V" n="29"/>est obseruatio consiliorum: vt perfectius obseruentur 
             pre<lb ed="#V" n="30" break="no"/>cepta diuina. Unde per hoc quod religiosi profitentur 
@@ -401,7 +401,7 @@
             pote<lb ed="#V" n="63" break="no"/>statis quod propter hoc dico: quia sicut dicit Ber. de 
             praecepto<lb ed="#V" n="64" break="no"/>et dispen. ca 8. quisque professus in quo vis genere 
             saluti<lb ed="#V" n="65" break="no"/>fere: nec vltra obedire legem cogendus: nec circa est 
-            inhi<lb ed="#V" n="66" break="no"/>bendus: quam sua ipsius videtur eomplecti professio. Si autem 
+            inhi<lb ed="#V" n="66" break="no"/>bendus: quam sua ipsius videtur complecti professio. Si autem 
             <lb ed="#V" n="67"/>prelatus preciperet suo subdito contrarium illi in quo 
             sub<lb ed="#V" n="68" break="no"/>ditus obligatur parentibus de iure nature: vel diuino 
             pre<lb ed="#V" n="69" break="no"/>ciperet contra deum: et ideo in illo precepto sibi non esset 

--- a/kzz7yh-f124844/cod-ve09v2_kzz7yh-f124844.xml
+++ b/kzz7yh-f124844/cod-ve09v2_kzz7yh-f124844.xml
@@ -136,7 +136,7 @@
             <lb ed="#V" n="20"/>vtilitatem temporalem dominorum sub eorum contineatur 
             pote<lb ed="#V" n="21" break="no"/>state distinguendum est de subditis. Quia aut sunt serui: 
             <lb ed="#V" n="22"/>aut liberi. Si serui simpliciter: dico quod domini possunt eis de nouo 
-            <lb ed="#V" n="23"/>tallias imponere: quamuis non virgant: nisi in vtilitatem 
+            <lb ed="#V" n="23"/>tallias imponere: quamuis non <sic>virgant:</sic> nisi in vtilitatem 
             do<lb ed="#V" n="24" break="no"/>minorum: et serui tenentur obedire. Quia seruus et res eius sunt 
             <lb ed="#V" n="25"/>possessio dominorum. Unde philosophus. I. Poli. dicit quod seruus est 
             <lb ed="#V" n="26"/>res possessa: vnde si fugiat dominum: domino debet restitui. Extra 
@@ -161,7 +161,7 @@
           </p>
           <p xml:id="kzz7yh-f124844-d1e299">
             ¶ Preterea: ad hoc etiam facit illud quod habetur. C. 
-            <lb ed="#V" n="45"/>noua vetigalia institui non posse. l. 1. et 2. et 3. Et. ff. de 
+            <lb ed="#V" n="45"/>noua <sic>vetigalia</sic> institui non posse. l. 1. et 2. et 3. Et. ff. de 
             legi<lb ed="#V" n="46" break="no"/>bus et senatusconsultis l. et ideo.
           </p>
           <p xml:id="kzz7yh-f124844-d1e306">


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve09v2_kzz7yh-f124844.xml`.

## Applied changes

- p. 175r l. 121: subditt -> subditi: double t at word end is OCR error for i
- p. 175v l. 21: fubditis -> subditis: long-s (s) misread as f at word start
- p. 175v l. 24: iserui -> serui: spurious leading i; context reads 'et serui tenentur obedire'
- p. 175v l. 43: habeter -> habetur: t/r transposition at word end
- p. 176r l. 2: mangis -> magis: spurious n inserted by OCR
- p. 176r l. 27: Pofessio -> Professio: long-s (s) misread as f; missing r after P
- p. 176r l. 66: eomplecti -> complecti: e/c OCR misread at word start

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_