### PR TITLE
Transcription corrections: cod-ve09v2_kzz7yh-f125549.xml (1 change)

### DIFF
--- a/kzz7yh-f125549/cod-ve09v2_kzz7yh-f125549.xml
+++ b/kzz7yh-f125549/cod-ve09v2_kzz7yh-f125549.xml
@@ -88,7 +88,7 @@
           scri<lb ed="#V" n="114" break="no"/>bitur <ref xml:id="kzz7yh-f125549-Rd1e165">Matth. 10.</ref> Qui perseuerauerit vsque in finem: hic 
           <lb ed="#V" n="115"/>saluus erit. Ad quam salutem per obedientie 
           perseueran<lb ed="#V" n="116" break="no"/>tiam: nos perducere dignetur et spiritualiter me dominus 
-          <lb ed="#V" n="117"/>noster Iesus Cchristus qui cum patre et spiritu sancto viuit et 
+          <lb ed="#V" n="117"/>noster Iesus Christus qui cum patre et spiritu sancto viuit et 
           <lb ed="#V" n="118"/>regnat deus per omnia secula seculorum. Amen. 
         </p>
       </div>


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve09v2_kzz7yh-f125549.xml`.

## Applied changes

- p. -r l. 117: Cchristus -> Christus: doubled C at word start is OCR error

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_