### PR TITLE
Transcription corrections: cod-ve09v2_kzz7yh-f12694.xml (5 changes)

### DIFF
--- a/kzz7yh-f12694/cod-ve09v2_kzz7yh-f12694.xml
+++ b/kzz7yh-f12694/cod-ve09v2_kzz7yh-f12694.xml
@@ -121,7 +121,7 @@
             <lb ed="#V" n="120"/>propria essentia. Si enim esset excessus in essentia in vno respectu 
             <lb ed="#V" n="121"/>alterius eiusdem speciei: non essent cum quibus excessus in 
             gradu<lb ed="#V" n="122" break="no"/>essentiali posset designari essentiali diferentia: et differentia essentialis 
-            ali<lb ed="#V" n="123" break="no"/>cui adueniens: speciem constituit: aute specialissimam: aut 
+            ali<lb ed="#V" n="123" break="no"/>cui adueniens: speciem constituit: aut specialissimam: aut 
             subal<lb ed="#V" n="124" break="no"/>ternam. Esse autem plures angelos tales: nullam 
             contradi<lb ed="#V" n="125" break="no"/>ctionem includit: siue habeant materiam siue non. Quia quamuis 
             <lb ed="#V" n="126"/>supradicto modo sint similes: ad hoc se ipsis formaliter 
@@ -186,7 +186,7 @@
             <lb ed="#V" n="31"/>vnius generis: sicut homines.
           </p>
           <p xml:id="kzz7yh-f12694-d1e339">
-            ¶ Ad secundm dicendum: quod non est 
+            ¶ Ad secundum dicendum: quod non est 
             si<lb ed="#V" n="32" break="no"/>mile de animabus. Quia sola corpora humana sunt 
             perfecti<lb ed="#V" n="33" break="no"/>bilia ab anima intellectiua: et nullum corpus humanum 
             perfe<lb ed="#V" n="34" break="no"/>ctibile est alia specifica perfectione quam aliud: et ideo omnes anime 
@@ -238,7 +238,7 @@
             <lb ed="#V" n="63"/>sunt secundum naturam sunt illa quecumque per se ipsa insunt hiis. 
             <lb ed="#V" n="64"/>ergo non tantum sunt proprietates naturales que insunt 
             composi<lb ed="#V" n="65" break="no"/>to per naturam forme: sed etiam ille que insunt composito per 
-            <lb ed="#V" n="66"/>naturam materie. Illle autem que dicuntur inesse per naturam 
+            <lb ed="#V" n="66"/>naturam materie. Ille autem que dicuntur inesse per naturam 
             for<lb ed="#V" n="67" break="no"/>me: consequuntur de necessitate quodlibet indiuiduum speciei: 
             <lb ed="#V" n="68"/>quia res est in specie principaliter per formam. Ille autem dicun¬ 
             <!--00050.xml-->
@@ -278,13 +278,13 @@
             ¶ Ad tertium dicendum quod existentia in 
             ea<lb ed="#V" n="94" break="no"/>dem speciem quamuis habeant materiam vnigeneam et differentiam in aliquibus 
             <lb ed="#V" n="95"/>proprietatibus naturalibus: que insunt composito ex parte materie: non 
-            <lb ed="#V" n="96"/>propter hoc sunt tramsmutabilia naturaliter abinuicem: qui 
+            <lb ed="#V" n="96"/>propter hoc sunt transmutabilia naturaliter abinuicem: qui 
             <lb ed="#V" n="97"/>enim sic sunt transmutabilia requirunt diuersitatem in 
             <lb ed="#V" n="98"/>forma secundum speciem.
           </p>
           <p xml:id="kzz7yh-f12694-d1e517">
             ¶ Uel potest dici quod forma naturalis et 
-            pro<lb ed="#V" n="99" break="no"/>prietates naturales conseequentes angelum siue ex parte materie siue 
+            pro<lb ed="#V" n="99" break="no"/>prietates naturales consequentes angelum siue ex parte materie siue 
             <lb ed="#V" n="100"/>ex parte forme: non sunt producibiles nisi a supernaturali 
             agen<lb ed="#V" n="101" break="no"/>te scilicet a deo. a quo est et dependet immediate tantum tota 
             <lb ed="#V" n="102"/>essentia angelorum. 

--- a/kzz7yh-f12694/cod-ve09v2_kzz7yh-f12694.xml
+++ b/kzz7yh-f12694/cod-ve09v2_kzz7yh-f12694.xml
@@ -102,7 +102,7 @@
             <lb ed="#V" n="108"/>quot indiuidua. 
           </p>
           <p xml:id="kzz7yh-f12694-d1e180">
-            <lb ed="#V" n="109"/>Contra Anselus in libro cur deus hoc. c. i. omnes angeli sunt 
+            <lb ed="#V" n="109"/>Contra Anselmum in libro cur deus hoc. c. i. omnes angeli sunt 
             <lb ed="#V" n="110"/>vnius nature. Sed quae sunt vnius nature: sunt vnius speciei. 
             <lb ed="#V" n="111"/>ergo omnes angeli sunt in vna specie.
           </p>


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve09v2_kzz7yh-f12694.xml`.

## Applied changes

- p. 18r l. 123: aute -> aut: spurious trailing e; context reads 'speciem constituit: aut specialissimam: aut subalternam'
- p. 18v l. 31: secundm -> secundum: OCR garbled ending; standard abbreviation expansion
- p. 18v l. 66: Illle -> Ille: triple l OCR error; context reads 'Ille autem que dicuntur inesse per naturam materie'
- p. 18v l. 96: tramsmutabilia -> transmutabilia: transposed letters 'tram' -> 'trans'
- p. 18v l. 99: conseequentes -> consequentes: doubled e is OCR error

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_