### PR TITLE
Transcription corrections: cod-ve09v2_kzz7yh-f13125.xml (12 changes)

### DIFF
--- a/kzz7yh-f13125/cod-ve09v2_kzz7yh-f13125.xml
+++ b/kzz7yh-f13125/cod-ve09v2_kzz7yh-f13125.xml
@@ -128,8 +128,8 @@
             crea<lb ed="#V" n="6" break="no"/>tum: nisi ad hoc quod intellectus similior fiat intelligibili et 
             <lb ed="#V" n="7"/>actualior respectu illius: et determinetur ad ipsum: et vt 
             <lb ed="#V" n="8"/>per ipsam intelligibile aliquo modo sit intelligente. 
-            Ange<lb ed="#V" n="9" break="no"/>lus autem per essentiam suam est similior sibi ipsi quam per. quamcumque 
-            <lb ed="#V" n="10"/>quam speciem: et est actualior respectu sui ipsius: et sufficienter 
+            Ange<lb ed="#V" n="9" break="no"/>lus autem per essentiam suam est similior sibi ipsi quam per. quamcum
+            <lb ed="#V" n="10" break="no"/>que quam speciem: et est actualior respectu sui ipsius: et sufficienter 
             de<lb ed="#V" n="11" break="no"/>terminatus respectu sui ipsius. et verius est in se ipso per 
             <lb ed="#V" n="12"/>essentiam suam quam intelligibile sit in intellectu per speciem. Et ideo 
             <lb ed="#V" n="13"/>per essentiam suam angelus intelligit semetipsum. Anima tamen 

--- a/kzz7yh-f13125/cod-ve09v2_kzz7yh-f13125.xml
+++ b/kzz7yh-f13125/cod-ve09v2_kzz7yh-f13125.xml
@@ -128,7 +128,7 @@
             crea<lb ed="#V" n="6" break="no"/>tum: nisi ad hoc quod intellectus similior fiat intelligibili et 
             <lb ed="#V" n="7"/>actualior respectu illius: et determinetur ad ipsum: et vt 
             <lb ed="#V" n="8"/>per ipsam intelligibile aliquo modo sit intelligente. 
-            Ange<lb ed="#V" n="9" break="no"/>lus autem per essentiam suam est similior sibi ipsi quam per. quancum 
+            Ange<lb ed="#V" n="9" break="no"/>lus autem per essentiam suam est similior sibi ipsi quam per. quamcumque 
             <lb ed="#V" n="10"/>quam speciem: et est actualior respectu sui ipsius: et sufficienter 
             de<lb ed="#V" n="11" break="no"/>terminatus respectu sui ipsius. et verius est in se ipso per 
             <lb ed="#V" n="12"/>essentiam suam quam intelligibile sit in intellectu per speciem. Et ideo 
@@ -155,7 +155,7 @@
             intel<lb ed="#V" n="30" break="no"/>lectu: cum per ipsam intellectus eius informetur et determinetur respectu illius 
             <lb ed="#V" n="31"/>eiusdem habitus: non cognoscit per speciem aliam: quamuis non sic 
             <lb ed="#V" n="32"/>possit dici de anima: dum est corporis corruptibilis forma: 
-            <lb ed="#V" n="33"/>quia naturaliter et de lege communi venit in cogionem habituum: qui 
+            <lb ed="#V" n="33"/>quia naturaliter et de lege communi venit in <sic>cognionem</sic> habituum: qui 
             <lb ed="#V" n="34"/>sunt in ea: incipiendo a cognitione obiecti: et inde veniendo 
             <lb ed="#V" n="35"/>ad cognitionem actus.
           </p>
@@ -326,7 +326,7 @@
           </p>
           <p xml:id="kzz7yh-f13125-d1e594">
             ¶ Ad secundum dicendum quod dicitur 
-            <lb ed="#V" n="12"/>deficit: quia in deo sunt infinite vdee: et quilet creatura propriam 
+            <lb ed="#V" n="12"/>deficit: quia in deo sunt infinite ydee: et quaelibet creatura propriam 
             <lb ed="#V" n="13"/>ydeam cognoscitur: vt in primo libero ostensum est. Species aut 
             con<lb ed="#V" n="14" break="no"/>create ipsis angelis sunt in numero finito et determinato. 
           </p>

--- a/kzz7yh-f13125/cod-ve09v2_kzz7yh-f13125.xml
+++ b/kzz7yh-f13125/cod-ve09v2_kzz7yh-f13125.xml
@@ -98,15 +98,15 @@
           </p>
           <p xml:id="kzz7yh-f13125-d1e170">
             ¶ Item cognitio est per assimilationem 
-            intel<lb ed="#V" n="125" break="no"/>lectus ad intelligibile. Sed substantia magis est subslantie 
+            intel<lb ed="#V" n="125" break="no"/>lectus ad intelligibile. Sed substantia magis est substantie 
             <lb ed="#V" n="126"/>similis quam accidens. Cum ergo species intelligibilis in intellectu sit 
             <lb ed="#V" n="127"/>accidens: magis potest angelus intelligere substantias alias a 
             <lb ed="#V" n="128"/>se per essentiam suam quam per speciem aliquam. 
           </p>
           <p xml:id="kzz7yh-f13125-d1e182">
-            <lb ed="#V" n="129"/>Contra super decimam propotionem de causis forme quae 
+            <lb ed="#V" n="129"/>Contra super decimam proportionem de causis forme quae 
             <lb ed="#V" n="130"/>sunt in intelligentiis secundis superioribus per 
-            <lb ed="#V" n="131"/>modum particularem: sunt in itelligentiis primis per modum 
+            <lb ed="#V" n="131"/>modum particularem: sunt in intelligentiis primis per modum 
             <lb ed="#V" n="132"/>vniversalem. Et loquitur de formis per quas intelligunt naturali 
             co<lb ed="#V" n="133" break="no"/>gnitione.
           </p>
@@ -192,8 +192,8 @@
           </p>
           <p xml:id="kzz7yh-f13125-d1e347">
             ¶ Ad tertium dicendum quod 
-            <lb ed="#V" n="56"/>quamuis Auicen. intellexit omnia esse in cognitione creato 
-            <lb ed="#V" n="57"/>ris: non per species alias a se: non tamen intellexit omnia que 
+            <lb ed="#V" n="56"/>quamuis Auicen. intellexit omnia esse in cognitione 
+            creato<lb ed="#V" n="57" break="no"/>ris: non per species alias a se: non tamen intellexit omnia que 
             <lb ed="#V" n="58"/>sunt in cognitione angelica esse ibi non per plures species 
             <lb ed="#V" n="59"/>alias a se: nec intellexit tot esse in cognitione angelica: 
             <lb ed="#V" n="60"/>quot sunt in cognitione diuina.
@@ -202,10 +202,10 @@
             ¶ Ad quartum cum 
             di<lb ed="#V" n="61" break="no"/>citur quod substantia magis est similis substantie quam accidens etc. 
             <lb ed="#V" n="62"/>Dico quod verum est de similitudine qua aliqua dicuntur 
-            si<lb ed="#V" n="63" break="no"/>milia: quia vniuocanatur in aliquo: non tumen opetet quod sit verum de 
+            si<lb ed="#V" n="63" break="no"/>milia: quia vniuocantur in aliquo: non tamen oportet quod sit verum de 
             si<lb ed="#V" n="64" break="no"/>militudine: qua vnum dicitur alterius similitudo: in imitando et 
             re<lb ed="#V" n="65" break="no"/>presentando: et sic similitudo in intellectu angelico similis est 
-            re<lb ed="#V" n="66" break="no"/>bus quie per similitudinem intelliguntur ab eo: et hec est 
+            re<lb ed="#V" n="66" break="no"/>bus quae per similitudinem intelliguntur ab eo: et hec est 
             similitu<lb ed="#V" n="67" break="no"/>do necessaria ad talium rerum cognitionem ab intellectu 
             <lb ed="#V" n="68"/>angelico.
           </p>
@@ -222,8 +222,8 @@
             cogno<lb ed="#V" n="71" break="no"/>scit per species: cognoscat per species concreatas. Et 
             vi<lb ed="#V" n="72" break="no"/>detur quod sic. Quia secundum philosophum id est metheororum. 
             Corpo<lb ed="#V" n="73" break="no"/>ra superiora no recipiunt impressiones peregrinas 
-            acci<lb ed="#V" n="74" break="no"/>dentes eis. Ergo nihil recipiunt ab istis inferioribus creatu 
-            <lb ed="#V" n="75"/>ris: ergo omnia cognoscunt per species concreatas que a 
+            acci<lb ed="#V" n="74" break="no"/>dentes eis. Ergo nihil recipiunt ab istis inferioribus 
+            creatu<lb ed="#V" n="75" break="no"/>ris: ergo omnia cognoscunt per species concreatas que a 
             supe<lb ed="#V" n="76" break="no"/>riori accepte sunt.
           </p>
           <p xml:id="kzz7yh-f13125-d1e410">
@@ -270,7 +270,7 @@
             superio<lb ed="#V" n="105" break="no"/>ra non recipiunt ab istis inferioribus. 
             <lb ed="#V" n="106"/>etc. Dico intelligendum est de receptione ordinata ad 
             generatio<lb ed="#V" n="107" break="no"/>ginatione: quia prius ordine nature: oportet ipsam reduci ad esse ymagina 
-            <lb ed="#V" n="108"/>bile quam intelligibile. Sed in angelo non est ymaginatio. ergonullam 
+            <lb ed="#V" n="108"/>bile quam intelligibile. Sed in angelo non est ymaginatio. ergo nullam 
             <lb ed="#V" n="109"/>speciem intelligibilem potest abstrahere: omnia ergo que per species 
             <lb ed="#V" n="110"/>naturali cognitione cognoscit: per concreatas spes cognoscit. 
           </p>
@@ -317,10 +317,10 @@
             si<lb ed="#V" n="3" break="no"/>militudinem a corporibus elementaribus non tam per 
             acti<lb ed="#V" n="4" break="no"/>uam virtutem corporum elementarium principaliter. Similiter 
             <lb ed="#V" n="5"/>dico quod angeli ab istis inferioribus similitudinem recipiunt 
-            <lb ed="#V" n="6"/>intelligibilem: non per virtutem istorum inferiorum nisi instraliter. 
+            <lb ed="#V" n="6"/>intelligibilem: non per virtutem istorum inferiorum nisi instrumentaliter. 
             <lb ed="#V" n="7"/>Quia angelus per suum actiuum principaliter: et per similitudine: 
-            <lb ed="#V" n="8"/>istorum inferiorum instraliter educit de posmso sui possibis: speciem 
-            intel<lb ed="#V" n="9" break="no"/>ligibilem: per quam de nouo habet de reinferiori aliquam 
+            <lb ed="#V" n="8"/>istorum inferiorum instrumentaliter educit de potentia sui possibilis: speciem 
+            intel<lb ed="#V" n="9" break="no"/>ligibilem: per quam de nouo habet de re inferiori aliquam 
             cogni<lb ed="#V" n="10" break="no"/>tionem: et illa est operatio naturalis: ad similitudinem qua in nobis est 
             <lb ed="#V" n="11"/>naturalis operatio intellectus agentis.
           </p>
@@ -339,7 +339,7 @@
             <lb ed="#V" n="18"/>¶ Ad tertium dicendum quod quamuis angelus non communicet cum istis 
             <lb ed="#V" n="19"/>inferioribus in materia: tamen potest recipere speciem ab istis inferioribus 
             <lb ed="#V" n="20"/>per suum actiuum principaliter: et per sensibiles similitudines 
-            isto<lb ed="#V" n="21" break="no"/>rum inferiorum instraliter: sicut expositum est. in solutione 
+            isto<lb ed="#V" n="21" break="no"/>rum inferiorum instrumentaliter: sicut expositum est. in solutione 
             argumen<lb ed="#V" n="22" break="no"/>ti primi. communicatio autem in materia inter aliqua non est necessaria nisi 
             <lb ed="#V" n="23"/>propter mutuam actionem et passionem: ordinatam ad mutuam 
             ge<lb ed="#V" n="24" break="no"/>nerationem et corruptione.


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve09v2_kzz7yh-f13125.xml`.

## Applied changes

- p. 18v l. 125: subslantie → substantie: sl/bs transposition (OCR misread)
- p. 18v l. 129: propotionem → proportionem: missing r (OCR dropout)
- p. 18v l. 131: itelligentiis → intelligentiis: missing n after initial i
- p. 19r l. 57: 'creato' + 'ris' split across line break without break="no" on lb n=57
- p. 19r l. 63: vniuocanatur → vniuocantur: extra 'a' (OCR insertion); tumen → tamen: u/a misread; opetet → oportet: missing 'or' (OCR dropout)
- p. 19r l. 66: quie → quae: i/a misread (OCR error for relative pronoun quae)
- p. 19r l. 75: 'creatu' + 'ris' split across line break without break="no" on lb n=75
- p. 19r l. 108: ergonullam → ergo nullam: two words run together (spacing error)
- p. 19v l. 6: instraliter → instrumentaliter: missing 'ument' (OCR dropout of abbreviated form)
- p. 19v l. 8: instraliter → instrumentaliter: OCR dropout; posmso → potentia: garbled word; possibis → possibilis: missing 'il' (OCR dropout)
- p. 19v l. 9: reinferiori → re inferiori: two words run together (spacing error)
- p. 19v l. 21: instraliter → instrumentaliter: missing 'ument' (OCR dropout of abbreviated form)

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_