### PR TITLE
Transcription corrections: cod-ve09v2_kzz7yh-f13667.xml (13 changes)

### DIFF
--- a/kzz7yh-f13667/cod-ve09v2_kzz7yh-f13667.xml
+++ b/kzz7yh-f13667/cod-ve09v2_kzz7yh-f13667.xml
@@ -266,7 +266,7 @@
             su<lb ed="#V" n="21" break="no"/>periorem: quam sibi magis propinquum vel equalem. Et bonum 
             ma<lb ed="#V" n="22" break="no"/>ius illi volebat: et bonum illius intensius optando. Quia cum 
             <lb ed="#V" n="23"/>gloria sit perfectio nature recte: et modo angelus inferior magis 
-            <lb ed="#V" n="24"/>diligat superiorem: quam sibi magis propinquum vel equalem.  quod 
+            <lb ed="#V" n="24"/>diligat superiorem: quam sibi magis propinquum vel equalem. Videtur quod 
             <lb ed="#V" n="25"/>motu naturali plus diligebat superiorem: quam sibi magis 
             propin<lb ed="#V" n="26" break="no"/>quum: vel equalem: quia ante auersionem in omnibus erat natura recta. 
           </p>

--- a/kzz7yh-f13667/cod-ve09v2_kzz7yh-f13667.xml
+++ b/kzz7yh-f13667/cod-ve09v2_kzz7yh-f13667.xml
@@ -80,7 +80,7 @@
             di<lb ed="#V" n="39" break="no"/>ligem deum quam se ipsum.
           </p>
           <p xml:id="kzz7yh-f13667-d1e143">
-            ¶ Item Aug. 14. de ci. c. vltmo dic quod 
+            ¶ Item Aug. 14. de ci. c. vlt. dicit quod 
             amor<lb ed="#V" n="40" break="no"/>dei vsque ad contemptum sui: fundamentum est charitatis dei. Sed 
             di<lb ed="#V" n="41" break="no"/>ligere deum plus quam se ipsum: est diligere eum vsque ad sui 
             contem<lb ed="#V" n="42" break="no"/>ptum. Si ergo angeli ex puris naturalibus hoc potuissent: ex 
@@ -266,7 +266,7 @@
             su<lb ed="#V" n="21" break="no"/>periorem: quam sibi magis propinquum vel equalem. Et bonum 
             ma<lb ed="#V" n="22" break="no"/>ius illi volebat: et bonum illius intensius optando. Quia cum 
             <lb ed="#V" n="23"/>gloria sit perfectio nature recte: et modo angelus inferior magis 
-            <lb ed="#V" n="24"/>diligat superiorem: quam sibi magis propinquum vel equalem. Utur quod 
+            <lb ed="#V" n="24"/>diligat superiorem: quam sibi magis propinquum vel equalem.  quod 
             <lb ed="#V" n="25"/>motu naturali plus diligebat superiorem: quam sibi magis 
             propin<lb ed="#V" n="26" break="no"/>quum: vel equalem: quia ante auersionem in omnibus erat natura recta. 
           </p>
@@ -305,7 +305,7 @@
             <lb ed="#V" n="48"/>¶ Ad tertium cum dicitur. quod in ecclesiastica ierarchia magis secundum 
             <lb ed="#V" n="49"/>rectum iudicium rationis diligit quis fratrem sui ordinis: quam alterum 
             <lb ed="#V" n="50"/>alterius ordinis meliorem etc. Dico quod non oportet hoc semper esse 
-            <lb ed="#V" n="51"/>verum: alius enim tantum posset excellere in bonitate istum: quod plimus 
+            <lb ed="#V" n="51"/>verum: alius enim tantum posset excellere in bonitate istum: quod plus 
             <lb ed="#V" n="52"/>deberet ponderare in alliciendo affectum diligentis: quam 
             con<lb ed="#V" n="53" break="no"/>formitas in eodem ordine. 
           </p>

--- a/kzz7yh-f13667/cod-ve09v2_kzz7yh-f13667.xml
+++ b/kzz7yh-f13667/cod-ve09v2_kzz7yh-f13667.xml
@@ -65,8 +65,8 @@
         </p>
         <p xml:id="kzz7yh-f13667-d1e117">
           <lb ed="#V" n="32"/>¶ Secundo vtrum ante conuersionem et auersionem: 
-          infe<lb ed="#V" n="33" break="no"/>ferior agelus magis diligebat angelum superiorem quam equalem 
-          <lb ed="#V" n="34"/>vel sibi propiuquum magis. 
+          infe<lb ed="#V" n="33" break="no"/>ferior angelus magis diligebat angelum superiorem quam equalem 
+          <lb ed="#V" n="34"/>vel sibi propinquum magis. 
         </p>
         <div xml:id="kzz7yh-f13667-Dd1e126">
           <head xml:id="kzz7yh-f13667-Hd1e128">Quaestio 1</head>
@@ -74,7 +74,7 @@
           <p xml:id="kzz7yh-f13667-d1e130">
             Quaesio Iet 
             <lb ed="#V" n="35"/>PRimo ostendo: quod angelus ex puris naturalibus non 
-            <lb ed="#V" n="36"/>potuisset deum diligem plus quam se ipsum: 
+            <lb ed="#V" n="36"/>potuisset deum diligere plus quam se ipsum: 
             di<lb ed="#V" n="37" break="no"/>ligem deum plus quam se ipsum: actus est caritatis. Sed ex puris 
             <lb ed="#V" n="38"/>naturalibus non potuisset in caritatis actum. Ergo nec 
             di<lb ed="#V" n="39" break="no"/>ligem deum quam se ipsum.
@@ -107,7 +107,7 @@
           <p xml:id="kzz7yh-f13667-d1e186">
             <lb ed="#V" n="56"/>Contra Aug. in libro de fide ad petrum longe ante 
             me<lb ed="#V" n="57" break="no"/>ium dicit de angelis: quod eos deus creauit: vt 
-            <lb ed="#V" n="58"/>etiam prese illum diligerent cuius se tales opere cognouissent. 
+            <lb ed="#V" n="58"/>etiam prae se illum diligerent cuius se tales opere cognouissent. 
           </p>
           <p xml:id="kzz7yh-f13667-d1e195">
             <lb ed="#V" n="59"/>¶ Item Eccls. 9. nescit hoc vtrum amore an odio dignus sit. 
@@ -127,7 +127,7 @@
             il<lb ed="#V" n="71" break="no"/>lud magis.
           </p>
           <p xml:id="kzz7yh-f13667-d1e230">
-            ¶ Sed contra. quandoncuque homines aliqui ex naturali 
+            ¶ Sed contra. quandocumque homines aliqui ex naturali 
             amo<lb ed="#V" n="72" break="no"/>re ad bonum patrie se exposuerunt morti: propter patrie salutem. Cum 
             <lb ed="#V" n="73"/>tamen hoc ex charitate non facerent: quia infideles erant. Ex naturalibus 
             <lb ed="#V" n="74"/>ergo potest hoc diligere commune bonum patrie: magis quam se ipsum. 
@@ -151,7 +151,7 @@
             cha<lb ed="#V" n="87" break="no"/>ritatis etc. Dico quod verum est: si diligatur sub ratione qua est summum 
             <lb ed="#V" n="88"/>bonum beatificans supernaturali beatitudine: omnes qui 
             per<lb ed="#V" n="89" break="no"/>seuerant vsque in finem: et amore eius obseruant mandata 
-            <lb ed="#V" n="90"/>illius. Sub hac ratione angelus exr puris naturalibus: non 
+            <lb ed="#V" n="90"/>illius. Sub hac ratione angelus ex puris naturalibus: non 
             <lb ed="#V" n="91"/>potuisset deum diligere plus quam se. Sed sub ratione qua est vniversale 
             <lb ed="#V" n="92"/>bonum: a quo dependet omne bonum create nature.
           </p>
@@ -186,14 +186,14 @@
           </p>
           <p xml:id="kzz7yh-f13667-d1e335">
             ¶ Dicunt 
-            <lb ed="#V" n="113"/>tamen aliqu quod inquantum deus est vniversale et commune bonu totius nature: 
+            <lb ed="#V" n="113"/>tamen aliqui quod inquantum deus est vniversale et commune bonum totius nature: 
             ma<lb ed="#V" n="114" break="no"/>li angeli naturali motu voluntatis diligunt deum plus quam se ipsum 
             <lb ed="#V" n="115"/>Sed quia sciunt eum contrarium male voluntati eorum: et se ipsos 
             puni<lb ed="#V" n="116" break="no"/>ri per eum: ex deliberatiua voluntate admittit ipsum. Sed 
             pri<lb ed="#V" n="117" break="no"/>ma solutio est rationabilior et securior.
           </p>
           <p xml:id="kzz7yh-f13667-d1e348">
-            ¶ Argumeta ad partem 
+            ¶ Argumenta ad partem 
             <lb ed="#V" n="118"/>aliam gratia conclusionis concedenda sunt: quauis non multum cogant. 
             <lb ed="#V" n="119"/>Quia ad auctoritatem Augustini dicerent aliqui: quod 
             ange<lb ed="#V" n="120" break="no"/>geli non fuerunt creati: in naturalibus puris: sed cum 
@@ -201,7 +201,7 @@
             <lb ed="#V" n="122"/>se.
           </p>
           <p xml:id="kzz7yh-f13667-d1e361">
-            ¶ Uel exponerent illud verbum: vt illum prese 
+            ¶ Uel exponerent illud verbum: vt illum prae se 
             dilige<lb ed="#V" n="123" break="no"/>rent: ita vt propter hunc finem creati essent: vt deum plus 
             <lb ed="#V" n="124"/>quam se diligerent.
           </p>
@@ -252,7 +252,7 @@
             melio<lb ed="#V" n="11" break="no"/>rem. Ergo similiter est in angelica ierarchia. 
           </p>
           <p xml:id="kzz7yh-f13667-d1e446">
-            <lb ed="#V" n="12"/>Contra philosophus secundo de generaotone In omnibus inqumus quod 
+            <lb ed="#V" n="12"/>Contra philosophus secundo de generatione In omnibus inquimus quod 
             <lb ed="#V" n="13"/>melius est desiderare naturam semper. Sed ante 
             con<lb ed="#V" n="14" break="no"/>uersionem et auersionem non in voluntate angelorum: aliquis 
             mo<lb ed="#V" n="15" break="no"/>tus nisi naturalis: quia in primo motu electiuo boni fuerunt 
@@ -279,7 +279,7 @@
           <p xml:id="kzz7yh-f13667-d1e496">
             ¶ Unde videtur mihi: quod 
             qui<lb ed="#V" n="31" break="no"/>libet angelus: plus diligebat deum quam se ipsum: et plus se ipsum 
-            <lb ed="#V" n="32"/>quam quencumque alium angelum. Et inter alios plus diligebat illu 
+            <lb ed="#V" n="32"/>quam quemcumque alium angelum. Et inter alios plus diligebat illum 
             <lb ed="#V" n="33"/>qui magis appropinquabat ad deum. 
           </p>
           <p xml:id="kzz7yh-f13667-d1e505">
@@ -289,7 +289,7 @@
             <lb ed="#V" n="37"/>bonitas vnius: ita excedit bonitatem alterius: quod voluntas 
             mo<lb ed="#V" n="38" break="no"/>tu naturali recto: magis fertur in magis bonum: quam in magis 
             si<lb ed="#V" n="39" break="no"/>milem. Unde si essent tres fratres de eodem patre et eadem matre: 
-            <lb ed="#V" n="40"/>omnes boni: sed praimogenitus longe melior aliis duobus: inter 
+            <lb ed="#V" n="40"/>omnes boni: sed primogenitus longe melior aliis duobus: inter 
             <lb ed="#V" n="41"/>se magis similibus in complexione et moribus. Si voluntas 
             <lb ed="#V" n="42"/>vnius illorum esset directa secundum rectum iudicium rationis in 
             dili<lb ed="#V" n="43" break="no"/>gendo: magis diligeret fratrem meliorem: quam alium minus 
@@ -304,7 +304,7 @@
           <p xml:id="kzz7yh-f13667-d1e540">
             <lb ed="#V" n="48"/>¶ Ad tertium cum dicitur. quod in ecclesiastica ierarchia magis secundum 
             <lb ed="#V" n="49"/>rectum iudicium rationis diligit quis fratrem sui ordinis: quam alterum 
-            <lb ed="#V" n="50"/>alterius ordinis meliorem etc. Dico quod non opetet hoc semper esse 
+            <lb ed="#V" n="50"/>alterius ordinis meliorem etc. Dico quod non oportet hoc semper esse 
             <lb ed="#V" n="51"/>verum: alius enim tantum posset excellere in bonitate istum: quod plimus 
             <lb ed="#V" n="52"/>deberet ponderare in alliciendo affectum diligentis: quam 
             con<lb ed="#V" n="53" break="no"/>formitas in eodem ordine. 


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve09v2_kzz7yh-f13667.xml`.

## Applied changes

- p. 19v l. 33: agelus → angelus: missing n (OCR dropout)
- p. 19v l. 34: propiuquum → propinquum: u/n transposition
- p. 19v l. 36: diligem → diligere: m misread for re at word end (OCR error)
- p. 19v l. 58: prese → prae se: two words run together; preposition prae + se (context: 'love him more than themselves')
- p. 19v l. 71: quandoncuque → quandocumque: spurious n inserted, u/u transposition
- p. 19v l. 90: exr → ex: spurious r appended (OCR insertion)
- p. 19v l. 113: aliqu → aliqui: missing final i (OCR dropout); bonu → bonum: missing final m (OCR dropout)
- p. 19v l. 117: Argumeta → Argumenta: missing n (OCR dropout)
- p. 19v l. 122: prese → prae se: two words run together; preposition prae + se
- p. 20r l. 12: generaotone → generatione: transposition of 'o' (OCR error); inqumus → inquimus: missing i (OCR dropout)
- p. 20r l. 32: quencumque → quemcumque: n/m misread; illu → illum: missing final m (line-end dropout)
- p. 20r l. 40: praimogenitus → primogenitus: spurious a inserted (OCR error)
- p. 20r l. 50: opetet → oportet: missing 'or' (OCR dropout)

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_