### PR TITLE
Transcription corrections: cod-ve09v2_kzz7yh-f14126.xml (11 changes)

### DIFF
--- a/kzz7yh-f14126/cod-ve09v2_kzz7yh-f14126.xml
+++ b/kzz7yh-f14126/cod-ve09v2_kzz7yh-f14126.xml
@@ -107,7 +107,7 @@
           <p xml:id="kzz7yh-f14126-d1e183">
             <lb ed="#V" n="78"/>Contra secundum Aug. lib. 83. q. q. 3. ominem facere 
             dete<lb ed="#V" n="79" break="no"/>riorem tanta culpa est: quod in sapientem hominem 
-            <lb ed="#V" n="80"/>cadere nequid. Ergo multo mines sabientissimus deus 
+            <lb ed="#V" n="80"/>cadere nequid. Ergo multo mines sapientissimus deus 
             tace<lb ed="#V" n="81" break="no"/>re potuit: vt angelus esset deterior. Ergo non potuit esse 
             <lb ed="#V" n="82"/>causa sue auersionis.
           </p>
@@ -130,7 +130,7 @@
             <lb ed="#V" n="92"/>Respondeo quod deus non potuit esse 
             causauersio<lb ed="#V" n="93" break="no"/>nis angelorum: nec ab instanti 
             crea<lb ed="#V" n="94" break="no"/>tionis: nec postea. Quia auersio angeli a deo reddidit ipsum 
-            <lb ed="#V" n="95"/>culpabilem in iuditio dei. Sed impossibile est quod iudex summe 
+            <lb ed="#V" n="95"/>culpabilem in <sic>iuditio</sic> dei. Sed impossibile est quod iudex summe 
             <lb ed="#V" n="96"/>iustus: culpam aliquam pro aliquo quod potuerit in eo. Cum ego 
             <lb ed="#V" n="97"/>deus sit iudex summe iustus: non potuit esse causa auersionis 
             <lb ed="#V" n="98"/>ipsius angeli.
@@ -141,7 +141,7 @@
             <lb ed="#V" n="100"/>summe concors. Nullo ergo modo potest esse contrarius sibi ipsi. 
             <lb ed="#V" n="101"/>Sed auersi a deo est contra legem eternam. Unde Aug. 22. contra Faustum. 
             <lb ed="#V" n="102"/>quasi inter medium et finem. Dicit quod iniquus quantum in ipso est 
-            per<lb ed="#V" n="103" break="no"/>turbat ordinem naturalem: quem lex eterna conseruari iubet. Etgo 
+            per<lb ed="#V" n="103" break="no"/>turbat ordinem naturalem: quem lex eterna conseruari iubet. Ergo 
             <lb ed="#V" n="104"/>deus non potuit esse causa iniquitatis ipsius angeli. ergo nec 
             auer<lb ed="#V" n="105" break="no"/>sionis illius: quia auersio a deo iniquitas est. 
           </p>
@@ -150,7 +150,7 @@
             in<lb ed="#V" n="107" break="no"/>cellectus non sic deordinat a fine: 
             <lb ed="#V" n="108"/>sicut auersio affectus: et ideo non est simile de ignorantia et 
             auer<lb ed="#V" n="109" break="no"/>sione. Non dico tamen quod deus creauerit angelos ignorantes: quia 
-            <lb ed="#V" n="110"/>ignorantia non est quecumque nestientia: sed nescientia illius rei: 
+            <lb ed="#V" n="110"/>ignorantia non est quecumque nescientia: sed nescientia illius rei: 
             <lb ed="#V" n="111"/>quam nesciens tenetur scire secundum exigentiam sue nature.
           </p>
           <p xml:id="kzz7yh-f14126-d1e273">
@@ -178,14 +178,14 @@
         </div>
         <div xml:id="kzz7yh-f14126-Dd1e312">
           <head xml:id="kzz7yh-f14126-Hd1e314">Quaestio 2</head>
-          <head xml:id="kzz7yh-f14126-Hd1e322" type="question-title">Utrum angelus ab instanti creationis suse potuerit averti voluntate propria</head>
+          <head xml:id="kzz7yh-f14126-Hd1e322" type="question-title">Utrum angelus ab instanti creationis suae potuerit averti voluntate propria</head>
           <p xml:id="kzz7yh-f14126-d1e316">
             ¶ Quaestio II. 
             <lb ed="#V" n="126"/>SEcundo queritur vtrum angelus ab instanti 
             crea<lb ed="#V" n="127" break="no"/>tionis sue potuerit auerti 
             volun<lb ed="#V" n="128" break="no"/>tate proposta. Et videtur quod sic. Quia cognitio potest esse in instanti 
             <lb ed="#V" n="129"/>Unde philosophus 10 ethi. ca. 4. vult quod visio est in non tempore. 
-            <lb ed="#V" n="130"/>Sed in eodem instanti in quo intellus intelligit voluntas potest 
+            <lb ed="#V" n="130"/>Sed in eodem instanti in quo intellectus intelligit voluntas potest 
             velle<lb ed="#V" n="131" break="no"/>ergo angelus ab instanti sue creationis potuit malum intelligere: et 
             <lb ed="#V" n="132"/>malum velle: et hoc est auerti.
           </p>
@@ -195,8 +195,8 @@
             crea<lb ed="#V" n="134" break="no"/>tionis habere potuit peccatum actuale.
           </p>
           <p xml:id="kzz7yh-f14126-d1e341">
-            ¶ Item facilius est deficemquam 
-            <lb ed="#V" n="135"/>proficere. ergo cum secundum beatum Aug. libro 2. super Gensem parum ante 
+            ¶ Item facilius est deficere quam 
+            <lb ed="#V" n="135"/>proficere. ergo cum secundum beatum Aug. libro 2. super Genesem parum ante 
             me<lb ed="#V" n="136" break="no"/>dium angeli boni ab instanti sue creationis fuerunt beati 
             <!--00054.xml-->
             <pb ed="#V" n="20-v"/>
@@ -234,8 +234,8 @@
           <p xml:id="kzz7yh-f14126-d1e409">
             <lb ed="#V" n="22"/>Respondeo quod angelus ab instanti creationis sue: 
             <lb ed="#V" n="23"/>non potuit se auertere: quia obiectum 
-            <lb ed="#V" n="24"/>naturalis actus ipsius voluntatis est bonum absolute. Obiec 
-            <lb ed="#V" n="25"/>tum autem volutatis deliberatiue est bonum in relatione. 
+            <lb ed="#V" n="24"/>naturalis actus ipsius voluntatis est bonum absolute. 
+            Obiec<lb ed="#V" n="25" break="no"/>tum autem volutatis deliberatiue est bonum in relatione. 
             <lb ed="#V" n="26"/>Uel ad finem: vel ad circumstantiam: vel ad obiectum: vel ad 
             <lb ed="#V" n="27"/>aliquid aliud. Regula etiam creata: actus naturalis 
             volun<lb ed="#V" n="28" break="no"/>tatis est naturale dictamen intellectus. Regula autem 
@@ -271,7 +271,7 @@
             <lb ed="#V" n="55"/>nature:. Malus autem actus voluntatis deliberatiue ipsius 
             <lb ed="#V" n="56"/>angeli: non potuit simul esse cum rectissimo naturali actu illius: quia 
             <lb ed="#V" n="57"/>quamuis non opponantur ratione speciei: opponuntur tamen ratione 
-            gene<lb ed="#V" n="58" break="no"/>ris: inquantum vno actu voluntas tendebat in suum princius 
+            gene<lb ed="#V" n="58" break="no"/>ris: inquantum vno actu voluntas tendebat in suum principium 
             <lb ed="#V" n="59"/>et alio recessit ab eo: nec vnus de istis actibus ordinabatur 
             <lb ed="#V" n="60"/>ad alium. Et ideo sicut videmus quod qualiscumque tristitia in 
             <lb ed="#V" n="61"/>aliquo remittit naturaliter perfectionem gaudii in eodem: et 
@@ -311,7 +311,7 @@
           <p xml:id="kzz7yh-f14126-d1e568">
             ¶ Ad secundum 
             <lb ed="#V" n="90"/>dicendum quod non est simile de peccato originali et actuali. Quia 
-            <lb ed="#V" n="91"/>peccatum orginaie est carentia boni debiti: numquam habiti tamen 
+            <lb ed="#V" n="91"/>peccatum originale est carentia boni debiti: numquam habiti tamen 
             <lb ed="#V" n="92"/>nec contrahitur per aliquem actum ipsius anime. Per 
             pecca<lb ed="#V" n="93" break="no"/>tum autem actuale est in anima carentia alicuius boni de 
             <lb ed="#V" n="94"/>biti prius habiti: et consistit in aliquo actu ipsius anime. 


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve09v2_kzz7yh-f14126.xml`.

## Applied changes

- p. 20r l. 80: sabientissimus → sapientissimus: b/p misread (OCR error)
- p. 20r l. 95: iuditio → <sic>iuditio</sic>: known printer misspelling for iudicio
- p. 20r l. 103: Etgo → Ergo: t/r transposition (OCR error)
- p. 20r l. 110: nestientia → nescientia: t/c misread (OCR error)
- p. 20r l. 125: suse → suae: s/a misread (OCR error); genitive of sua
- p. 20r l. 130: intellus → intellectus: missing 'ect' (OCR dropout)
- p. 20r l. 134: deficemquam → deficere quam: two words run together + em/ere confusion at word end
- p. 20r l. 135: Gensem → Genesem: missing 'ne' in proper name Genesis (OCR dropout)
- p. 20v l. 25: 'Obiec' + 'tum' split across line break without break="no" on lb n=25
- p. 20v l. 58: princius → principium: missing 'ipium' (OCR dropout)
- p. 20v l. 91: orginaie → originale: transposition and missing letters (OCR error)

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_