### PR TITLE
Transcription corrections: cod-ve09v2_kzz7yh-f15536.xml (6 changes)

### DIFF
--- a/kzz7yh-f15536/cod-ve09v2_kzz7yh-f15536.xml
+++ b/kzz7yh-f15536/cod-ve09v2_kzz7yh-f15536.xml
@@ -71,7 +71,7 @@
           <head xml:id="kzz7yh-f15536-Hd1e124">Quaestio 1</head>
           <head xml:id="kzz7yh-f15536-Hd1e128" type="question-title">Utrum angeli fuerunt creati in gloria</head>
           <p xml:id="kzz7yh-f15536-d1e126">
-            Quaeod 1. 
+            Quaestio 1. 
             <lb ed="#V" n="54"/>PRimo ostendo quod fuerunt 
             creati<lb ed="#V" n="55" break="no"/>in gloria: quia <ref xml:id="kzz7yh-f15536-Rd1e137">Aug. 
             <lb ed="#V" n="56"/>primo super Gen. versus principium</ref>. Et videtur velle 
@@ -109,7 +109,7 @@
             volen<lb ed="#V" n="75" break="no"/>tem nec nolentem.
           </p>
           <p xml:id="kzz7yh-f15536-d1e191">
-            ¶ Item Boe. lib. 3. de consolis non 
+            ¶ Item Boe. lib. 3. de consolatione non 
             mul<lb ed="#V" n="76" break="no"/>tum post principium beatitudo est status omnium bonorum 
             <lb ed="#V" n="77"/>aggregatione perfectus. Ergo illi qui non steterunt non 
             fue<lb ed="#V" n="78" break="no"/>rut creati in gluria. ergo a simili nec alii. 
@@ -141,7 +141,7 @@
             <lb ed="#V" n="94"/>glosandum est: ex quo creati sunt id est cito postquam creati sunt. 
           </p>
           <p xml:id="kzz7yh-f15536-d1e246">
-            <lb ed="#V" n="95"/>¶ Ad tertium dicendum quod quamuis in instansti sue creationis deum 
+            <lb ed="#V" n="95"/>¶ Ad tertium dicendum quod quamuis in instanti sue creationis deum 
             <lb ed="#V" n="96"/>non cognouerunt per discursum: tamen ex hoc non sequitur: 
             <lb ed="#V" n="97"/>quod in illo instanti deum per essentiam viderint: sed 
             intellige<lb ed="#V" n="98" break="no"/>bant ipsam in se ipsis: et ita cognitione que est in speculo: 
@@ -174,7 +174,7 @@
           </p>
           <p xml:id="kzz7yh-f15536-d1e299">
             ¶ Item deus cum sit liberalissimus statim dat 
-            <lb ed="#V" n="112"/>gratiamnsuam creature rationali vel intellectuali: cum 
+            <lb ed="#V" n="112"/>gratiam suam creature rationali vel intellectuali: cum 
             disposi<lb ed="#V" n="113" break="no"/>ta est. Sed innocentia maxima est dispositio. Ergo cum 
             <lb ed="#V" n="114"/>illam habuerint angeli ab instanti sue creationis: ab illo 
             in<lb ed="#V" n="115" break="no"/>stanti dispositi fuerunt ad gratie susceptionem. 
@@ -196,7 +196,7 @@
             pre<lb ed="#V" n="126" break="no"/>cedenti questione habitum est: ergo nec gratiam. 
           </p>
           <p xml:id="kzz7yh-f15536-d1e340">
-            <lb ed="#V" n="127"/>Respondeo quod gratia tripiter potest accipi. Uno 
+            <lb ed="#V" n="127"/>Respondeo quod gratia tripliciter potest accipi. Uno 
             <lb ed="#V" n="128"/>modo largissime scilicet pro omni scilicet 
             do<lb ed="#V" n="129" break="no"/>no gratis dato. Et sic etiam naturalia gratuita dicuntur. Et 
             <lb ed="#V" n="130"/>sic loquitur Damas. lib. 2. cap. 3. cum dicitur. quod angelus est secundum 
@@ -244,7 +244,7 @@
             po<lb ed="#V" n="24" break="no"/>tuisset si voluisset. 
           </p>
           <p xml:id="kzz7yh-f15536-d1e430">
-            <lb ed="#V" n="25"/>Ad primum in oppositum solutum est in corpoe 
+            <lb ed="#V" n="25"/>Ad primum in oppositum solutum est in corpore 
             <lb ed="#V" n="26"/>questionis.
           </p>
           <p xml:id="kzz7yh-f15536-d1e438">

--- a/kzz7yh-f15536/cod-ve09v2_kzz7yh-f15536.xml
+++ b/kzz7yh-f15536/cod-ve09v2_kzz7yh-f15536.xml
@@ -160,7 +160,7 @@
           <p xml:id="kzz7yh-f15536-d1e275">
             ¶ Quaestio II. 
             <lb ed="#V" n="103"/>SEcundo quaeritur vtrum angeli fuerunt 
-            <lb ed="#V" n="104"/>craeati in gratia. Et videtur quod sic. 
+            <lb ed="#V" n="104"/><sic>craeati</sic> in gratia. Et videtur quod sic. 
             <lb ed="#V" n="105"/>Aug. 12. de ci. c. 9. dicit de angelis. quod deus creauit 
             <lb ed="#V" n="106"/>eos cum amore casto quo illi adherent simul eis 
             con<lb ed="#V" n="107" break="no"/>dens naturam et largiens gratiam.


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve09v2_kzz7yh-f15536.xml`.

## Applied changes

- p. 22r l. 53: Quaeod → Quaestio (garbled section label)
- p. 22r l. 75: consolis → consolatione (garbled Boethius reference)
- p. 22r l. 95: instansti → instanti (doubled st)
- p. 22r l. 112: gratiamnsuam → gratiam suam (merged words)
- p. 22r l. 127: tripiter → tripliciter (OCR dropped lic)
- p. 22v l. 25: corpoe → corpore (OCR dropped r)

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_