### PR TITLE
Transcription corrections: cod-ve09v2_kzz7yh-f15895.xml (8 changes)

### DIFF
--- a/kzz7yh-f15895/cod-ve09v2_kzz7yh-f15895.xml
+++ b/kzz7yh-f15895/cod-ve09v2_kzz7yh-f15895.xml
@@ -113,7 +113,7 @@
           <p xml:id="kzz7yh-f15895-d1e198">
             <lb ed="#V" n="63"/>Respondeo quod angelis qui steterunt fuit 
             re<lb ed="#V" n="64" break="no"/>uelata sua futura conuersio. 
-            Loquem<lb ed="#V" n="65" break="no"/>do de reuelatione secundum quod dicit certam cognitionem. Raitionabile 
+            Loquem<lb ed="#V" n="65" break="no"/>do de reuelatione secundum quod dicit certam cognitionem. Rationabile 
             <lb ed="#V" n="66"/>enim erat: vt nec malis futuris reuelaretur suus casus: nec 
             <lb ed="#V" n="67"/>beatis futuris sua conuersio. Quia mali futuri: ex illa 
             reuela<lb ed="#V" n="68" break="no"/>tione tristitiam ante peccatum habuissent. Et beati futuri quodet 
@@ -124,7 +124,7 @@
           </p>
           <p xml:id="kzz7yh-f15895-d1e222">
             ¶ Nec te moueat ad conrium quod dicit <ref xml:id="kzz7yh-f15895-Rd1e232">Aug. xi. super Gen. 
-            <lb ed="#V" n="71"/>longe ante medium</ref>. An dicemus hoec deum dya<!--not sure about this word-->. reuelare noluisse 
+            <lb ed="#V" n="71"/>longe ante medium</ref>. An dicemus hoc deum dya<!--not sure about this word-->. reuelare noluisse 
             <lb ed="#V" n="72"/>cum adhuc esset angelus bonus: vel quid facturus. vel quid 
             <lb ed="#V" n="73"/>passurus esset: ceteris vero hoc reuelasse quod essent in eternum 
             <lb ed="#V" n="74"/>in veritate mansuri. Non enim intendit hoc Aug. asserere: sed 
@@ -132,7 +132,7 @@
             <lb ed="#V" n="76"/>Sed quo malo merito ita descernebatur a ceteris: vt ei deus 
             <lb ed="#V" n="77"/>nec ea que ad ipsum pertinerent futura reuelaret: nunquid 
             <lb ed="#V" n="78"/>prius ille vltor fuit: quam iste peccator: absit. Et infra post 
-            <lb ed="#V" n="79"/>medium. Aut certe rationem requerendum: quemadmodum omnes 
+            <lb ed="#V" n="79"/>medium. Aut certe rationem requirendum: quemadmodum omnes 
             <lb ed="#V" n="80"/>sancti angeli: si inter illos aliquando pariter beatus cum 
             <lb ed="#V" n="81"/>suis angelis iuxta dyab. nundum habuerunt: etiam ipsi certam 
             <lb ed="#V" n="82"/>prescientiam perpetue felicitatis sue: sed eam post casum eius 
@@ -151,13 +151,13 @@
             <lb ed="#V" n="93"/>permansionem: quia cognoscere perfectionem mundi: magis 
             <lb ed="#V" n="94"/>consonare videtur perfectioni nature: scire autem certitudi 
             <lb ed="#V" n="95"/>naliter suam permansionem magis consonare videtur 
-            perfectio<lb ed="#V" n="96" break="no"/>ni glorie: angeli autem non fuerut creati in gluria: sed creati 
+            perfectio<lb ed="#V" n="96" break="no"/>ni glorie: angeli autem non fuerunt creati in gloria: sed creati 
             fue<lb ed="#V" n="97" break="no"/>runt in natura perfecta naturali perfectione.
           </p>
           <p xml:id="kzz7yh-f15895-d1e286">
             ¶ Ad secundum 
             <lb ed="#V" n="98"/>dicendum quod non timebant de lapsu. quia quamuis non essent certi de 
-            <lb ed="#V" n="99"/>sua permansione scientia infallibili: tamen habebant communiecturam 
+            <lb ed="#V" n="99"/>sua permansione scientia infallibili: tamen habebant coniecturam 
             <lb ed="#V" n="100"/>probabilem: nec habebant in se aliquam ad contrarium inclinationem. 
             <lb ed="#V" n="101"/>Et preterea condecentia bonitatis dei non permisisset 
             pro<lb ed="#V" n="102" break="no"/>illo statu in eis oriri aliquem timorem.
@@ -182,7 +182,7 @@
           <head xml:id="kzz7yh-f15895-Hd1e331">Quaestio 2</head>
           <head xml:id="kzz7yh-f15895-Hd1e340" type="question-title">Utrum angelis qui ceciderunt potuerit revelari sua futura aversio</head>
           <p xml:id="kzz7yh-f15895-d1e333">
-            Quaesio II. 
+            Quaestio II. 
             <lb ed="#V" n="115"/>SEcundo queritur vtrum angelis qui 
             ceci<lb ed="#V" n="116" break="no"/>derunt potuerit reuelari sua 
             fu<lb ed="#V" n="117" break="no"/>tura auersio. Et videtur quod sic. Quia christus reuelauit 
@@ -205,7 +205,7 @@
           <p xml:id="kzz7yh-f15895-d1e366">
             <lb ed="#V" n="127"/>Contra primo libro retracu. ca 8. Omnis pena si 
             iusta<lb ed="#V" n="128" break="no"/>est: peccati pena est. Sed deus cum sit summo 
-            <lb ed="#V" n="129"/>iustus: non potest esse causa iniustitie. rgo non potest causare 
+            <lb ed="#V" n="129"/>iustus: non potest esse causa iniustitie. Ergo non potest causare 
             <lb ed="#V" n="130"/>in aliquo penam ante omnem culpam. Sed si deus angelo 
             reue<lb ed="#V" n="131" break="no"/>lasset suum casum: ipse angelus doluisset: et ita penam ante 
             cul<lb ed="#V" n="132" break="no"/>pam habuisset.
@@ -262,7 +262,7 @@
             ¶ Ad secundum dicendum quod quamuis 
             Luci<lb ed="#V" n="31" break="no"/>fer praeuiderit se habiturum principatum super malos: non tamen 
             <lb ed="#V" n="32"/>preuidit antens: hoc est suum casum. Sicut Ioseph preuidit suum 
-            <lb ed="#V" n="33"/>principatum futurum: non tamen praeuidit suam veditionem per quam ad 
+            <lb ed="#V" n="33"/>principatum futurum: non tamen praeuidit suam venditionem per quam ad 
             <lb ed="#V" n="34"/>principatum deuenit. Unde Ber. vbi prius. Miror cum in dei 
             <lb ed="#V" n="35"/>prescientia tuum praeuideris principatum: cur non in eandem 
             praeuidisti<lb ed="#V" n="36" break="no"/>et praecipitium.

--- a/kzz7yh-f15895/cod-ve09v2_kzz7yh-f15895.xml
+++ b/kzz7yh-f15895/cod-ve09v2_kzz7yh-f15895.xml
@@ -94,7 +94,7 @@
           </p>
           <p xml:id="kzz7yh-f15895-d1e168">
             ¶ Item aut 
-            <lb ed="#V" n="53"/>suam futuram conuersionem certitudinaliter presciebaut aut 
+            <lb ed="#V" n="53"/>suam futuram conuersionem certitudinaliter <sic>presciebaut</sic> aut 
             cre<lb ed="#V" n="54" break="no"/>debant. Sed non credebant: quia fides est enigmatica 
             cogni<lb ed="#V" n="55" break="no"/>tio: et ipsi enigmaticam cognitionem non habebant: ergo eam 
             <lb ed="#V" n="56"/>sub certitudine praecognoscebant. 
@@ -105,7 +105,7 @@
             futu<lb ed="#V" n="59" break="no"/>ra confirmatione.
           </p>
           <p xml:id="kzz7yh-f15895-d1e189">
-            ¶ Item plus est dare certitudinem de glatia: 
+            ¶ Item plus est dare certitudinem de gloria: 
             <lb ed="#V" n="60"/>quam dare gratiam. Sed vt habitum est in quaestione praecedenti. 
             angeli<lb ed="#V" n="61" break="no"/>boni non habuerunt gratiam gratum facientem ante conuersionem suam. 
             <lb ed="#V" n="62"/>Ergo nec suo future confirmationis: certam habuerunt praescientiam. 
@@ -129,12 +129,12 @@
             <lb ed="#V" n="73"/>passurus esset: ceteris vero hoc reuelasse quod essent in eternum 
             <lb ed="#V" n="74"/>in veritate mansuri. Non enim intendit hoc Aug. asserere: sed 
             po<lb ed="#V" n="75" break="no"/>nit in quaestione. Unde postea paucis interpositis subiungit. 
-            <lb ed="#V" n="76"/>Sed quo malo merito ita descernebatur a ceteris: vt ei deus 
+            <lb ed="#V" n="76"/>Sed quo malo merito ita <sic>descernebatur</sic> a ceteris: vt ei deus 
             <lb ed="#V" n="77"/>nec ea que ad ipsum pertinerent futura reuelaret: nunquid 
             <lb ed="#V" n="78"/>prius ille vltor fuit: quam iste peccator: absit. Et infra post 
             <lb ed="#V" n="79"/>medium. Aut certe rationem requirendum: quemadmodum omnes 
             <lb ed="#V" n="80"/>sancti angeli: si inter illos aliquando pariter beatus cum 
-            <lb ed="#V" n="81"/>suis angelis iuxta dyab. nundum habuerunt: etiam ipsi certam 
+            <lb ed="#V" n="81"/>suis angelis iuxta dyab. <sic>nundum</sic> habuerunt: etiam ipsi certam 
             <lb ed="#V" n="82"/>prescientiam perpetue felicitatis sue: sed eam post casum eius 
             <lb ed="#V" n="83"/>acceperint. Aut quo merito ante suum peccatum dyaus. cum 
             <lb ed="#V" n="84"/>angelis suis a ceteris angelis discretus fuerit: vt ipse casus 
@@ -237,13 +237,13 @@
             <lb ed="#V" n="13"/>ipsos desperare coegisset: non potest autem deus esse causa vt aliquis 
             <lb ed="#V" n="14"/>de salute desperet. Nec est potuit eis reuelari sua auersio: 
             <lb ed="#V" n="15"/>sine reuelatione irreparabilitatis eiusdem: vt bene vnder 
-            conclude<lb ed="#V" n="16" break="no"/>re rationes ad partem secundam: specialiter ratio Anselnus quamuis aliqui contrarium dicant. 
+            conclude<lb ed="#V" n="16" break="no"/>re rationes ad partem secundam: specialiter ratio Anselmi quamuis aliqui contrarium dicant. 
           </p>
           <p xml:id="kzz7yh-f15895-d1e440">
             <lb ed="#V" n="17"/>Ad primum in oppositum dicendum quod quamuis christus 
             <lb ed="#V" n="18"/>Petro praedixerit suum lapsum: non 
             <lb ed="#V" n="19"/>tamen dedit illi de illo lapsu: praescientiam certam. Quod patet quia Matth. 
-            <lb ed="#V" n="20"/>26. postquam christus dixerat: antequam gallus causatet ter me negabis: 
+            <lb ed="#V" n="20"/>26. postquam christus dixerat: antequam gallus <sic>causatet</sic> ter me negabis: 
             <lb ed="#V" n="21"/>statim sequitur: ait illi Petrus: et si oportuerit me mori 
             te<lb ed="#V" n="22" break="no"/>cum non te negabo. Unde forte Petrus credidit hic christum 
             <lb ed="#V" n="23"/>intellexisse sub aliqua conditione.
@@ -261,7 +261,7 @@
           <p xml:id="kzz7yh-f15895-d1e476">
             ¶ Ad secundum dicendum quod quamuis 
             Luci<lb ed="#V" n="31" break="no"/>fer praeuiderit se habiturum principatum super malos: non tamen 
-            <lb ed="#V" n="32"/>preuidit antens: hoc est suum casum. Sicut Ioseph preuidit suum 
+            <lb ed="#V" n="32"/>preuidit antecedens: hoc est suum casum. Sicut Ioseph preuidit suum 
             <lb ed="#V" n="33"/>principatum futurum: non tamen praeuidit suam venditionem per quam ad 
             <lb ed="#V" n="34"/>principatum deuenit. Unde Ber. vbi prius. Miror cum in dei 
             <lb ed="#V" n="35"/>prescientia tuum praeuideris principatum: cur non in eandem 


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve09v2_kzz7yh-f15895.xml`.

## Applied changes

- p. 22v l. 65: Raitionabile → Rationabile: letter transposition (ai → a)
- p. 22v l. 71: hoec → hoc: spurious e insertion
- p. 22v l. 79: requerendum → requirendum: e/i vowel error in stem
- p. 22v l. 96: fuerut → fuerunt: missing n; gluria → gloria: u/o misread
- p. 22v l. 99: communiecturam → coniecturam: garbled prefix (OCR error)
- p. 22v l. 114: Quaesio → Quaestio: missing t
- p. 22v l. 129: rgo → Ergo: initial E dropped by OCR
- p. 23r l. 33: veditionem → venditionem: missing n (Joseph sale/betrayal)

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_