### PR TITLE
Transcription corrections: cod-ve09v2_kzz7yh-f16866.xml (2 changes)

### DIFF
--- a/kzz7yh-f16866/cod-ve09v2_kzz7yh-f16866.xml
+++ b/kzz7yh-f16866/cod-ve09v2_kzz7yh-f16866.xml
@@ -215,7 +215,7 @@
         </p>
         <p xml:id="kzz7yh-f16866-d1e424">
           ¶ Secundo de conuersorum 
-          <lb ed="#V" n="108"/>confirmatione et auersorum obstinatione. dist. 7. ibi. supre 
+          <lb ed="#V" n="108"/>confirmatione et auersorum obstinatione. dist. 7. ibi. supra 
           <lb ed="#V" n="109"/>dictum est.
         </p>
         <p xml:id="kzz7yh-f16866-d1e431">
@@ -273,7 +273,7 @@
           superaddi<lb ed="#V" n="8" break="no"/>ta gratia ne aduerterentur ibi. Ideoque. 
         </p>
         <p xml:id="kzz7yh-f16866-d1e502">
-          <lb ed="#V" n="9"/>CIrca hanc distinctionm queruntur duo. 
+          <lb ed="#V" n="9"/>CIrca hanc distinctionem queruntur duo. 
         </p>
         <p xml:id="kzz7yh-f16866-d1e507">
           <lb ed="#V" n="10"/>¶ Primo de auersione 


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve09v2_kzz7yh-f16866.xml`.

## Applied changes

- p. 24r l. 108: supre → supra: 'supre' ends line 108 and 'dictum' starts line 109, forming 'supredictum' → 'supradictum'; missing 'a' in stem
- p. 24v l. 9: distinctionm → distinctionem: missing 'e' before final 'm'

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_