### PR TITLE
Transcription corrections: cod-ve09v2_kzz7yh-f18048.xml (8 changes)

### DIFF
--- a/kzz7yh-f18048/cod-ve09v2_kzz7yh-f18048.xml
+++ b/kzz7yh-f18048/cod-ve09v2_kzz7yh-f18048.xml
@@ -171,7 +171,7 @@
             crea<lb ed="#V" n="73" break="no"/>te. Deformatio autem auersionis est infra potestatem ipsius 
             vo<lb ed="#V" n="74" break="no"/>luntatis ratione defectibilitatis sue. Per nullam tamen propriam 
             <lb ed="#V" n="75"/>vt dictum est: potuerunt in substantiam actus conuersionis ad 
-            <lb ed="#V" n="76"/>deum: non tamen perfecte: quia ile actus non potuisset ita intensus 
+            <lb ed="#V" n="76"/>deum: non tamen perfecte: quia ile actus non potuisset esse ita intensus 
             <lb ed="#V" n="77"/>per solam naturam sicut fuit per naturam simul et gratiam.
           </p>
         </div>
@@ -185,8 +185,8 @@
             glo<lb ed="#V" n="80" break="no"/>riam. Et videtur quod non. Quia Magister in praesenti dist. ca. 
             <lb ed="#V" n="81"/>vltimo vult quod in eis premium praecessit meritum. Sed 
             con<lb ed="#V" n="82" break="no"/>uersio in eis ordine nature precessit praemium: ergo non fuit illi 
-            <lb ed="#V" n="83"/>eidem 
-            <lb ed="#V" n="84"/>uersio fuit momentanea: ergo cum magno premio debeat 
+            <lb ed="#V" n="83"/>premii meritum. Item ¶ illud premium est maximum illa 
+            con<lb ed="#V" n="84" break="no"/>uersio fuit momentanea: ergo cum magno premio debeat 
             <lb ed="#V" n="85"/>respondere magnum meritum: videtur quod illa conuersio non fuit meritus 
             <lb ed="#V" n="86"/>sufficiens ad tantum praemium.
           </p>

--- a/kzz7yh-f18048/cod-ve09v2_kzz7yh-f18048.xml
+++ b/kzz7yh-f18048/cod-ve09v2_kzz7yh-f18048.xml
@@ -155,7 +155,7 @@
           <p xml:id="kzz7yh-f18048-d1e272">
             <lb ed="#V" n="63"/>¶ Ad tertium dicendum: quod quamuis mali angeli numquam habuerunt 
             <lb ed="#V" n="64"/>gratiam: tamen eis imputatur: quod non sunt conuersi. Quia non 
-            <lb ed="#V" n="65"/>inchoaueuerunt per naturalia sua conuersionem suam: quam 
+            <lb ed="#V" n="65"/><sic>inchoaueuerunt</sic> per naturalia sua conuersionem suam: quam 
             si<lb ed="#V" n="66" break="no"/>per suam voluntatem deliberatiuam inchoassent: eis fuisset 
             <lb ed="#V" n="67"/>superaddita gratum faciens gratia: per quam eorum conuersio 
             fuis<lb ed="#V" n="68" break="no"/>set placita et completa.
@@ -171,7 +171,7 @@
             crea<lb ed="#V" n="73" break="no"/>te. Deformatio autem auersionis est infra potestatem ipsius 
             vo<lb ed="#V" n="74" break="no"/>luntatis ratione defectibilitatis sue. Per nullam tamen propriam 
             <lb ed="#V" n="75"/>vt dictum est: potuerunt in substantiam actus conuersionis ad 
-            <lb ed="#V" n="76"/>deum: non tamen perfecte: quia ile actus non potuisentee ita intensus 
+            <lb ed="#V" n="76"/>deum: non tamen perfecte: quia ile actus non potuisset ita intensus 
             <lb ed="#V" n="77"/>per solam naturam sicut fuit per naturam simul et gratiam.
           </p>
         </div>
@@ -181,11 +181,11 @@
           <p xml:id="kzz7yh-f18048-d1e320">
             ¶ Quaestio II. 
             <lb ed="#V" n="78"/>SEcundo queritur vtrum boni angeli per 
-            <lb ed="#V" n="79"/>suam conuersionem mueruerunt 
+            <lb ed="#V" n="79"/>suam conuersionem <sic>mueruerunt</sic> 
             glo<lb ed="#V" n="80" break="no"/>riam. Et videtur quod non. Quia Magister in praesenti dist. ca. 
             <lb ed="#V" n="81"/>vltimo vult quod in eis premium praecessit meritum. Sed 
             con<lb ed="#V" n="82" break="no"/>uersio in eis ordine nature precessit praemium: ergo non fuit illi 
-            <lb ed="#V" n="83"/>eiem 
+            <lb ed="#V" n="83"/>eidem 
             <lb ed="#V" n="84"/>uersio fuit momentanea: ergo cum magno premio debeat 
             <lb ed="#V" n="85"/>respondere magnum meritum: videtur quod illa conuersio non fuit meritus 
             <lb ed="#V" n="86"/>sufficiens ad tantum praemium.
@@ -264,7 +264,7 @@
             <lb ed="#V" n="130"/>TErtio queritur vtrum illi angeli
             <lb ed="#V" n="131"/>sint maiores in 
             <lb ed="#V" n="132"/>gloria: qui nobiliorem habent naturam. Et videtur 
-            <lb ed="#V" n="133"/>quod non. Quia aliqua natura inferior est maior per glatiam. 
+            <lb ed="#V" n="133"/>quod non. Quia aliqua natura inferior est maior per gloriam: 
             <lb ed="#V" n="134"/>aliqua alia superiori natura. Sicut patet de beata virgine: de qua 
             <lb ed="#V" n="135"/>cantat ecclesia quod est super choros angelorum exaltata: 
             <lb ed="#V" n="136"/>ergo a simili quidam angelus alio inferior per naturam est 
@@ -290,7 +290,7 @@
             necessita<lb ed="#V" n="11" break="no"/>te secundum capacitatem nature: quod erroneum est. 
           </p>
           <p xml:id="kzz7yh-f18048-d1e515">
-            <lb ed="#V" n="12"/>Contra Anselus in libro de casu diaboli: quasi inter 
+            <lb ed="#V" n="12"/>Contra Anselmum in libro de casu diaboli: quasi inter 
             prin<lb ed="#V" n="13" break="no"/>cipium et medium libri. Dicit de bonis 
             an<lb ed="#V" n="14" break="no"/>gelis quod adeo prouecti sunt vt sint adepti quicquid velle 
             po<lb ed="#V" n="15" break="no"/>tuerunt: nec iam videant quid plus velle possint. Sed 

--- a/kzz7yh-f18048/cod-ve09v2_kzz7yh-f18048.xml
+++ b/kzz7yh-f18048/cod-ve09v2_kzz7yh-f18048.xml
@@ -88,7 +88,7 @@
             ¶ Item secundum 
             <lb ed="#V" n="16"/>philosophum. 3. de anima. intellectus semper est rectus: quod non esset 
             ve<lb ed="#V" n="17" break="no"/>rum nisi rectitudo sibi naturalis esset: ergo substantia 
-            intellectua<lb ed="#V" n="18" break="no"/>lis naturaliter est recta. Sed non est recta nisi ad deum conuersfa. ergo 
+            intellectua<lb ed="#V" n="18" break="no"/>lis naturaliter est recta. Sed non est recta nisi ad deum conuersa. ergo 
             <lb ed="#V" n="19"/>eius conuersio ad deum est per naturam.
           </p>
           <p xml:id="kzz7yh-f18048-d1e161">
@@ -123,7 +123,7 @@
             <lb ed="#V" n="37"/>gratum facientem promota: et facta placita: et per gloriam 
             con<lb ed="#V" n="38" break="no"/>sumata: et quamuis inter ista non fuerit ordo secundum prius et 
             poste<lb ed="#V" n="39" break="no"/>rius in duratione: tamen inter illa fuit prius et posterius 
-            or<lb ed="#V" n="40" break="no"/>dine nature. Sic enim primo fuit motts liberi arbitrii in deum 
+            or<lb ed="#V" n="40" break="no"/>dine nature. Sic enim primo fuit motus liberi arbitrii in deum 
             <lb ed="#V" n="41"/>in quo fuit sue conuersionis inceptio. Secundo promota 
             <lb ed="#V" n="42"/>fuit per gratum faciens adiutorium quando ipsi angelo facta 
             <lb ed="#V" n="43"/>est gratie gratum facientis infusio. Tertio recepit angelus 
@@ -148,7 +148,7 @@
             <lb ed="#V" n="57"/>conclusiones: ita contingit voluntatem male moueri motu 
             deli<lb ed="#V" n="58" break="no"/>beratiuo: qui est in electione aliorum a fine. Cum autem in 
             argu<lb ed="#V" n="59" break="no"/>mento dicitur quod natura non est recta nisi ad deum conuersa. Dico quod 
-            <lb ed="#V" n="60"/>naura angeli ab instanti sue creationis non fuit recta 
+            <lb ed="#V" n="60"/>natura angeli ab instanti sue creationis non fuit recta 
             rectitudi<lb ed="#V" n="61" break="no"/>ne grata: sed rectitudine naturali: quia et ex tunc ad deum 
             na<lb ed="#V" n="62" break="no"/>turaliter fuit conuersa. Sed non per motum deliberatiuum. 
           </p>
@@ -208,14 +208,14 @@
           <p xml:id="kzz7yh-f18048-d1e369">
             ¶ Item illi qui 
             ce<lb ed="#V" n="97" break="no"/>ciderunt per suam auersionem penam quam habent meruerunt. ergo similiter 
-            <lb ed="#V" n="98"/>angeli qui steterunt per suam conuersionem glatiam quam habent meruerunt. 
+            <lb ed="#V" n="98"/>angeli qui steterunt per suam conuersionem gloriam quam habent meruerunt. 
             <!-- I think this should be new paragraph-->
             <lb ed="#V" n="99"/>Ad hanc quaestionem dixerunt quidam: quod conuersio 
             angelo<lb ed="#V" n="100" break="no"/>rum non fuit sufficiens meritum pro tanto praemio quod 
             <lb ed="#V" n="101"/>habent. Sed modo merentur ipsum per obsequia: quae ex mandato dei 
             no<lb ed="#V" n="102" break="no"/>bis exhibent. Nec videtur eis absurdum cum videamus regem 
             da<lb ed="#V" n="103" break="no"/>re dextrarium militi qui nondum meruit ipsum: quia scit illum 
-            militen<lb ed="#V" n="104" break="no"/>dato dextrario bene vsurum. Sed haec opisio cmmuniter non tenetur. 
+            militen<lb ed="#V" n="104" break="no"/>dato dextrario bene vsurum. Sed haec opinio communiter non tenetur. 
             <lb ed="#V" n="105"/>Magister enim est congruus ordo vt meritum praecedat praemium 
             <lb ed="#V" n="106"/>quam sequatur.
           </p>
@@ -227,10 +227,10 @@
           </p>
           <p xml:id="kzz7yh-f18048-d1e403">
             ¶ Concedo ergo quod per illam 
-            <lb ed="#V" n="110"/>conuersionem essentialem gluriam meruerunt. Si enim homo non 
+            <lb ed="#V" n="110"/>conuersionem essentialem gloriam meruerunt. Si enim homo non 
             fuis<lb ed="#V" n="111" break="no"/>set factus: tunc ista obsequiaque modo homini exhibent: non 
-            exhi<lb ed="#V" n="112" break="no"/>buissent. Nec tamen dicendum est quod suam gluriam sine merito 
-            habuis<lb ed="#V" n="113" break="no"/>sent. Nonergo merentur gloriam essentialem per obsegua 
+            exhi<lb ed="#V" n="112" break="no"/>buissent. Nec tamen dicendum est quod suam gloriam sine merito 
+            habuis<lb ed="#V" n="113" break="no"/>sent. Non ergo merentur gloriam essentialem per obsequia 
             <lb ed="#V" n="114"/>que nobis exhibent. 
           </p>
           <p xml:id="kzz7yh-f18048-d1e416">


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve09v2_kzz7yh-f18048.xml`.

## Applied changes

- p. 25v l. 18: conuersfa → conuersa: spurious 'f' inserted; 'nisi ad deum conuersa' (unless converted to God)
- p. 25v l. 40: motts → motus: 'tt' instead of 'us'; 'primo fuit motus liberi arbitrii in deum'
- p. 25v l. 60: naura → natura: transposition of 'a' and 't'; 'naura angeli' → 'natura angeli'
- p. 25v l. 98: glatiam → gloriam: 'gl-at-iam' → 'gl-or-iam'; transposition/misread; 'conuersionem gloriam quam habent meruerunt'
- p. 25v l. 104: opisio → opinio: 's' misread for 'n'; 'haec opinio communiter non tenetur' (this opinion is not commonly held); cmmuniter → communiter: missing 'o' after 'c'; 'communiter non tenetur'
- p. 25v l. 110: gluriam → gloriam: 'u' instead of 'o'; 'conuersionem essentialem gloriam meruerunt'
- p. 25v l. 112: gluriam → gloriam: 'u' instead of 'o'; 'suam gloriam sine merito habuissent'
- p. 25v l. 113: Nonergo → Non ergo: missing space between 'Non' and 'ergo'; obsegua → obsequia: missing 'i'; 'merentur gloriam essentialem per obsequia' (through services/ministrations)

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_