### PR TITLE
Transcription corrections: cod-ve09v2_kzz7yh-f18593.xml (3 changes)

### DIFF
--- a/kzz7yh-f18593/cod-ve09v2_kzz7yh-f18593.xml
+++ b/kzz7yh-f18593/cod-ve09v2_kzz7yh-f18593.xml
@@ -229,7 +229,7 @@
         </p>
         <p xml:id="kzz7yh-f18593-d1e458">
           ¶ Primo determinat de descensu eorum: in 
-          <lb ed="#V" n="84"/>hune aerem caliginosum
+          <lb ed="#V" n="84"/>hunc aerem caliginosum
         </p>
         <p xml:id="kzz7yh-f18593-d1e463">
           ¶ Secundo de descensu eorum 
@@ -275,7 +275,7 @@
         </p>
         <p xml:id="kzz7yh-f18593-d1e518">
           ¶ Quarto ostendit quod per 
-          <lb ed="#V" n="97"/>sanctos homines miniuitur potestas demonum. ibi. laliis quoque. I 
+          <lb ed="#V" n="97"/>sanctos homines minuitur potestas demonum. ibi. aliis quoque. I 
         </p>
         <p xml:id="kzz7yh-f18593-d1e523">
           <lb ed="#V" n="98"/>CIrca hanc distinctionem queruntur 
@@ -286,7 +286,7 @@
           digni<lb ed="#V" n="100" break="no"/>tate a qua ceciderunt.
         </p>
         <p xml:id="kzz7yh-f18593-d1e535">
-          ¶ Secundo de peciea quam re 
+          ¶ Secundo de pena quam re 
           <lb ed="#V" n="101"/>ceperunt.
         </p>
         <p xml:id="kzz7yh-f18593-d1e541">


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve09v2_kzz7yh-f18593.xml`.

## Applied changes

- p. 26v l. 84: hune → hunc: 'e' misread for 'c'; 'in hunc aerem caliginosum' (into this dark air)
- p. 26v l. 97: miniuitur → minuitur: extra 'i'; 'minuitur potestas demonum' (the power of demons is lessened); laliis → aliis: spurious initial 'l'; 'ibi. aliis quoque' (also to others); the candidate suggestion 'laeliis' was wrong
- p. 26v l. 100: peciea → pena: garbled OCR of 'pena' (punishment); 'Secundo de pena quam receperunt' (second, about the punishment they received)

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_