### PR TITLE
Transcription corrections: cod-ve09v2_kzz7yh-f19041.xml (3 changes)

### DIFF
--- a/kzz7yh-f19041/cod-ve09v2_kzz7yh-f19041.xml
+++ b/kzz7yh-f19041/cod-ve09v2_kzz7yh-f19041.xml
@@ -95,7 +95,7 @@
             priorita<lb ed="#V" n="119" break="no"/>te durationis. ergo hoc est intelligendum de prioritate naturalis dignitatis. 
           </p>
           <p xml:id="kzz7yh-f19041-d1e163">
-            <lb ed="#V" n="120"/>¶ . 
+            <lb ed="#V" n="120"/>¶ Item non 
             <!--00067.xml-->
             <pb ed="#V" n="27-r"/>
             <cb ed="#P" n="a"/>
@@ -229,7 +229,7 @@
             <lb ed="#V" n="86"/>primo libro de sacra. par. 5 cap. 33. Non enim vt quidam 
             pu<lb ed="#V" n="87" break="no"/>tant conditio hominis: ita ad restaurationem angelorum 
             <lb ed="#V" n="88"/>preuisa est: quasi homo factus non fuisset: nisi angelus 
-            ce<lb ed="#V" n="89" break="no"/>cidisset: sed idcirco ad restaurandum et supplendum : 
+            ce<lb ed="#V" n="89" break="no"/>cidisset: sed idcirco ad restaurandum et supplendum 
             lapso<lb ed="#V" n="90" break="no"/>rum angelorum numerum homo factus dicitur: quia cum 
             <lb ed="#V" n="91"/>homo postmodum creatus illic. Unde illi ceciderunt 
             du<lb ed="#V" n="92" break="no"/>ctus est illius societatis numerus: qui in cadentibus 

--- a/kzz7yh-f19041/cod-ve09v2_kzz7yh-f19041.xml
+++ b/kzz7yh-f19041/cod-ve09v2_kzz7yh-f19041.xml
@@ -95,7 +95,7 @@
             priorita<lb ed="#V" n="119" break="no"/>te durationis. ergo hoc est intelligendum de prioritate naturalis dignitatis. 
           </p>
           <p xml:id="kzz7yh-f19041-d1e163">
-            <lb ed="#V" n="120"/>¶ Icen don. 
+            <lb ed="#V" n="120"/>¶ . 
             <!--00067.xml-->
             <pb ed="#V" n="27-r"/>
             <cb ed="#P" n="a"/>
@@ -174,7 +174,7 @@
             <lb ed="#V" n="49"/>SEcundo queritur vtrum de quolibet ordine 
             <lb ed="#V" n="50"/>aliqua multitudo ceciderit. Et 
             <lb ed="#V" n="51"/>videtur quod non. Apostolus ad Eph. vlt. dicit. quod non est 
-            no<lb ed="#V" n="52" break="no"/>bis collutatio aduersus carnem et sanguinem: sed 
+            no<lb ed="#V" n="52" break="no"/>bis <sic>collutatio</sic> aduersus carnem et sanguinem: sed 
             ad<lb ed="#V" n="53" break="no"/>uersus mundi principes et potestates: mundi: aduersus rectores 
             <lb ed="#V" n="54"/>tenebrarum harum contra spiritualia nequitie in celestibus. Cum 
             <lb ed="#V" n="55"/>ergo ibi non nominet: nisi principes et potestates. Uidetur 
@@ -229,8 +229,8 @@
             <lb ed="#V" n="86"/>primo libro de sacra. par. 5 cap. 33. Non enim vt quidam 
             pu<lb ed="#V" n="87" break="no"/>tant conditio hominis: ita ad restaurationem angelorum 
             <lb ed="#V" n="88"/>preuisa est: quasi homo factus non fuisset: nisi angelus 
-            ce<lb ed="#V" n="89" break="no"/>cidisset: sed idcirco ad restaurandum et supplendum lapso: 
-            <lb ed="#V" n="90"/>rum angelorum numerum homo factus dicitur: quia cum 
+            ce<lb ed="#V" n="89" break="no"/>cidisset: sed idcirco ad restaurandum et supplendum : 
+            lapso<lb ed="#V" n="90" break="no"/>rum angelorum numerum homo factus dicitur: quia cum 
             <lb ed="#V" n="91"/>homo postmodum creatus illic. Unde illi ceciderunt 
             du<lb ed="#V" n="92" break="no"/>ctus est illius societatis numerus: qui in cadentibus 
             di<lb ed="#V" n="93" break="no"/>minutus fuerat per hominem reperatur. Et parum post dicit. 

--- a/kzz7yh-f19041/cod-ve09v2_kzz7yh-f19041.xml
+++ b/kzz7yh-f19041/cod-ve09v2_kzz7yh-f19041.xml
@@ -142,7 +142,7 @@
             <lb ed="#V" n="30"/>¶ Uel dicendum quod Damas. fuit huius opinionis: quod 
             sub<lb ed="#V" n="31" break="no"/>stantiarum intellectualium: quedam sunt a globo lunari 
             supe<lb ed="#V" n="32" break="no"/>rius: quarum quedam sunt assistentes: quedam corpora 
-            cele<lb ed="#V" n="33" break="no"/>stia admistrantes: et nulla istarum peccauit. Quedam sunt 
+            cele<lb ed="#V" n="33" break="no"/>stia administrantes: et nulla istarum peccauit. Quedam sunt 
             in<lb ed="#V" n="34" break="no"/>fra globum lunarem: et suprema istarum: et multe alie 
             peccaue<lb ed="#V" n="35" break="no"/>runt. Alie autem que steterunt: sunt ista inferiora 
             admini<lb ed="#V" n="36" break="no"/>strantes: et ideo lucifer dicitur fuisse prelatus terrestri 
@@ -154,7 +154,7 @@
           </p>
           <p xml:id="kzz7yh-f19041-d1e277">
             ¶ Ad secundum 
-            <lb ed="#V" n="42"/>dicendum quod in Eechiele vocatur cherub: propter 
+            <lb ed="#V" n="42"/>dicendum quod in Ezechiele vocatur cherub: propter 
             splen<lb ed="#V" n="43" break="no"/>dorem scientie: non quia esset de ordine qui cherubin 
             dici<lb ed="#V" n="44" break="no"/>tur.
           </p>
@@ -260,7 +260,7 @@
           </p>
           <p xml:id="kzz7yh-f19041-d1e464">
             <lb ed="#V" n="109"/>¶ Unde quandoque homines similiores in complexione 
-            di<lb ed="#V" n="110" break="no"/>uersa eligunt. Et dissimiles in complutione quandoque eligunt similia. 
+            di<lb ed="#V" n="110" break="no"/>uersa eligunt. Et dissimiles in complexione quandoque eligunt similia. 
           </p>
         </div>
       </div>


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve09v2_kzz7yh-f19041.xml`.

## Applied changes

- p. 27r l. 33: admistrantes → administrantes: missing 'ni' syllable
- p. 27r l. 42: Eechiele → Ezechiele: double-E misread for Ez
- p. 27r l. 110: complutione → complexione: garbled word; context 'dissimiles in complexione' matches the earlier 'similiores in complexione' in the same sentence

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_