### PR TITLE
Transcription corrections: cod-ve09v2_kzz7yh-f19416.xml (7 changes)

### DIFF
--- a/kzz7yh-f19416/cod-ve09v2_kzz7yh-f19416.xml
+++ b/kzz7yh-f19416/cod-ve09v2_kzz7yh-f19416.xml
@@ -93,7 +93,7 @@
             quanto<lb ed="#V" n="128" break="no"/>status altior tanto casus grauior. Sed angelus malus 
             ce<lb ed="#V" n="129" break="no"/>cidit de celo empyreo secundum Magistrum distinctione 
             pre<lb ed="#V" n="130" break="no"/>senti. Cum ergo caelum empyreum sit locus altissimus 
-            vi<lb ed="#V" n="131" break="no"/>detur quod cederit in locum maxime infimum. qui est 
+            vi<lb ed="#V" n="131" break="no"/>detur quod <sic>cederit</sic> in locum maxime infimum. qui est 
             infer<lb ed="#V" n="132" break="no"/>nus.
           </p>
           <p xml:id="kzz7yh-f19416-d1e170">
@@ -255,7 +255,7 @@
             ¶ Preterea Aug. 14. 
             <lb ed="#V" n="91"/>de ciui. cap. 14. elationis vitium in dei aduersario qui est 
             <lb ed="#V" n="92"/>dyabolus: maxime dominari sacris litteris edocetur. Sed 
-            <lb ed="#V" n="93"/>secundum philosophum. 3. ethicorum. cap. 9. qualis est vnuquisque talis et 
+            <lb ed="#V" n="93"/>secundum philosophum. 3. ethicorum. cap. 9. qualis est <sic>vnuquisque</sic> talis et 
             fi<lb ed="#V" n="94" break="no"/>nis videtur ei. Ergo dyabolus finem suum constituit in 
             <lb ed="#V" n="95"/>excellentia. Cum ergo secundum philosophum 6 ethicorum. cap. 6 Fines 
             <lb ed="#V" n="96"/>sint principium operabilium: quicquid malus angelus 

--- a/kzz7yh-f19416/cod-ve09v2_kzz7yh-f19416.xml
+++ b/kzz7yh-f19416/cod-ve09v2_kzz7yh-f19416.xml
@@ -142,11 +142,11 @@
             ma<lb ed="#V" n="22" break="no"/>gnam penam habeant. Huic videtur consentire illud quod 
             nar<lb ed="#V" n="23" break="no"/>rat sacra scriptura Matth. 8 scilicet demones dixisse. Iesu fili 
             <lb ed="#V" n="24"/>dicendum cur venisti hec ante tempus torquere nos. Ubi 
-            di<lb ed="#V" n="25" break="no"/>cit Glo. sciebant enim sibi futuram in dei iuditio 
+            di<lb ed="#V" n="25" break="no"/>cit Glo. sciebant enim sibi futuram in dei <sic>iuditio</sic> 
             damna<lb ed="#V" n="26" break="no"/>tionem. Et beatus Petrus. 2o ca. cap. 2. Dicit quod 
-            reseruan<lb ed="#V" n="27" break="no"/>tur cruciandi in iuditio: tunc scilicet recepturi sue 
+            reseruan<lb ed="#V" n="27" break="no"/>tur cruciandi in <sic>iuditio</sic>: tunc scilicet recepturi sue 
             damnatio<lb ed="#V" n="28" break="no"/>nis complementum. Unde Glo. restat adhuc pena 
-            vlti<lb ed="#V" n="29" break="no"/>mi iuditii: quia paratus est ignis dyabolo et angelis eius: 
+            vlti<lb ed="#V" n="29" break="no"/>mi <sic>iuditii</sic>: quia paratus est ignis dyabolo et angelis eius: 
             <lb ed="#V" n="30"/>Non enim permittit eos dominus consumi: sed seruat vt 
             <lb ed="#V" n="31"/>grauius puniantur cum membris suis. 
           </p>
@@ -218,7 +218,7 @@
           </p>
           <p xml:id="kzz7yh-f19416-d1e383">
             ¶ Item philosophus. x. 
-            ethi<lb ed="#V" n="70" break="no"/>corum. cap. 8. Dicit quod philosophia habet mirabiles deleciationes 
+            ethi<lb ed="#V" n="70" break="no"/>corum. cap. 8. Dicit quod philosophia habet mirabiles delectationes 
             <lb ed="#V" n="71"/>puritate et firmitate. Sed mali angeli multum sciunt 
             de<lb ed="#V" n="72" break="no"/>philosophia. Ergo habent magnas delectationes.
           </p>
@@ -299,9 +299,9 @@
           <p xml:id="kzz7yh-f19416-d1e523">
             <lb ed="#V" n="122"/>Ad primum alterius partis dicendum quod 
             desi<!-- line coord error -->derium nunquam completur: ita
-            <lb ed="#V" n="123"/>vt delectet appetitum: nisi ex eius euentum appetens fortiatur 
+            <lb ed="#V" n="123"/>vt delectet appetitum: nisi ex eius euentum appetens sortiatur 
             <lb ed="#V" n="124"/>finem: vere vel estimatiue: propter quam illud appetebat: quam 
-            <lb ed="#V" n="125"/>numquam fortietur malus angelus post iudicium.
+            <lb ed="#V" n="125"/>numquam sortietur malus angelus post iudicium.
           </p>
           <p xml:id="kzz7yh-f19416-d1e534">
             ¶ Ad 
@@ -324,7 +324,7 @@
             <pb ed="#V" n="28-r"/>
             <cb ed="#P" n="a"/>
             <lb ed="#V" n="1"/>ipsis effectum qui est delectatio. Siue autem illa 
-            influ<lb ed="#V" n="2" break="no"/>entia. Causa secunda non potest suum essectum causare. 
+            influ<lb ed="#V" n="2" break="no"/>entia. Causa secunda non potest suum effectum causare. 
             <lb ed="#V" n="3"/>Quia sicut dicitur in commen. super primam 
             propositio<lb ed="#V" n="4" break="no"/>nem de causis: non figitur causatum cause secunde nisi per 
             <lb ed="#V" n="5"/>virtutem cause prime. 


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve09v2_kzz7yh-f19416.xml`.

## Applied changes

- p. 27v l. 25: iuditio → <sic>iuditio</sic>: known misspelling
- p. 27v l. 27: iuditio → <sic>iuditio</sic>: known misspelling
- p. 27v l. 29: iuditii → <sic>iuditii</sic>: known misspelling (genitive of iuditium)
- p. 27v l. 70: deleciationes → delectationes: spurious 'i' inserted
- p. 27v l. 123: fortiatur → sortiatur: f/s misread at word start
- p. 27v l. 125: fortietur → sortietur: f/s misread at word start
- p. 28r l. 2: essectum → effectum: ss/ff confusion for eff-

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_