### PR TITLE
Transcription corrections: cod-ve09v2_kzz7yh-f19903.xml (6 changes)

### DIFF
--- a/kzz7yh-f19903/cod-ve09v2_kzz7yh-f19903.xml
+++ b/kzz7yh-f19903/cod-ve09v2_kzz7yh-f19903.xml
@@ -79,7 +79,7 @@
             <lb ed="#V" n="15"/>inter malos angelos non est praelatio.
           </p>
           <p xml:id="kzz7yh-f19903-d1e139">
-            ¶ Item in eplura iude: dicitur 
+            ¶ Item in epistola iude: dicitur 
             <lb ed="#V" n="16"/>de malis angelis: quod non seruauerunt suum principatum. Sed 
             praela<lb ed="#V" n="17" break="no"/>tio non est sine aliquo principatu. Ergo inter ipsos non est 
             <lb ed="#V" n="18"/>prelatio.
@@ -97,7 +97,7 @@
             <lb ed="#V" n="24"/>illi magis subiecti essent. quod non est verum. 
           </p>
           <p xml:id="kzz7yh-f19903-d1e167">
-            <lb ed="#V" n="25"/>Contra saluator Matth. 2. Discedite a me 
+            <lb ed="#V" n="25"/>Contra saluator Matth. 25. Discedite a me 
             maledi<lb ed="#V" n="26" break="no"/>cti in ignem eternum qui praeparatus est dyabolo 
             <lb ed="#V" n="27"/>et angelis eius. Ibi dyabolum vocans principem demonum: et 
             <lb ed="#V" n="28"/>angelos eius: malos angelos ei subiectos.
@@ -125,11 +125,11 @@
           <p xml:id="kzz7yh-f19903-d1e212">
             ¶ Inter eos tamen est 
             prela<lb ed="#V" n="41" break="no"/>tio de facto. Quia illis quos vident nobiliores in natura. Et 
-            <lb ed="#V" n="42"/>stremnuiores in potentia: et subtiliores in malitia: alii 
+            <lb ed="#V" n="42"/>strennuiores in potentia: et subtiliores in malitia: alii 
             obe<lb ed="#V" n="43" break="no"/>diunt: non ex amore: sed ex odio quod habent contra genus 
             huma<lb ed="#V" n="44" break="no"/>num: vt sic obedientes ipsi omnes simul fortiorem exercitum 
             consti<lb ed="#V" n="45" break="no"/>tuant: contra virtutes et genus humanum. Et quia in vno eorum 
-            <lb ed="#V" n="46"/>secuet in lucifero. Nobilior est natura: et stremnuior potentia: et 
+            <lb ed="#V" n="46"/> in lucifero. Nobilior est natura: et strenuior potentia: et 
             sub<lb ed="#V" n="47" break="no"/>tilior malitia: quam in aliquo alio. Ideo alii omnes illi obediunt 
             <lb ed="#V" n="48"/>Unde Glo. i. cor. 15. Super illud cum euacuauerit omnem 
             principa<lb ed="#V" n="49" break="no"/>tum. Dum durat mundus: angeli angelis: demones 
@@ -200,7 +200,7 @@
             ¶ Item Orig. 
             <lb ed="#V" n="85"/>et est in Glo. Iosue. xi. ca. Puto sane: quia sancti 
             repugnan<lb ed="#V" n="86" break="no"/>tes aduersus istos incentores: et vincentes minuant 
-            exerci<lb ed="#V" n="87" break="no"/>tum demonum: ne vltra fas sit illi spiritui qui ab aliquo scuomo 
+            exerci<lb ed="#V" n="87" break="no"/>tum demonum: ne vltra fas sit illi spiritui qui ab aliquo  
             ca<lb ed="#V" n="88" break="no"/>ste et pudice viuendo victus est: impugnare iterum alium hominem. 
             <lb ed="#V" n="89"/>ergo multo minus illum a quo victus est. 
           </p>

--- a/kzz7yh-f19903/cod-ve09v2_kzz7yh-f19903.xml
+++ b/kzz7yh-f19903/cod-ve09v2_kzz7yh-f19903.xml
@@ -129,7 +129,7 @@
             obe<lb ed="#V" n="43" break="no"/>diunt: non ex amore: sed ex odio quod habent contra genus 
             huma<lb ed="#V" n="44" break="no"/>num: vt sic obedientes ipsi omnes simul fortiorem exercitum 
             consti<lb ed="#V" n="45" break="no"/>tuant: contra virtutes et genus humanum. Et quia in vno eorum 
-            <lb ed="#V" n="46"/> in lucifero. Nobilior est natura: et strenuior potentia: et 
+            <lb ed="#V" n="46"/>scilicet in lucifero. Nobilior est natura: et strennuior potentia: et 
             sub<lb ed="#V" n="47" break="no"/>tilior malitia: quam in aliquo alio. Ideo alii omnes illi obediunt 
             <lb ed="#V" n="48"/>Unde Glo. i. cor. 15. Super illud cum euacuauerit omnem 
             principa<lb ed="#V" n="49" break="no"/>tum. Dum durat mundus: angeli angelis: demones 
@@ -200,7 +200,7 @@
             ¶ Item Orig. 
             <lb ed="#V" n="85"/>et est in Glo. Iosue. xi. ca. Puto sane: quia sancti 
             repugnan<lb ed="#V" n="86" break="no"/>tes aduersus istos incentores: et vincentes minuant 
-            exerci<lb ed="#V" n="87" break="no"/>tum demonum: ne vltra fas sit illi spiritui qui ab aliquo  
+            exerci<lb ed="#V" n="87" break="no"/>tum demonum: ne vltra fas sit illi spiritui qui ab aliquo sancto 
             ca<lb ed="#V" n="88" break="no"/>ste et pudice viuendo victus est: impugnare iterum alium hominem. 
             <lb ed="#V" n="89"/>ergo multo minus illum a quo victus est. 
           </p>

--- a/kzz7yh-f19903/cod-ve09v2_kzz7yh-f19903.xml
+++ b/kzz7yh-f19903/cod-ve09v2_kzz7yh-f19903.xml
@@ -160,7 +160,7 @@
           </p>
           <p xml:id="kzz7yh-f19903-d1e280">
             ¶ Ad quartum dicendum quod auctoritas Aug. 
-            intelli<lb ed="#V" n="67" break="no"/>gitur de seruiltute et prelatione: que est de iure: non tantum 
+            intelli<lb ed="#V" n="67" break="no"/>gitur de seruitute et prelatione: que est de iure: non tantum 
             quan<lb ed="#V" n="68" break="no"/>tum ad potestatem: sed etiam quantum ad potestatis executionem. 
             <!--00069.xml-->
             <cb ed="#P" n="b"/>
@@ -193,7 +193,7 @@
             ¶ Item hoc est 
             <lb ed="#V" n="81"/>natura superbi: quod quanto magis vincitur: tanto magis victorem 
             <lb ed="#V" n="82"/>odit: et magis se vendicare conatur. 
-            <lb ed="#V" n="83"/>ontra Iac. 4. resistite dyabolo et fugiet a vobis. ergo 
+            <lb ed="#V" n="83"/>Contra Iac. 4. resistite dyabolo et fugiet a vobis. ergo 
             <lb ed="#V" n="84"/>videtur quod victus non amplius temptet.
           </p>
           <p xml:id="kzz7yh-f19903-d1e341">
@@ -210,9 +210,9 @@
           </p>
           <p xml:id="kzz7yh-f19903-d1e362">
             ¶ Uno modo de 
-            <lb ed="#V" n="92"/>victoria ita perfecta: quod dyabolus desperat contra illu habere victoriam 
+            <lb ed="#V" n="92"/>victoria ita perfecta: quod dyabolus desperat contra illum habere victoriam 
             <lb ed="#V" n="93"/>de illo vitio: et omni alio: et quia dyabolus superbus est et horret 
-            <lb ed="#V" n="94"/>vinci. Idon illum amplius non temptat: nisi coniecturet illum postea 
+            <lb ed="#V" n="94"/>vinci. Ideo illum amplius non temptat: nisi coniecturet illum postea 
             de<lb ed="#V" n="95" break="no"/>biliorem et proniorem ad malum effectu. Quare tamen alium hominem 
             <lb ed="#V" n="96"/>quem non extimat: ita fortem: sicut illum a quo victus est non 
             temp<lb ed="#V" n="97" break="no"/>tet: non video. Quare est ille qui vicit perfecte aliquem 
@@ -226,7 +226,7 @@
           <p xml:id="kzz7yh-f19903-d1e391">
             <lb ed="#V" n="104"/>Ad primum argumentum dicendum quod vel Iob
             <lb ed="#V" n="105"/>non habuit illas plures temptationes 
-            <lb ed="#V" n="106"/>ab eodem dyabolo. Uel ille dyabolus:rquoniam erat victus 
+            <lb ed="#V" n="106"/>ab eodem dyabolo. Uel ille dyabolus: quoniam erat victus 
             <lb ed="#V" n="107"/>a Iob in vno presumebat ipsum vincere in alio. Unde 
             <lb ed="#V" n="108"/>quando in illa fortissima temptatione quam sibi facere potuit: 
             <lb ed="#V" n="109"/>victus est: ipsum amplius non temptauit.
@@ -249,7 +249,7 @@
             <lb ed="#V" n="117"/>desperet de victoria.
           </p>
           <p xml:id="kzz7yh-f19903-d1e433">
-            ¶ Auctoritas tamen Origenesem aut 
+            ¶ Auctoritas tamen Origenis aut 
             <lb ed="#V" n="118"/>dubia est: autem debet intelligi: quod dyabolus ita plene victus 
             <lb ed="#V" n="119"/>ab aliquo sancto quod simpliciter desperat de victoria 
             haben<lb ed="#V" n="120" break="no"/>da contra illum: amplius eum non temptat: nec alium quam 


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve09v2_kzz7yh-f19903.xml`.

## Applied changes

- p. 28r l. 67: seruiltute → seruitute: spurious 'l' inserted
- p. 28r l. 83: ontra → Contra: missing initial 'C'
- p. 28r l. 92: illu → illum: missing final 'm'
- p. 28r l. 94: Idon → Ideo: d/e and n/o misreads
- p. 28r l. 106: dyabolus:rquoniam → dyabolus: quoniam: stray 'r' inserted before 'quoniam'
- p. 28r l. 117: Origenesem → Origenis: garbled accusative form; context 'Auctoritas tamen Origenis' requires genitive

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_