### PR TITLE
Transcription corrections: cod-ve09v2_kzz7yh-f21074.xml (6 changes)

### DIFF
--- a/kzz7yh-f21074/cod-ve09v2_kzz7yh-f21074.xml
+++ b/kzz7yh-f21074/cod-ve09v2_kzz7yh-f21074.xml
@@ -74,9 +74,8 @@
             <lb ed="#V" n="71"/>PRimo ostendo quod boni angeli 
             pos<lb ed="#V" n="72" break="no"/>sunt peccare. Quia 
             <lb ed="#V" n="73"/>per confirmationem ab ipsis non est subtractum illud quod 
-            <!-- Something happened with these next two lines, I think they got switched in order. -->
-            lau<lb ed="#V" n="74" break="no"/>  
-            <lb ed="#V" n="75"/>dabile est: sed posse transgredi est laudabile. Unde ponitur 
+            <lb ed="#V" n="74"/>secundum philosophum. 2. perhiarmen. secundum rationem potestatis ipse eedem 
+            lau<lb ed="#V" n="75" break="no"/>dabile est: sed posse transgredi est laudabile. Unde ponitur 
             <lb ed="#V" n="76"/>sunt contrariorum. Sed voluntas angelorum est 
             pote<lb ed="#V" n="77" break="no"/>in laude viri iusti. Eccls. 31. Ergo possunt peccare.
           </p>
@@ -107,7 +106,7 @@
             nun<lb ed="#V" n="92" break="no"/>quam casuros: ergo peccare nequeunt.
           </p>
           <p xml:id="kzz7yh-f21074-d1e182">
-            ¶ Item Anselmus i . libo cur 
+            ¶ Item Anselmus i. libro cur 
             <lb ed="#V" n="93"/>deus homo. cap. 17. Nequaquam putandum est bonos 
             ange<lb ed="#V" n="94" break="no"/>los esse confirmatos casu malorum: sed suo merito. Si ergo 
             <lb ed="#V" n="95"/>boni angeli confirmati sunt: vt dicit Ansel. sequitur quod 
@@ -152,7 +151,7 @@
             <lb ed="#V" n="127"/>hoc peccare nequeunt. Et Isido id est libo de summo bono. c. x. 
             <lb ed="#V" n="128"/>Dicens quod quamuis sint mutabiles natura: non tamen sinit 
             <lb ed="#V" n="129"/>eos contemplatio mutari diuina. 
-            <lb ed="#V" n="130"/>atqui boni 
+            <lb ed="#V" n="130"/>¶ Quod boni 
           </p>
           <p xml:id="kzz7yh-f21074-d1e274">
             <!--00073.xml-->

--- a/kzz7yh-f21074/cod-ve09v2_kzz7yh-f21074.xml
+++ b/kzz7yh-f21074/cod-ve09v2_kzz7yh-f21074.xml
@@ -75,8 +75,8 @@
             pos<lb ed="#V" n="72" break="no"/>sunt peccare. Quia 
             <lb ed="#V" n="73"/>per confirmationem ab ipsis non est subtractum illud quod 
             <!-- Something happened with these next two lines, I think they got switched in order. -->
-            lau<lb ed="#V" n="74" break="no"/> Unum posecundum philosophum. 2. perhiarmensm secundum rationem potestatis ipse eedem 
-            <lb ed="#V" n="75"/>dabile est: sed posse transgredi est laudabile. Unde potesitu 
+            lau<lb ed="#V" n="74" break="no"/>  
+            <lb ed="#V" n="75"/>dabile est: sed posse transgredi est laudabile. Unde ponitur 
             <lb ed="#V" n="76"/>sunt contrariorum. Sed voluntas angelorum est 
             pote<lb ed="#V" n="77" break="no"/>in laude viri iusti. Eccls. 31. Ergo possunt peccare.
           </p>
@@ -107,7 +107,7 @@
             nun<lb ed="#V" n="92" break="no"/>quam casuros: ergo peccare nequeunt.
           </p>
           <p xml:id="kzz7yh-f21074-d1e182">
-            ¶ Item Anselus i . libo cur 
+            ¶ Item Anselmus i . libo cur 
             <lb ed="#V" n="93"/>deus homo. cap. 17. Nequaquam putandum est bonos 
             ange<lb ed="#V" n="94" break="no"/>los esse confirmatos casu malorum: sed suo merito. Si ergo 
             <lb ed="#V" n="95"/>boni angeli confirmati sunt: vt dicit Ansel. sequitur quod 
@@ -152,7 +152,7 @@
             <lb ed="#V" n="127"/>hoc peccare nequeunt. Et Isido id est libo de summo bono. c. x. 
             <lb ed="#V" n="128"/>Dicens quod quamuis sint mutabiles natura: non tamen sinit 
             <lb ed="#V" n="129"/>eos contemplatio mutari diuina. 
-            <lb ed="#V" n="130"/>cqui boni 
+            <lb ed="#V" n="130"/>atqui boni 
           </p>
           <p xml:id="kzz7yh-f21074-d1e274">
             <!--00073.xml-->
@@ -223,7 +223,7 @@
           <p xml:id="kzz7yh-f21074-d1e388">
             <lb ed="#V" n="38"/>Contra Anselmus in libro de libertate arbitrii. parum post 
             <lb ed="#V" n="39"/>principium. liberior est voluntas que a 
-            recti<lb ed="#V" n="40" break="no"/>tudine non peccandi declinare nequid quam illa que potest 
+            recti<lb ed="#V" n="40" break="no"/>tudine non peccandi declinare <sic>nequid</sic> quam illa que potest 
             dese<lb ed="#V" n="41" break="no"/>rere.
           </p>
           <p xml:id="kzz7yh-f21074-d1e400">

--- a/kzz7yh-f21074/cod-ve09v2_kzz7yh-f21074.xml
+++ b/kzz7yh-f21074/cod-ve09v2_kzz7yh-f21074.xml
@@ -87,7 +87,7 @@
             mu<lb ed="#V" n="80" break="no"/>malum sibi contrarium.
           </p>
           <p xml:id="kzz7yh-f21074-d1e148">
-            ¶ Item voluntas veritibilis ad 
+            ¶ Item voluntas vertibilis ad 
             bo<lb ed="#V" n="81" break="no"/>tabilia sunt: eo quod de nihilo facta sunt. Sed gloria non 
             amo<lb ed="#V" n="82" break="no"/>num et ad malum ante suam electionem: vertibilis est etiam ad 
             <lb ed="#V" n="83"/>uit ab angelorum voluntate esse de nihilo. Ergo ita est 
@@ -97,7 +97,7 @@
           <p xml:id="kzz7yh-f21074-d1e161">
             ¶ Item 
             <lb ed="#V" n="86"/>peritur. Sed voluntas bonorum angelorum ante suam 
-            ele<lb ed="#V" n="87" break="no"/>ctionem erat veritibilis ad bonum et ad malum. ergo et modo. 
+            ele<lb ed="#V" n="87" break="no"/>ctionem erat vertibilis ad bonum et ad malum. ergo et modo. 
           </p>
           <p xml:id="kzz7yh-f21074-d1e169">
             <lb ed="#V" n="88"/>Contra Aug. 12 de ciuita. cap. 9. Loquens de bonis 
@@ -144,7 +144,7 @@
             bo<lb ed="#V" n="119" break="no"/>ni angeli deum videntes: in ipso nihil possunt 
             apprehende<lb ed="#V" n="120" break="no"/>re sub ratione mali: et quicquid in creatura posset 
             desidera<lb ed="#V" n="121" break="no"/>ri: in eo excellentius et perfectius conspiciunt: quamuis non secundum 
-            <lb ed="#V" n="122"/>eandem rationem vniuocama: ideo nihil possunt diligere nisi 
+            <lb ed="#V" n="122"/>eandem rationem vniuocam: ideo nihil possunt diligere nisi 
             <lb ed="#V" n="123"/>ipsum vel propter ipsum. Et hanc rationem tangit Anselmus de 
             <lb ed="#V" n="124"/>casu dyaboli: inter principium et medium. Dicens quod boni 
             an<lb ed="#V" n="125" break="no"/>geli adeo prouecti sunt: vt sicut adepti quicquid velle 
@@ -184,8 +184,8 @@
           </p>
           <p xml:id="kzz7yh-f21074-d1e324">
             ¶ Ad 
-            <lb ed="#V" n="16"/>quartum cum dicitur: quod voluntas est veritibilis ad bonum 
-            <lb ed="#V" n="17"/>et ad malum ante suam electionem: est etiam veritibilis ad 
+            <lb ed="#V" n="16"/>quartum cum dicitur: quod voluntas est vertibilis ad bonum 
+            <lb ed="#V" n="17"/>et ad malum ante suam electionem: est etiam vertibilis ad 
             bo<lb ed="#V" n="18" break="no"/>num et ad malum post electionem etc. Dico quod hoc non habet 
             ve<lb ed="#V" n="19" break="no"/>ritatem de libero arbitrio confirmato: in bono: vel 
             obstina<lb ed="#V" n="20" break="no"/>to in malo. Primum enim non potest in malum. Et secundum 
@@ -212,7 +212,7 @@
             Uolun<lb ed="#V" n="31" break="no"/>tas pro sui ingenita libertate nulla cogitur necessitate. 
             Er<lb ed="#V" n="32" break="no"/>go omnis necessitas minuit libertatem. Cum ergo 
             angeli<lb ed="#V" n="33" break="no"/>per confirmationem de necessitate velint bonum: videtur 
-            <lb ed="#V" n="34"/>cuod minus sint liberi quam ante.
+            <lb ed="#V" n="34"/>quod minus sint liberi quam ante.
           </p>
           <p xml:id="kzz7yh-f21074-d1e379">
             ¶ Item obstinatio minuit 


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve09v2_kzz7yh-f21074.xml`.

## Applied changes

- p. 29v l. 80: veritibilis → vertibilis: t/r transposition
- p. 29v l. 87: veritibilis → vertibilis: t/r transposition
- p. 29v l. 122: vniuocama → vniuocam: spurious trailing 'a'
- p. 30r l. 16: veritibilis → vertibilis: t/r transposition
- p. 30r l. 17: veritibilis → vertibilis: t/r transposition
- p. 30r l. 34: cuod → quod: c/q misread

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_