### PR TITLE
Transcription corrections: cod-ve09v2_kzz7yh-f21495.xml (8 changes)

### DIFF
--- a/kzz7yh-f21495/cod-ve09v2_kzz7yh-f21495.xml
+++ b/kzz7yh-f21495/cod-ve09v2_kzz7yh-f21495.xml
@@ -146,7 +146,7 @@
             <lb ed="#V" n="1"/>tam: que iustitia terminus est digne penitentie. Maiorem 
             <lb ed="#V" n="2"/>probo sic. sicut dicit Auicen. 9. methaphysice. cap. secundo. 
             <lb ed="#V" n="3"/>nulla virtus mouet nisi mediante inclinatione: 
-            extendem<lb ed="#V" n="4" break="no"/>do nullum inclinationis ad quamlibet dispositionem 
+            extenden<lb ed="#V" n="4" break="no"/>do nullum inclinationis ad quamlibet dispositionem 
             incli<lb ed="#V" n="5" break="no"/>nantem coadiuuantem virtutem ad mouendum. Et hoc 
             pa<lb ed="#V" n="6" break="no"/>tet in naturalibus: ignis enim non posset se mouere 
             mo<lb ed="#V" n="7" break="no"/>tu ordinato ad essendum sursum: nisi inclinaretur ad 
@@ -222,9 +222,8 @@
             dilige<lb ed="#V" n="66" break="no"/>bat fratres suos affectione naturali: et ideo nolebat eos 
             dan<lb ed="#V" n="67" break="no"/>nari: ne videndo eorum damnationem amplius torqueretur. 
             <lb ed="#V" n="68"/>Unde Glos seruitur diuiti ad penam: et cognitio 
-            <!--00074.xml-->
-            <cb ed="#P" n="b"/>
-            paupe<lb ed="#V" n="69" break="no"/>ris quam despexit et memoria fratrum quos reliquit: vt de 
+            paupe<!--00074.xml-->
+            <cb ed="#P" n="b"/><lb ed="#V" n="69" break="no"/>ris quam despexit et memoria fratrum quos reliquit: vt de 
             vi<lb ed="#V" n="70" break="no"/>sa gloria despecti: et de pena inutiliter amatorum amplius 
             <lb ed="#V" n="71"/>torqueatur.
           </p>

--- a/kzz7yh-f21495/cod-ve09v2_kzz7yh-f21495.xml
+++ b/kzz7yh-f21495/cod-ve09v2_kzz7yh-f21495.xml
@@ -82,13 +82,13 @@
           </p>
           <p xml:id="kzz7yh-f21495-d1e145">
             ¶ Item Dam. libro 2. ca. vlt. 
-            <lb ed="#V" n="97"/>penitentia est ex eo quod preter naturm: ad illud quod secundum naturam. Sed 
+            <lb ed="#V" n="97"/>penitentia est ex eo quod preter naturam: ad illud quod secundum naturam. Sed 
             <lb ed="#V" n="98"/>facilius est se mouere secundum naturam quam praeter naturam. Ergo cum 
             dya<lb ed="#V" n="99" break="no"/>bolus potuerit peccare multo fortius potest digne 
             penite<lb ed="#V" n="100" break="no"/>re.
           </p>
           <p xml:id="kzz7yh-f21495-d1e156">
-            ¶ Item quod possibile est secndum diuinam potentiam: simpliciter 
+            ¶ Item quod possibile est secundum diuinam potentiam: simpliciter 
             <lb ed="#V" n="101"/>est possibile. Unde hoc simpliciter est vera aliquid creari 
             possibile<lb ed="#V" n="102" break="no"/>est. Sed deus posset facere quod dyabolus digne peniteret 
             <lb ed="#V" n="103"/>quod hoc contradictionem non includit. Ergo dyabolus potest 
@@ -120,8 +120,8 @@
             <lb ed="#V" n="118"/>non possunt se per penitentiam dignam conuertere. 
           </p>
           <p xml:id="kzz7yh-f21495-d1e209">
-            <lb ed="#V" n="119"/>Respondeo quod dyabolus digne penitere non otest 
-            <lb ed="#V" n="120"/>nde dicit Anselmus de eo in fine 
+            <lb ed="#V" n="119"/>Respondeo quod dyabolus digne penitere non potest 
+            <lb ed="#V" n="120"/>Unde dicit Anselmus de eo in fine 
             libri<lb ed="#V" n="121" break="no"/>de libertate arbitrii: quod rectitudine caret irrecuperabiliter. 
             <lb ed="#V" n="122"/>Cuius rationem aliqui sic assignant. Uoluntas spiritus separati 
             <lb ed="#V" n="123"/>quamuis ante electionem possit eorum que non naturaliter vult 
@@ -181,7 +181,7 @@
             transmu<lb ed="#V" n="33" break="no"/>tari ad partem aliam. Sed dyabolus ita perfecte 
             habitua<lb ed="#V" n="34" break="no"/>tus est in superbia: et ita intense: quod eius superbia amplius 
             <lb ed="#V" n="35"/>intendi non potest: quamuis semper extendatur. Et sic ex 
-            <lb ed="#V" n="36"/>pone illud pslamum. Superbia eorum qui te oderunt ascendit 
+            <lb ed="#V" n="36"/>pone illud psalmum. Superbia eorum qui te oderunt ascendit 
             <lb ed="#V" n="37"/>semper. Sicut enim angeli boni ex toto conatu se 
             conuer<lb ed="#V" n="38" break="no"/>tunt ad deum: ita angelus malus ex toto conatu suo se 
             con<lb ed="#V" n="39" break="no"/>uertit ad indebitam excellentiam appetendam. Unde 
@@ -245,7 +245,7 @@
             <lb ed="#V" n="82"/>omne illud possibile quod non includit contradictionem. Sed 
             <lb ed="#V" n="83"/>ex hoc non sequitur quod dyabolus possit se ad dignam 
             peni<lb ed="#V" n="84" break="no"/>tentiam. disponere: quia in se non habet nec habiturus est 
-            <lb ed="#V" n="85"/>illud adintorium: sine quo se ad penitentiam disponere non 
+            <lb ed="#V" n="85"/>illud adiutorium: sine quo se ad penitentiam disponere non 
             <lb ed="#V" n="86"/>potest.
           </p>
           <p xml:id="kzz7yh-f21495-d1e467">
@@ -269,7 +269,7 @@
           <p xml:id="kzz7yh-f21495-d1e498">
             <lb ed="#V" n="99"/>¶ Ad sextum dicendum quod naturalis cognitio veri: et 
             na<lb ed="#V" n="100" break="no"/>turalis dilectio boni: per se non sunt principium 
-            superna<lb ed="#V" n="101" break="no"/>turalis sanitatis. Ad quam digna penitentia dispotonit vel 
+            superna<lb ed="#V" n="101" break="no"/>turalis sanitatis. Ad quam digna penitentia disponit vel 
             ad<lb ed="#V" n="102" break="no"/>ducit. Sed cum hoc requiritur aliquod supernaturale 
             adiuto<lb ed="#V" n="103" break="no"/>rium adeo gratis datum: quodcumque sit illud.
           </p>
@@ -313,7 +313,7 @@
             <lb ed="#V" n="126"/>in actu culpe.
           </p>
           <p xml:id="kzz7yh-f21495-d1e583">
-            ¶ Item Glo. intellit super illud prime ca. 
+            ¶ Item Glo. intelligit super illud prime ca. 
             <lb ed="#V" n="127"/>Ioan. c. 3. ab initio dyabolus peccat. Sic dicit: quod ab 
             ini<lb ed="#V" n="128" break="no"/>tio sue creationis peccare incipiens peccat continue vsquein proaesens. 
           </p>

--- a/kzz7yh-f21495/cod-ve09v2_kzz7yh-f21495.xml
+++ b/kzz7yh-f21495/cod-ve09v2_kzz7yh-f21495.xml
@@ -145,8 +145,8 @@
             <cb ed="#P" n="a"/>
             <lb ed="#V" n="1"/>tam: que iustitia terminus est digne penitentie. Maiorem 
             <lb ed="#V" n="2"/>probo sic. sicut dicit Auicen. 9. methaphysice. cap. secundo. 
-            <lb ed="#V" n="3"/>nulla virtus mouet nisi mediante inclinatione: extendem 
-            <lb ed="#V" n="4"/>do nullum inclinationis ad quamlibet dispositionem 
+            <lb ed="#V" n="3"/>nulla virtus mouet nisi mediante inclinatione: 
+            extendem<lb ed="#V" n="4" break="no"/>do nullum inclinationis ad quamlibet dispositionem 
             incli<lb ed="#V" n="5" break="no"/>nantem coadiuuantem virtutem ad mouendum. Et hoc 
             pa<lb ed="#V" n="6" break="no"/>tet in naturalibus: ignis enim non posset se mouere 
             mo<lb ed="#V" n="7" break="no"/>tu ordinato ad essendum sursum: nisi inclinaretur ad 
@@ -221,10 +221,10 @@
             ¶ Uel potest dici quod 
             dilige<lb ed="#V" n="66" break="no"/>bat fratres suos affectione naturali: et ideo nolebat eos 
             dan<lb ed="#V" n="67" break="no"/>nari: ne videndo eorum damnationem amplius torqueretur. 
-            <lb ed="#V" n="68"/>Unde Glos seruitur diuiti ad penam: et cognitio paupe 
+            <lb ed="#V" n="68"/>Unde Glos seruitur diuiti ad penam: et cognitio 
             <!--00074.xml-->
             <cb ed="#P" n="b"/>
-            <lb ed="#V" n="69"/>ris quam despexit et memoria fratrum quos reliquit: vt de 
+            paupe<lb ed="#V" n="69" break="no"/>ris quam despexit et memoria fratrum quos reliquit: vt de 
             vi<lb ed="#V" n="70" break="no"/>sa gloria despecti: et de pena inutiliter amatorum amplius 
             <lb ed="#V" n="71"/>torqueatur.
           </p>
@@ -315,7 +315,7 @@
           <p xml:id="kzz7yh-f21495-d1e583">
             ¶ Item Glo. intelligit super illud prime ca. 
             <lb ed="#V" n="127"/>Ioan. c. 3. ab initio dyabolus peccat. Sic dicit: quod ab 
-            ini<lb ed="#V" n="128" break="no"/>tio sue creationis peccare incipiens peccat continue vsquein proaesens. 
+            ini<lb ed="#V" n="128" break="no"/>tio sue creationis peccare incipiens peccat continue vsque in praesens. 
           </p>
           <p xml:id="kzz7yh-f21495-d1e590">
             <lb ed="#V" n="129"/>Respondeo quod dyabolus semper est et erit in 
@@ -356,8 +356,8 @@
             <lb ed="#V" n="21"/>in precedenti ratione habitum est. Dyabolus semper est 
             <lb ed="#V" n="22"/>in aliquo vsu liberi arbitrii. Ergo complacet sibi semper 
             de<lb ed="#V" n="23" break="no"/>liberatiue in aliqua malitia: vel vt melius dicam semper 
-            <lb ed="#V" n="24"/>adeheret deliberatiue alicui malitie: semper ergo est in 
-            ali<lb ed="#V" n="25" break="no"/>quo actu culpe. Nec tamen semper demeribitur: proprie 
+            <lb ed="#V" n="24"/><sic>adeheret</sic> deliberatiue alicui malitie: semper ergo est in 
+            ali<lb ed="#V" n="25" break="no"/>quo actu culpe. Nec tamen semper <sic>demeribitur:</sic> proprie 
             lo<lb ed="#V" n="26" break="no"/>quendo de demerito: secundum quod demeritum dicitur culpa pro qua 
             <lb ed="#V" n="27"/>secundum decretum diuini iudicii infligi debet a iudice peccanti 
             <lb ed="#V" n="28"/>pena: quia pro malo actu liberi arbitrii post iuditium non infligetur 


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve09v2_kzz7yh-f21495.xml`.

## Applied changes

- p. 30r l. 97: naturm → naturam: missing 'a' (OCR dropout)
- p. 30r l. 100: secndum → secundum: missing 'u' (consonant cluster garbling)
- p. 30r l. 119: otest → potest: missing initial 'p'
- p. 30r l. 120: nde → Unde: missing initial 'U'
- p. 30v l. 36: pslamum → psalmum: letter transposition sl→lm (should be psal-)
- p. 30v l. 85: adintorium → adiutorium: missing 'u' (OCR dropout in 'iut' cluster)
- p. 30v l. 101: dispotonit → disponit: spurious 'to' insertion
- p. 30v l. 126: intellit → intelligit: 'igi' dropped from middle of word

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_