### PR TITLE
Transcription corrections: cod-ve09v2_kzz7yh-f22165.xml (12 changes)

### DIFF
--- a/kzz7yh-f22165/cod-ve09v2_kzz7yh-f22165.xml
+++ b/kzz7yh-f22165/cod-ve09v2_kzz7yh-f22165.xml
@@ -99,7 +99,7 @@
           </p>
           <p xml:id="kzz7yh-f22165-d1e174">
             ¶ Item per gratiam reformantur omnes partes 
-            <lb ed="#V" n="84"/>imaginis: secundum Glo. super illud pslamum. Signatum est super nos 
+            <lb ed="#V" n="84"/>imaginis: secundum Glo. super illud psalmum. Signatum est super nos 
             <lb ed="#V" n="85"/>lumen vultus tui. Ergo similiter tota imago per 
             pecca<lb ed="#V" n="86" break="no"/>tum deformatur. Sed deformatio memorie que est pars 
             <lb ed="#V" n="87"/>imaginis: videtur esse per obliuionem. Ergo videtur quod 
@@ -134,7 +134,7 @@
           </p>
           <p xml:id="kzz7yh-f22165-d1e235">
             ¶ 
-            Se<lb ed="#V" n="106" break="no"/>cundo modo est ipiam intelligentiam non conuerti vt debet 
+            Se<lb ed="#V" n="106" break="no"/>cundo modo est ipsam intelligentiam non conuerti vt debet 
             <lb ed="#V" n="107"/>super ea que in memoria retinentur.
           </p>
           <p xml:id="kzz7yh-f22165-d1e242">
@@ -280,7 +280,7 @@
             ma<lb ed="#V" n="61" break="no"/>libro ergo habent cognitionem futurorum 
           </p>
           <p xml:id="kzz7yh-f22165-d1e494">
-            <lb ed="#V" n="62"/>Ad istam quonem dicunt quidam: quod quamuis 
+            <lb ed="#V" n="62"/>Ad istam quaestionem dicunt quidam: quod quamuis 
             de<lb ed="#V" n="63" break="no"/>mones per sua naturalem 
             <lb ed="#V" n="64"/>virtutem habeant futurorum predictorum valde probabilem 
             coniectu<lb ed="#V" n="65" break="no"/>ram: eo quod eorum cause sunt naturales et determinate: et vt in 
@@ -333,7 +333,7 @@
             ¶ Aliis autem videtur 
             <lb ed="#V" n="100"/>contrarium: quia natura de necessitate operatur. Et ideo omnes 
             effe<lb ed="#V" n="101" break="no"/>ctus naturales nisi impediantur per liberum arbitrium diuinum vel 
-            <lb ed="#V" n="102"/>angelicum: vel humanum. De necessitate eueniut 
+            <lb ed="#V" n="102"/>angelicum: vel humanum. De necessitate eueniunt 
             praesupposi<lb ed="#V" n="103" break="no"/>ta influentia dei gnaturali: que necessaria est ad conseruationem 
             <lb ed="#V" n="104"/>nature create: et ipsius operationem. Unde si natura 
             disposue<lb ed="#V" n="105" break="no"/>rit nubem ad pluuiam: de necessitate resoluetur in pluuiam: nisi 
@@ -344,10 +344,10 @@
             <lb ed="#V" n="110"/>motum et cursum: et coniunctionem planetarum inter se: et cum 
             stel<lb ed="#V" n="111" break="no"/>lis fixis: prescire possunt per suam virtutem sub certitudine 
             <lb ed="#V" n="112"/>futurum euentum istarum impressionum naturalium: et futurum 
-            impedi<lb ed="#V" n="113" break="no"/>mentum ne dispotio ad eas reducatur ad actum. Ea tamen que 
+            impedi<lb ed="#V" n="113" break="no"/>mentum ne dispositio ad eas reducatur ad actum. Ea tamen que 
             depem<lb ed="#V" n="114" break="no"/>dent a liberi arbitrii per suam virtutem naturalem sub certitudine 
             praecogno<lb ed="#V" n="115" break="no"/>scere non possunt: sed per signa: et per ea quae frequenter accidere 
-            vi<lb ed="#V" n="116" break="no"/>derunt: de illis communiecturant et multotiens decipiuntur. 
+            vi<lb ed="#V" n="116" break="no"/>derunt: de illis coniecturant et multotiens decipiuntur. 
             <lb ed="#V" n="117"/>Qui vult tenere primam opinionem potest 
             respon<lb ed="#V" n="118" break="no"/>dere ad argumenta in contrarium. 
           </p>
@@ -371,7 +371,7 @@
           </p>
           <p xml:id="kzz7yh-f22165-d1e669">
             <lb ed="#V" n="132"/>¶ Ad secundum dicendum. autem quod diabolus illa non praesciuit sub 
-            cer<lb ed="#V" n="133" break="no"/>titudine. Sed per signa probabiliter communiecturauit: eo quod 
+            cer<lb ed="#V" n="133" break="no"/>titudine. Sed per signa probabiliter coniecturauit: eo quod 
             vi<lb ed="#V" n="134" break="no"/>debat quedam presentia ad que probabiliter coniecturabat: 
             <lb ed="#V" n="135"/>arsionem capitolii: et victoriam sylle postea seq. Aut sciuit se 
             <lb ed="#V" n="136"/>permissum et licentiatum ad talia faciendum. Et ideo predixit 
@@ -382,7 +382,7 @@
             <cb ed="#P" n="a"/>
             <lb ed="#V" n="1"/>illud quod per suam procurationem erat futurum. Sic enim dicit 
             <lb ed="#V" n="2"/>beatus <ref xml:id="kzz7yh-f22165-Rd1e711">Aug. 2. super Gen. circa finem</ref>: aliquando nephandi 
-            <lb ed="#V" n="3"/>spiritus etiam que ipsi facturi suut: velut diuinando praedicunt. 
+            <lb ed="#V" n="3"/>spiritus etiam que ipsi facturi sunt: velut diuinando praedicunt. 
           </p>
           <p xml:id="kzz7yh-f22165-d1e700">
             <lb ed="#V" n="4"/>¶ Ad tertium dicendum quod auctoritas Aui. soluitur per hoc quod 
@@ -428,7 +428,7 @@
           <p xml:id="kzz7yh-f22165-d1e773">
             ¶ Ad quartum 
             <lb ed="#V" n="30"/>dicendum: quod quamuis non habuerit praecognitionem sui casus: tamen potest 
-            <lb ed="#V" n="31"/>habere perecognitionem impressionum naturalium: quia hoc est futurum necessarium 
+            <lb ed="#V" n="31"/>habere praecognitionem impressionum naturalium: quia hoc est futurum necessarium 
             <lb ed="#V" n="32"/>et suus casus fuit futurum contingens.
           </p>
           <p xml:id="kzz7yh-f22165-d1e782">
@@ -465,14 +465,14 @@
             arti<lb ed="#V" n="53" break="no"/>culum excommunicatum dicunt quod non est contra istam opinionem. Non enim ponit 
             <lb ed="#V" n="54"/>hoc opinio effectus libero arbitri seu dependentes ex liberi arbitrio diuino vel 
             ange<lb ed="#V" n="55" break="no"/>lico vel humano de necessitate euenire quando eueniunt: nec de 
-            <lb ed="#V" n="56"/>necessitate impediri quando impediuntur. Quioa ponebant illi contra quos 
+            <lb ed="#V" n="56"/>necessitate impediri quando impediuntur. Quia ponebant illi contra quos 
             <lb ed="#V" n="57"/>ille praedictus articulus fuit excommunicatus. Unde nec ponit haec 
             opi<lb ed="#V" n="58" break="no"/>nio concursum causarum: quae sunt voluntarie operantes esse necessarium 
-            quam<lb ed="#V" n="59" break="no"/>uis ponat concursum causarum pure naturalium de necessitate concurre 
-            <lb ed="#V" n="60"/>re: quando concurrant: supposito motu celi: sicut modo est. et dei 
+            quam<lb ed="#V" n="59" break="no"/>uis ponat concursum causarum pure naturalium de necessitate 
+            concurre<lb ed="#V" n="60" break="no"/>re: quando concurrant: supposito motu celi: sicut modo est. et dei 
             in<lb ed="#V" n="61" break="no"/>stuentia generali: sine qua nulla creatura esse posset nec agere. 
             <lb ed="#V" n="62"/>Si tamen hoc secunda opinio qualiter cumque incidat in praedictum articulum 
-            <lb ed="#V" n="63"/>excommunicatum seu quencumque alium horrenda est et fugienda. 
+            <lb ed="#V" n="63"/>excommunicatum seu quemcumque alium horrenda est et fugienda. 
           </p>
           <p xml:id="kzz7yh-f22165-d1e860">
             <lb ed="#V" n="64"/>¶ Quomodo autem isti nitantur effugere qui pro prima opinione in 

--- a/kzz7yh-f22165/cod-ve09v2_kzz7yh-f22165.xml
+++ b/kzz7yh-f22165/cod-ve09v2_kzz7yh-f22165.xml
@@ -315,7 +315,7 @@
               ni<lb ed="#V" n="87" break="no"/>hil sit a casu: sed omnia eueniunt de necessitate: et quod omnia futu. 
               <lb ed="#V" n="88"/>ra que erunt de necessitate erunt: et que non erunt: 
               impossibile<lb ed="#V" n="89" break="no"/>est esse: et quod nihil euenit contingenter: considerando omnes causas</quote>. 
-            <lb ed="#V" n="90"/>Et post subiungit excommunicator dominus Stephanus episotmus 
+            <lb ed="#V" n="90"/>Et post subiungit <sic>excommunicator</sic> dominus Stephanus episcopus 
             Pari<lb ed="#V" n="91" break="no"/>risiensis. et sacre theologie doctor quod est <quote xml:id="kzz7yh-f22165-Qfgfjh8" source="http://scta.info/resource/z88d99-avn8u2-d1e264@35-48">error: quia concursus 
               <lb ed="#V" n="92"/>causarum est de diffinitione casualis effectus: vt dicit Boeus. lib. de 
               <lb ed="#V" n="93"/>consolatione</quote>.
@@ -334,7 +334,7 @@
             <lb ed="#V" n="100"/>contrarium: quia natura de necessitate operatur. Et ideo omnes 
             effe<lb ed="#V" n="101" break="no"/>ctus naturales nisi impediantur per liberum arbitrium diuinum vel 
             <lb ed="#V" n="102"/>angelicum: vel humanum. De necessitate eueniunt 
-            praesupposi<lb ed="#V" n="103" break="no"/>ta influentia dei gnaturali: que necessaria est ad conseruationem 
+            praesupposi<lb ed="#V" n="103" break="no"/>ta influentia dei generali: que necessaria est ad conseruationem 
             <lb ed="#V" n="104"/>nature create: et ipsius operationem. Unde si natura 
             disposue<lb ed="#V" n="105" break="no"/>rit nubem ad pluuiam: de necessitate resoluetur in pluuiam: nisi 
             <lb ed="#V" n="106"/>superueniat aliqua fortior causa naturalis: qua hoc de necessitate 
@@ -394,7 +394,7 @@
           </p>
           <p xml:id="kzz7yh-f22165-d1e716">
             ¶ Uel potest dici. quod illud 
-            ver<lb ed="#V" n="10" break="no"/>bum debet intelligi de angelis sanctis qui plura contingeniia 
+            ver<lb ed="#V" n="10" break="no"/>bum debet intelligi de angelis sanctis qui plura <sic>contingeniia</sic> 
             <lb ed="#V" n="11"/>futura intuentur supernaturaliter: per hoc quod sunt a creatore 
             <lb ed="#V" n="12"/>supernaturaliter illustrati.
           </p>
@@ -440,8 +440,8 @@
             futu<lb ed="#V" n="37" break="no"/>rum: pro illo tempore quod assignat. Et praeterea diabolus non dicit 
             ip<lb ed="#V" n="38" break="no"/>sis magis: quicquid praescit: quandoque quia non vult: quandoque quia prohibetur 
             <lb ed="#V" n="39"/>adeo et angelis sanctis. Potest est dici quod quandoque significat 
-            ma<lb ed="#V" n="40" break="no"/>gis: et repntat aliquid futurum: et ipsi magi illam significationem 
-            <lb ed="#V" n="41"/>vel repntationem non bene intelligunt: et sic decipiuntur.
+            ma<lb ed="#V" n="40" break="no"/>gis: et repraesentat aliquid futurum: et ipsi magi illam significationem 
+            <lb ed="#V" n="41"/>vel repraesentationem non bene intelligunt: et sic decipiuntur.
           </p>
           <p xml:id="kzz7yh-f22165-d1e804">
             ¶ Ad 
@@ -476,7 +476,7 @@
           </p>
           <p xml:id="kzz7yh-f22165-d1e860">
             <lb ed="#V" n="64"/>¶ Quomodo autem isti nitantur effugere qui pro prima opinione in 
-            cor<lb ed="#V" n="65" break="no"/>pore quaestionis allegata sunt: quam opinionem vndeer veram sensisse 
+            cor<lb ed="#V" n="65" break="no"/>pore quaestionis allegata sunt: quam opinionem viduntur veram sensisse 
             <lb ed="#V" n="66"/>philosophus et commen. eius non recito modo: quia de hoc iterum aliquid tangetur 
             infe<lb ed="#V" n="67" break="no"/>rius. dist. 37. in illa quaestione vtrum effectus fortuiti vel casuales 
             re<lb ed="#V" n="68" break="no"/>ducantur in aliquam creatam causa: quae sit eorum causa perse. 


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve09v2_kzz7yh-f22165.xml`.

## Applied changes

- p. 31r l. 84: pslamum → psalmum: letter transposition (psl → psal)
- p. 31r l. 106: ipiam → ipsam: 'p' dropped, 'i' misread for 's' (context: 'ipiam intelligentiam' → 'ipsam intelligentiam')
- p. 31v l. 62: quonem → quaestionem: garbled abbreviation expansion (q-nem with missing letters)
- p. 31v l. 102: eueniut → eueniunt: missing 'n' before 't'
- p. 31v l. 113: dispotio → dispositio: letters transposed/dropped (spo → spos → pos in 'disposi-')
- p. 31v l. 116: communiecturant → coniecturant: garbled form of 'coniecturant' (they conjecture/surmise)
- p. 31v l. 133: communiecturauit → coniecturauit: garbled form of 'coniecturauit' (he conjectured)
- p. 32r l. 3: suut → sunt: 'u' misread for 'n' (OCR doubled vowel)
- p. 32r l. 31: perecognitionem → praecognitionem: 'pere' garbled from 'prae'
- p. 32r l. 56: Quioa → Quia: 'oa' garbled from 'a'
- p. 32r l. 60: 'concurre' + 're' split across line break without break="no" on lb n=60
- p. 32r l. 63: quencumque → quemcumque: 'n' → 'm' before consonant (standard assimilation)

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_