### PR TITLE
Transcription corrections: cod-ve09v2_kzz7yh-f22940.xml (27 changes)

### DIFF
--- a/kzz7yh-f22940/cod-ve09v2_kzz7yh-f22940.xml
+++ b/kzz7yh-f22940/cod-ve09v2_kzz7yh-f22940.xml
@@ -97,7 +97,7 @@
               varie<lb ed="#V" n="89" break="no"/>tate virgarum pecorum conceptorum color aliquid duceret fecit hoc 
               <lb ed="#V" n="90"/>anima grauide pecudis per oculos affecta forinsecus et 
               inte<lb ed="#V" n="91" break="no"/>rius secum pro modulo suo formandi regulam trahens</quote>. Cum 
-            <lb ed="#V" n="92"/>ergo productio forme accidentalis sit dispitmo ad formam 
+            <lb ed="#V" n="92"/>ergo productio forme accidentalis sit dispositio ad formam 
             sub<lb ed="#V" n="93" break="no"/>stantialem: Uideretur quod imaginatio possit immediate 
             tramsmu<lb ed="#V" n="94" break="no"/>tare materiam ad formam substantialem: ergo multo fortius hoc potest 
             <lb ed="#V" n="95"/>virtus naturalis diaboli que est potentior.
@@ -233,11 +233,11 @@
           <p xml:id="kzz7yh-f22940-d1e426">
             <lb ed="#V" n="53"/>¶ Argumenta ad oppositum gratia principalis 
             conclusio<lb ed="#V" n="54" break="no"/>nis possunt concedi. Tamen primum solutione indiget. 
-            <lb ed="#V" n="55"/>Conius enim tenetur quod illi serpentes quos fecerunt 
+            <lb ed="#V" n="55"/> enim tenetur quod illi serpentes quos fecerunt 
             malefi<lb ed="#V" n="56" break="no"/>ci pharaonis fuerunt veri serpentes. Unde Glo. 
             allega<lb ed="#V" n="57" break="no"/>ta sub opinione ibi est posita: quia etiam postea in eadem 
             <lb ed="#V" n="58"/>Glo. ad membrum ponitur sub dubitatione: et dicuntur virge in tex 
-            <lb ed="#V" n="59"/>tuteo quod facti fuerunt de materia virgarum. 
+            <lb ed="#V" n="59"/>titulo quod facti fuerunt de materia virgarum. 
           </p>
         </div>
         <div xml:id="kzz7yh-f22940-Dd1e446">
@@ -266,14 +266,14 @@
           </p>
           <p xml:id="kzz7yh-f22940-d1e488">
             ¶ Item Boe. libro 
-            <lb ed="#V" n="72"/>secundo. de cathegoricis sunivermsitlis: boni homines non aliter 
+            <lb ed="#V" n="72"/>secundo. de cathegoricis syllogismis: boni homines non aliter 
             ca<lb ed="#V" n="73" break="no"/>uent nisi mala nouerint. ergo omnis scientia bona est: 
             <lb ed="#V" n="74"/>siue sit respectu boni: siue respectu mali. Sed ars 
             magi<lb ed="#V" n="75" break="no"/>ca scientia est. ergo bona est. Sed omni bono creato licet 
             <lb ed="#V" n="76"/>vti: ergo arte magica licitum est hominibus vti. 
           </p>
           <p xml:id="kzz7yh-f22940-d1e502">
-            <lb ed="#V" n="77"/>Contra Auguus 8. de ciniat. cap. 10 Dicit quod exercere 
+            <lb ed="#V" n="77"/>Contra Augustinum 8. de ciuitate. cap. 19 Dicit quod exercere 
             <lb ed="#V" n="78"/>artes magicas: damnabile est. Et in eodem 
             <lb ed="#V" n="79"/>capitulo dicit quod legibus est humanis puniuntur.
           </p>
@@ -297,7 +297,7 @@
             homi<lb ed="#V" n="90" break="no"/>nibus: et lege diuina et lege positiua. Et credo quod etiam 
             le<lb ed="#V" n="91" break="no"/>ge nature: eo quod diabolus est aduersarius obstinatus summi 
             <lb ed="#V" n="92"/>principis nostri dei: et est ab ecclesia irreuocabiliter 
-            preci<lb ed="#V" n="93" break="no"/>sus: et ita mendax et fallax. Quioa si aliquando dicit veritatem 
+            preci<lb ed="#V" n="93" break="no"/>sus: et ita mendax et fallax. Quod si aliquando dicit veritatem 
             <lb ed="#V" n="94"/>vtilem: aut eam dicit compulsus a deo: aut hac intentione vt 
             <lb ed="#V" n="95"/>magis sibi postea in mendacio credatur: vt sic decipiat 
             cau<lb ed="#V" n="96" break="no"/>telosius: et ideo qui familiariter eum inuocat peccat directe 

--- a/kzz7yh-f22940/cod-ve09v2_kzz7yh-f22940.xml
+++ b/kzz7yh-f22940/cod-ve09v2_kzz7yh-f22940.xml
@@ -63,7 +63,7 @@
         </p>
         <p xml:id="kzz7yh-f22940-d1e116">
           ¶ Primo vtrum demones 
-          <lb ed="#V" n="72"/>possunt tramsmutare materiam ad formam substatialem 
+          <lb ed="#V" n="72"/>possunt transmutare materiam ad formam substantialem 
           <lb ed="#V" n="73"/>per suam virtutem immediate.
         </p>
         <p xml:id="kzz7yh-f22940-d1e123">
@@ -76,22 +76,22 @@
             ¶ Quaestio I. 
             <lb ed="#V" n="75"/>PRimo ostendo quod demo per suam 
             ver<lb ed="#V" n="76" break="no"/>cutem immediate potest 
-            <lb ed="#V" n="77"/>materiam tramsmutare ad formam substantialem. Quia vt 
+            <lb ed="#V" n="77"/>materiam transmutare ad formam substantialem. Quia vt 
             <lb ed="#V" n="78"/>habetur Exo. 7. Malefici pharaonis fecerunt 
-            dra<lb ed="#V" n="79" break="no"/>cones: et vt habetur sequenti cap. fecerut est ranas. Cum ergo 
-            ope<lb ed="#V" n="80" break="no"/>rarentur virtute diabolica. Ur quod diabolus potest tramsmutare 
-            <lb ed="#V" n="81"/>materiam ad subiteactialem formam.
+            dra<lb ed="#V" n="79" break="no"/>cones: et vt habetur sequenti cap. fecerunt est ranas. Cum ergo 
+            ope<lb ed="#V" n="80" break="no"/>rarentur virtute diabolica. Ur quod diabolus potest transmutare 
+            <lb ed="#V" n="81"/>materiam ad substantialem formam.
           </p>
           <p xml:id="kzz7yh-f22940-d1e150">
             ¶ Item quod potest virtus inferior potest virtus superior 
             <lb ed="#V" n="82"/>Sed virtus naturalis ipsius demonis superior est quam virtus 
             na<lb ed="#V" n="83" break="no"/>turalis cuiuscumque corporis. Si ergo virtus naturalis ipsius 
-            cor<lb ed="#V" n="84" break="no"/>poris potest tramsmutare materiam ad formam substantialem: multo 
+            cor<lb ed="#V" n="84" break="no"/>poris potest transmutare materiam ad formam substantialem: multo 
             <lb ed="#V" n="85"/>fortius hoc potest diabolus sua naturali virtute.
           </p>
           <p xml:id="kzz7yh-f22940-d1e161">
             ¶ Item imaginatio 
-            <lb ed="#V" n="86"/>potest immediate tramsmutare materiam ad formam substantialem. Unde 
+            <lb ed="#V" n="86"/>potest immediate transmutare materiam ad formam substantialem. Unde 
             <lb ed="#V" n="87"/><ref xml:id="kzz7yh-f22940-Rbnmvnm" corresp="#kzz7yh-f22940-Qa9900a">Aug. 3. de tri. ca. 7.</ref> Exponens quomodo oues Iacob ex contuitu 
             <lb ed="#V" n="88"/>virgarum concipiebat fetus diuersi coloris. Dicit <quote xml:id="kzz7yh-f22940-Qa9900a" source="http://scta.info/resource/adt-l3-d1e432@135-162">vt de 
               varie<lb ed="#V" n="89" break="no"/>tate virgarum pecorum conceptorum color aliquid duceret fecit hoc 
@@ -106,7 +106,7 @@
             ¶ Item Auic. 6 
             natura<lb ed="#V" n="96" break="no"/>lium lib. 4. cap. 4. dicit quod cum anima fuerit constans 
             nobilis<lb ed="#V" n="97" break="no"/>simis principiis obediet ei materia que est in mundo et patietur 
-            <lb ed="#V" n="98"/>ex eo. Et sicut patet postea intelligit etiam de tramsmutatione 
+            <lb ed="#V" n="98"/>ex eo. Et sicut patet postea intelligit etiam de transmutatione 
             <lb ed="#V" n="99"/>materie ad formam substantialem: ergo multo fortius hoc potest 
             <lb ed="#V" n="100"/>virtus naturalis ipsius demonis: que potentior est quam virtus 
             <lb ed="#V" n="101"/>naturalis anime cuiuscumque.
@@ -116,44 +116,44 @@
             <lb ed="#V" n="102"/>quod miracula magicis artibus fiunt. Sed sicut dicit in eodem 
             <lb ed="#V" n="103"/>ca. Per diabolicas potestates magice artes possunt quicquid 
             <lb ed="#V" n="104"/>possunt. ergo diabolus per suam virtutem potest facere 
-            mi<lb ed="#V" n="105" break="no"/>racula. Sed hoc est maius miraculum scilicet quam materiam tramsmutare 
+            mi<lb ed="#V" n="105" break="no"/>racula. Sed hoc est maius miraculum scilicet quam materiam transmutare 
             <lb ed="#V" n="106"/>ad formam: ergo multo fortius potest diabolus transmutare 
             <lb ed="#V" n="107"/>materiam ad substantialem formam.
           </p>
           <p xml:id="kzz7yh-f22940-d1e218">
             ¶ Item homines per artem 
-            alchi<lb ed="#V" n="108" break="no"/>mie tramsmutant materiam de vna forma substantiali ad aliam. ergo 
+            alchi<lb ed="#V" n="108" break="no"/>mie transmutant materiam de vna forma substantiali ad aliam. ergo 
             <lb ed="#V" n="109"/>multo fortius potest hoc diabolus facere. 
           </p>
           <p xml:id="kzz7yh-f22940-d1e225">
             <lb ed="#V" n="110"/>Contra Glo. super illud Exo. 7. Deuorauit 
             virga<lb ed="#V" n="111" break="no"/>Aaron virgas eorum. Dicit quod hoc potuit 
             absor<lb ed="#V" n="112" break="no"/>bere quod erant: non quod videbantur et non erant: ergo magi 
-            pha<lb ed="#V" n="113" break="no"/>raonis non fecerut veros dracones. Cum ergo tunc 
+            pha<lb ed="#V" n="113" break="no"/>raonis non fecerunt veros dracones. Cum ergo tunc 
             diabo<lb ed="#V" n="114" break="no"/>lus operaretur per eos secundum totum conatum suum. Uidetur quod non 
-            <lb ed="#V" n="115"/>possit tramsmutare per propriam virtutem materiam ad formam. 
+            <lb ed="#V" n="115"/>possit transmutare per propriam virtutem materiam ad formam. 
           </p>
           <p xml:id="kzz7yh-f22940-d1e241">
             <lb ed="#V" n="116"/>¶ Item Aug. 3. de trini. ca. 7. Dicit quod angeli mali in 
             trans<lb ed="#V" n="117" break="no"/>mutando materiam ad formam se habent: sicut agricole ad 
             productio<lb ed="#V" n="118" break="no"/>nem segetum. Sed agricole ad hoc non attingunt: nisi mediante 
-            <lb ed="#V" n="119"/>opere nature: ergo nec diabolus potest tramsmutare materiam 
+            <lb ed="#V" n="119"/>opere nature: ergo nec diabolus potest transmutare materiam 
             <lb ed="#V" n="120"/>ad formam substantialem nisi mediante opere nature. 
           </p>
           <p xml:id="kzz7yh-f22940-d1e254">
             <lb ed="#V" n="121"/>Respondeo quod quamuis diabolus per suam virtutem 
-            <lb ed="#V" n="122"/>imediate possit tramsmutare istas 
+            <lb ed="#V" n="122"/>immediate possit transmutare istas 
             <lb ed="#V" n="123"/>res materiales secundum locum: et est ad formam artificialem: eo quod forma 
-            <lb ed="#V" n="124"/>artificialis causatur: per aliquarum pertium ablationem: sicut patet in 
-            fi<lb ed="#V" n="125" break="no"/>gura incisionis: vel per localem mutationem pertium: vt habeant 
-            <lb ed="#V" n="126"/>diuersum situm in suo toto: sicut patet in forma compositionis. Tmsen ter 
-            <lb ed="#V" n="127"/>suam virtutem immediate non potest tramsmutare materiam ad formam 
+            <lb ed="#V" n="124"/>artificialis causatur: per aliquarum partium ablationem: sicut patet in 
+            fi<lb ed="#V" n="125" break="no"/>gura incisionis: vel per localem mutationem partium: vt habeant 
+            <lb ed="#V" n="126"/>diuersum situm in suo toto: sicut patet in forma compositionis. Tamen per 
+            <lb ed="#V" n="127"/>suam virtutem immediate non potest transmutare materiam ad formam 
             nan<lb ed="#V" n="128" break="no"/>lem: neque substantialem: neque accidentalem. Unde commen. super. 7. meta. 
-            <lb ed="#V" n="129"/>impossibile est quod forme separate tramsmutent materiam. Non enim 
+            <lb ed="#V" n="129"/>impossibile est quod forme separate transmutent materiam. Non enim 
             tramsmu<lb ed="#V" n="130" break="no"/>tat materiam nisi illud quod est in materia. Cuius ratio est: quia aut hoc faceret 
             <lb ed="#V" n="131"/>operando per modum nature: aut per modum artis. Non primo modo siue 
-            <lb ed="#V" n="132"/>loquamur de agente secundum naturam vniuoce vivel equoce: quia ad talem 
-            ac<lb ed="#V" n="133" break="no"/>tionem non est eius naura a creatore determinata: qui omnes naturas creata: 
+            <lb ed="#V" n="132"/>loquamur de agente secundum naturam vniuoce vel equiuoce: quia ad talem 
+            ac<lb ed="#V" n="133" break="no"/>tionem non est eius natura a creatore determinata: qui omnes naturas creata: 
             <lb ed="#V" n="134"/>determinauit ab institutione nature ad suas proprias actiones naturales 
             <lb ed="#V" n="135"/>quamuis ipse nature create actiue illas naturales actiones eliciant: ad 
             <lb ed="#V" n="136"/>quas determinate sunt ab ipsarum iustitutione. Nec est hoc posset 
@@ -161,8 +161,8 @@
             <pb ed="#V" n="32-v"/>
             <cb ed="#P" n="a"/>
             <lb ed="#V" n="1"/>facere operando per modum artis. agens enim quod est 
-            na<lb ed="#V" n="2" break="no"/>tura creata: de necessitate presupponit ad suam actio 
-            <lb ed="#V" n="3"/>nem aliquem effectum artificis increati: sicut materiam 
+            na<lb ed="#V" n="2" break="no"/>tura creata: de necessitate presupponit ad suam 
+            actio<lb ed="#V" n="3" break="no"/>nem aliquem effectum artificis increati: sicut materiam 
             <lb ed="#V" n="4"/>et eius possibilitatem ad formam: que a solo artifice 
             increa<lb ed="#V" n="5" break="no"/>to produci potuit: et deus sic limitauit potentiam omnis 
             <lb ed="#V" n="6"/>artificis creati vt in sua actione presupponat aliquem 
@@ -184,7 +184,7 @@
           <p xml:id="kzz7yh-f22940-d1e341">
             <lb ed="#V" n="21"/>Ad primum in opositum dicendum: quod magi pharaonis 
             il<lb ed="#V" n="22" break="no"/>ios serpentes fecerunt mediante 
-            <lb ed="#V" n="23"/>opere nature: si tamen fuerunt veri serpenttes.
+            <lb ed="#V" n="23"/>opere nature: si tamen fuerunt veri serpentes.
           </p>
           <p xml:id="kzz7yh-f22940-d1e351">
             ¶ Ad 
@@ -247,7 +247,7 @@
             <lb ed="#V" n="61"/>SEcundo queritur vtrum 
             li<lb ed="#V" n="62" break="no"/>ceat 
             ho<lb ed="#V" n="63" break="no"/>minibus vti demonum ministerio vel arte. Et 
-            <lb ed="#V" n="64"/>videtur quod sic. Apstoulus ad Corin. 5 dicit se 
+            <lb ed="#V" n="64"/>videtur quod sic. Apostolus ad Corin. 5 dicit se 
             tradi<lb ed="#V" n="65" break="no"/>disse quendam peccatorem sathane: ergo vsus fuit 
             demo<lb ed="#V" n="66" break="no"/>nis ministerio.
           </p>
@@ -283,7 +283,7 @@
             diui<lb ed="#V" n="81" break="no"/>nationis fuerit spiritus morte moriatur. 
           </p>
           <p xml:id="kzz7yh-f22940-d1e518">
-            <lb ed="#V" n="82"/>Respondeo quod vti ministerio diaboli: soc dupliciter 
+            <lb ed="#V" n="82"/>Respondeo quod vti ministerio diaboli: hoc dupliciter 
             <lb ed="#V" n="83"/>potest intelligi. Aut diuina 
             virtu<lb ed="#V" n="84" break="no"/>te: que superior est: sibi aliqua licita imperando. Sicut 
             ali<lb ed="#V" n="85" break="no"/>qui viri sancti fecisse leguntur. Unde Paulus vt 
@@ -298,7 +298,7 @@
             le<lb ed="#V" n="91" break="no"/>ge nature: eo quod diabolus est aduersarius obstinatus summi 
             <lb ed="#V" n="92"/>principis nostri dei: et est ab ecclesia irreuocabiliter 
             preci<lb ed="#V" n="93" break="no"/>sus: et ita mendax et fallax. Quioa si aliquando dicit veritatem 
-            <lb ed="#V" n="94"/>vtilem: aute eam dicit compulsus a deo: aut hac intentione vt 
+            <lb ed="#V" n="94"/>vtilem: aut eam dicit compulsus a deo: aut hac intentione vt 
             <lb ed="#V" n="95"/>magis sibi postea in mendacio credatur: vt sic decipiat 
             cau<lb ed="#V" n="96" break="no"/>telosius: et ideo qui familiariter eum inuocat peccat directe 
             <lb ed="#V" n="97"/>contra deum: et contra ecclesiam: et contra se ipsum: cum diabolus 
@@ -308,7 +308,7 @@
             ma<lb ed="#V" n="101" break="no"/>gicis erit prohibitum tamquam illicitum et prophanum. Unde Aug. 
             <lb ed="#V" n="102"/>2 lib. de doctri. christia. post medium: loquens de magicis 
             ar<lb ed="#V" n="103" break="no"/>tibus: dicit. omnes igitur artes huiusmodi vel nugatorie vel 
-            <lb ed="#V" n="104"/>noxie superstitionis: ex quadam pestifera focietate 
+            <lb ed="#V" n="104"/>noxie superstitionis: ex quadam pestifera societate 
             homi<lb ed="#V" n="105" break="no"/>num et demonum: quasi pacta infideliter et dolose constituta 
             pe<lb ed="#V" n="106" break="no"/>nitus sunt repudianda et fugienda christiano. 
           </p>

--- a/kzz7yh-f22940/cod-ve09v2_kzz7yh-f22940.xml
+++ b/kzz7yh-f22940/cod-ve09v2_kzz7yh-f22940.xml
@@ -233,11 +233,11 @@
           <p xml:id="kzz7yh-f22940-d1e426">
             <lb ed="#V" n="53"/>¶ Argumenta ad oppositum gratia principalis 
             conclusio<lb ed="#V" n="54" break="no"/>nis possunt concedi. Tamen primum solutione indiget. 
-            <lb ed="#V" n="55"/> enim tenetur quod illi serpentes quos fecerunt 
+            <lb ed="#V" n="55"/>Contus enim tenetur quod illi serpentes quos fecerunt 
             malefi<lb ed="#V" n="56" break="no"/>ci pharaonis fuerunt veri serpentes. Unde Glo. 
             allega<lb ed="#V" n="57" break="no"/>ta sub opinione ibi est posita: quia etiam postea in eadem 
-            <lb ed="#V" n="58"/>Glo. ad membrum ponitur sub dubitatione: et dicuntur virge in tex 
-            <lb ed="#V" n="59"/>titulo quod facti fuerunt de materia virgarum. 
+            <lb ed="#V" n="58"/>Glo. ad membrum ponitur sub dubitatione: et dicuntur virge in 
+            tex<lb ed="#V" n="59" break="no"/>tu: quod facti fuerunt de materia virgarum. 
           </p>
         </div>
         <div xml:id="kzz7yh-f22940-Dd1e446">


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve09v2_kzz7yh-f22940.xml`.

## Applied changes

- p. 32r l. 72: tramsmutare -> transmutare: ms/ns cluster misread; substatialem -> substantialem: garbled OCR
- p. 32r l. 77: tramsmutare -> transmutare: ms/ns cluster misread
- p. 32r l. 79: fecerut -> fecerunt: missing -n- in -runt ending
- p. 32r l. 80: tramsmutare -> transmutare: ms/ns cluster misread
- p. 32r l. 81: subiteactialem -> substantialem: garbled OCR
- p. 32r l. 84: tramsmutare -> transmutare: ms/ns cluster misread
- p. 32r l. 86: tramsmutare -> transmutare: ms/ns cluster misread
- p. 32r l. 98: tramsmutatione -> transmutatione: ms/ns cluster misread
- p. 32r l. 105: tramsmutare -> transmutare: ms/ns cluster misread
- p. 32r l. 108: tramsmutant -> transmutant: ms/ns cluster misread
- p. 32r l. 113: fecerut -> fecerunt: missing -n- in -runt ending
- p. 32r l. 115: tramsmutare -> transmutare: ms/ns cluster misread
- p. 32r l. 119: tramsmutare -> transmutare: ms/ns cluster misread
- p. 32r l. 122: imediate -> immediate: missing -m-; tramsmutare -> transmutare: ms/ns cluster misread
- p. 32r l. 124: pertium -> partium: e/a misread in pars genitive plural
- p. 32r l. 125: pertium -> partium: e/a misread in pars genitive plural
- p. 32r l. 126: Tmsen -> Tamen: garbled OCR; ter -> per: t/p misread; context: Tamen per suam virtutem immediate non potest transmutare
- p. 32r l. 127: tramsmutare -> transmutare: ms/ns cluster misread
- p. 32r l. 129: tramsmutent -> transmutent: ms/ns cluster misread
- p. 32r l. 132: vivel -> vel: extra vi inserted by OCR; equoce -> equiuoce: missing -iu- in aequivoce
- p. 32r l. 133: naura -> natura: transposed letters, missing t
- p. 32v l. 3: 'actio' + 'nem' split across line break without break="no" on lb n=3
- p. 32v l. 23: serpenttes -> serpentes: doubled t OCR error
- p. 32v l. 64: Apstoulus -> Apostolus: garbled OCR, transposed letters
- p. 32v l. 82: soc -> hoc: s/h misread at word start; context: vti ministerio diaboli: hoc dupliciter
- p. 32v l. 94: aute -> aut: extra e appended by OCR; context: aut eam dicit compulsus a deo: aut hac intentione
- p. 32v l. 104: focietate -> societate: f/s misread at word start (long-s)

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_