### PR TITLE
Transcription corrections: cod-ve09v2_kzz7yh-f26568.xml (1 change)

### DIFF
--- a/kzz7yh-f26568/cod-ve09v2_kzz7yh-f26568.xml
+++ b/kzz7yh-f26568/cod-ve09v2_kzz7yh-f26568.xml
@@ -320,7 +320,7 @@
         </p>
         <p xml:id="kzz7yh-f26568-d1e650">
           ¶ Secundo de ministerio ordinatorum 10 dist. ibi. 
-          <lb ed="#V" n="73"/>lhoc etiam inuestigandum
+          <lb ed="#V" n="73"/>hoc etiam inuestigandum
         </p>
         <p xml:id="kzz7yh-f26568-d1e655">
           ¶ Prima in duas.

--- a/kzz7yh-f26568/cod-ve09v2_kzz7yh-f26568.xml
+++ b/kzz7yh-f26568/cod-ve09v2_kzz7yh-f26568.xml
@@ -342,8 +342,7 @@
           nar<lb ed="#V" n="77" break="no"/>rando.
         </p>
         <p xml:id="kzz7yh-f26568-d1e677">
-          ¶ Secundo quaestiones incidentes mouendo. ibi liam nuc 
-          in<lb ed="#V" n="78" break="no"/>quirere
+          ¶ Secundo quaestiones incidentes mouendo. ibi iam nunc in<lb ed="#V" n="78" break="no"/>quirere
         </p>
         <p xml:id="kzz7yh-f26568-d1e682">
           ¶ Prima in duas.
@@ -369,7 +368,7 @@
         </p>
         <p xml:id="kzz7yh-f26568-d1e707">
           ¶ Tunc 
-          <lb ed="#V" n="83"/>sequitur illa pars que ibi incipit. liam nunc innquerete.
+          <lb ed="#V" n="83"/>sequitur illa pars que ibi incipit. iam nunc inquirere.
         </p>
         <p xml:id="kzz7yh-f26568-d1e712">
           ¶ Et 


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve09v2_kzz7yh-f26568.xml`.

## Applied changes

- p. 38r l. 73: lhoc → hoc: l/I misread at word start (section incipit)

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_