### PR TITLE
Transcription corrections: cod-ve09v2_kzz7yh-f29733.xml (5 changes)

### DIFF
--- a/kzz7yh-f29733/cod-ve09v2_kzz7yh-f29733.xml
+++ b/kzz7yh-f29733/cod-ve09v2_kzz7yh-f29733.xml
@@ -114,7 +114,7 @@
           </p>
           <p xml:id="kzz7yh-f29733-d1e192">
             ¶ Ad tertium dicendum: quam 
-            mit<lb ed="#V" n="94" break="no"/>ti et affistere non repugnant: secundum quod assistere accipitur pro 
+            mit<lb ed="#V" n="94" break="no"/>ti et assistere non repugnant: secundum quod assistere accipitur pro 
             imme<lb ed="#V" n="95" break="no"/>diata visione diuine essentie.
           </p>
         </div>
@@ -134,7 +134,7 @@
             <lb ed="#V" n="101"/>vsum exterioris officii nunquam habent.
           </p>
           <p xml:id="kzz7yh-f29733-d1e222">
-            ¶ Item in ecclsiastica 
+            ¶ Item in ecclesiastica 
             <lb ed="#V" n="102"/>hierarchia aliqui ita vacant contemplationi quod non actioni: ergo 
             <lb ed="#V" n="103"/>a simili ita est in angelica hierarchia. 
             <!--TODO: Something happened here, Paragraph break error?-->
@@ -149,7 +149,7 @@
           </p>
           <p xml:id="kzz7yh-f29733-d1e243">
             ¶ Item cum filius dei sit in infinitum 
-            di<lb ed="#V" n="109" break="no"/>gnior quocumque angelo: et ipse propter salutem nostram missusfuerit 
+            di<lb ed="#V" n="109" break="no"/>gnior quocumque angelo: et ipse propter salutem nostram missus fuerit 
             <lb ed="#V" n="110"/>vt habetur ad Galis 4. multo fortius videtur quod omnes angeli quantuncumque 
             <lb ed="#V" n="111"/>digni propter nostram salutem mittantur. 
             <lb ed="#V" n="112"/>Respondeo quod omnes angelos mitti dupliciter potest
@@ -177,7 +177,7 @@
             <pb ed="#V" n="42-r"/>
             <cb ed="#P" n="a"/>
             <lb ed="#V" n="1"/>batur ad hanc partem dicendum: quod angelus missus ad 
-            <lb ed="#V" n="2"/>Isaiam non fuit de crdine saraphin. Sed sic nominatur: 
+            <lb ed="#V" n="2"/>Isaiam non fuit de ordine saraphin. Sed sic nominatur: 
             <lb ed="#V" n="3"/>ab effectu propter quem missus est: quia suit missus ad 
             exci<lb ed="#V" n="4" break="no"/>tandum et disponendum voluntatem propsee ad diuine 
             di<lb ed="#V" n="5" break="no"/>lectionis incendium. Et hec solutio accipitur ex sententia 
@@ -195,7 +195,7 @@
           <head xml:id="kzz7yh-f29733-Hd1e323">Quaestio 3</head>
           <head xml:id="kzz7yh-f29733-Hd1e339" type="question-title">Utrum inferiores angeli mittantur a deo mediantibus superioribus</head>
           <p xml:id="kzz7yh-f29733-d1e325">
-            Quaesio III. 
+            Quaestio III. 
             <lb ed="#V" n="11"/>TErtio queritur vtrum inferiores 
             <lb ed="#V" n="12"/>angeli mittantur 
             <lb ed="#V" n="13"/>a deo mediantibus superioribus. Sed quia superius 

--- a/kzz7yh-f29733/cod-ve09v2_kzz7yh-f29733.xml
+++ b/kzz7yh-f29733/cod-ve09v2_kzz7yh-f29733.xml
@@ -179,7 +179,7 @@
             <lb ed="#V" n="1"/>batur ad hanc partem dicendum: quod angelus missus ad 
             <lb ed="#V" n="2"/>Isaiam non fuit de ordine saraphin. Sed sic nominatur: 
             <lb ed="#V" n="3"/>ab effectu propter quem missus est: quia suit missus ad 
-            exci<lb ed="#V" n="4" break="no"/>tandum et disponendum voluntatem propsee ad diuine 
+            exci<lb ed="#V" n="4" break="no"/>tandum et disponendum voluntatem prophetae ad diuine 
             di<lb ed="#V" n="5" break="no"/>lectionis incendium. Et hec solutio accipitur ex sententia 
             <lb ed="#V" n="6"/>Diony. 13 capi. angelice hierar. Et etiam missus fuit 
             me<lb ed="#V" n="7" break="no"/>diate ab aliquo de ordine seraphin: vnde et a mittente: et ab 


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve09v2_kzz7yh-f29733.xml`.

## Applied changes

- p. 41v l. 94: affistere: not in Latin word list — review needed
- p. 41v l. 101: ecclsiastica → ecclesiastica: missing letter
- p. 41v l. 109: missusfuerit: not in Latin word list — review needed
- p. 42r l. 2: crdine: 3+ consecutive consonants — likely garbled OCR
- p. 42r l. 10: Quaesio: not in Latin word list — review needed

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_