### PR TITLE
Transcription corrections: cod-ve09v2_kzz7yh-f31379.xml (9 changes)

### DIFF
--- a/kzz7yh-f31379/cod-ve09v2_kzz7yh-f31379.xml
+++ b/kzz7yh-f31379/cod-ve09v2_kzz7yh-f31379.xml
@@ -124,7 +124,7 @@
           </p>
           <p xml:id="kzz7yh-f31379-d1e207">
             ¶ Item 
-            <lb ed="#V" n="52"/><ref xml:id="kzz7yh-f31379-Rd1e215">Glo.</ref> <ref xml:id="kzz7yh-f31379-Rd1e217">Mat. 18</ref> super illud. <quote xml:id="kzz7yh-f31379-Qd1e219" source="http://scta.info/resource/mt18_10@12-13">angeli eorum</quote>. magna deignitas 
+            <lb ed="#V" n="52"/><ref xml:id="kzz7yh-f31379-Rd1e215">Glo.</ref> <ref xml:id="kzz7yh-f31379-Rd1e217">Mat. 18</ref> super illud. <quote xml:id="kzz7yh-f31379-Qd1e219" source="http://scta.info/resource/mt18_10@12-13">angeli eorum</quote>. magna dignitas 
             <lb ed="#V" n="53"/>animarum vt vnaqueque habeat ab ortu natiuitatis in 
             cu<lb ed="#V" n="54" break="no"/>stodiam sui angelum delegatum. 
           </p>
@@ -170,7 +170,7 @@
           </p>
           <p xml:id="kzz7yh-f31379-d1e295">
             ¶ Ad 3m dicendum quod quamuis diabolus totum 
-            posside<lb ed="#V" n="87" break="no"/>bit antixprsum vt dicit Glosionus super illud. 2. ad Thesu. 2. cuius 
+            posside<lb ed="#V" n="87" break="no"/>bit antichristum vt dicit Glosionus super illud. 2. ad Thesu. 2. cuius 
             <lb ed="#V" n="88"/>est aduentus secundum operationem sathane: tamen habebit 
             ange<lb ed="#V" n="89" break="no"/>lum custodem: quia quamuis non proficiet in promotione 
             salu<lb ed="#V" n="90" break="no"/>tis illius: tamen multos effectus malos prohibebit quos 
@@ -196,7 +196,7 @@
             <lb ed="#V" n="101"/>eos mediate per angelicum ministerium non propter 
             cu<lb ed="#V" n="102" break="no"/>stodie sue insufficientiam: sed propter dilectionis quam 
             ha<lb ed="#V" n="103" break="no"/>bet ad nos manifestationem: et sue bonitatis 
-            communicatio<lb ed="#V" n="104" break="no"/>nem: et propter maiorem pertium vniuersi connexionem: quia et sicut per 
+            communicatio<lb ed="#V" n="104" break="no"/>nem: et propter maiorem partium vniuersi connexionem: quia et sicut per 
             <lb ed="#V" n="105"/>illam custodiam homines adiuuantur: ita angeli in 
             custo<lb ed="#V" n="106" break="no"/>diendo aliquod premium accidentale merentur. 
           </p>
@@ -214,7 +214,7 @@
             an<lb ed="#V" n="112" break="no"/>gelorum. ergo videtur quod deseruerunt custodire babylonem. 
           </p>
           <p xml:id="kzz7yh-f31379-d1e369">
-            <lb ed="#V" n="113"/>¶ Item super illud Isa. 5. auferam sepem eius. dicit Glosu id est 
+            <lb ed="#V" n="113"/>¶ Item super illud Isa. 5. auferam sepem eius. dicit Glossa id est 
             an<lb ed="#V" n="114" break="no"/>gelorum custodiam. ergo videtur quod genti iudeorum significate per 
             <lb ed="#V" n="115"/>vineam quam deus custodia angelorum quasi sepiuerat: 
             subtra<lb ed="#V" n="116" break="no"/>xit angelorum custodiam.
@@ -244,7 +244,7 @@
             <lb ed="#V" n="130"/>Ad istam quaestionem voluerunt aliqui dicere quod aliquando
             an<lb ed="#V" n="131" break="no"/>gelus deserit quem custodiebat: quando scilicet 
             vi<lb ed="#V" n="132" break="no"/>det ipsum ita obstinatum quod circa ipsum non potest proficere. Sicut 
-            <lb ed="#V" n="133"/>medicus deserit infirmum de cuius saitate desperat.
+            <lb ed="#V" n="133"/>medicus deserit infirmum de cuius sanitate desperat.
           </p>
           <p xml:id="kzz7yh-f31379-d1e428">
             ¶ Pro quae etiam 
@@ -282,7 +282,7 @@
           <p xml:id="kzz7yh-f31379-d1e487">
             ¶ Ea 
             <lb ed="#V" n="16"/>etiam que adducta suerunt pro alia opinione in corpore 
-            que<lb ed="#V" n="17" break="no"/>stionis uon cogunt. quia angelus circa hominem quantuncunque 
+            que<lb ed="#V" n="17" break="no"/>stionis non cogunt. quia angelus circa hominem quantuncunque 
             ma<lb ed="#V" n="18" break="no"/>lum dum est in via potest exercere effectum retractonis 
             <lb ed="#V" n="19"/>ab aliquo malo quod non potest medicus circa quencumque 
             infir<lb ed="#V" n="20" break="no"/>mum. Angelus. etiam malus nisi sit ita perfecte victus quod non 
@@ -316,7 +316,7 @@
             sin<lb ed="#V" n="35" break="no"/>gulis quibusque gentibus sunt prelata: cum subiectorum 
             <lb ed="#V" n="36"/>mores aduersum se vicissim prepositorum spirituum opecem 
             meren<lb ed="#V" n="37" break="no"/>tur: ipsi qui presunt spiritus contra se venire refetuntur 
-            <lb ed="#V" n="38"/>Ergo videtur quod propter conrietatem populorum quos custodiunt 
+            <lb ed="#V" n="38"/>Ergo videtur quod propter contrarietatem populorum quos custodiunt 
             <lb ed="#V" n="39"/>inter se angeli custodientes contrariantur. 
           </p>
           <p xml:id="kzz7yh-f31379-d1e555">
@@ -339,7 +339,7 @@
             <lb ed="#V" n="51"/>capi. de. di. no. comparat egressionem creaturarum a deo: 
             egres<lb ed="#V" n="52" break="no"/>sui linearum a centro. eo quod linee quanto magis elongantur 
             <lb ed="#V" n="53"/>a centro: tanto magis elongantur inter se et ille partes que 
-            <lb ed="#V" n="54"/>centro sunt propinquiores: sunt propinquores inter se. et 
+            <lb ed="#V" n="54"/>centro sunt propinquiores: sunt propinquiores inter se. et 
             <lb ed="#V" n="55"/>vbi iunguntur centro iunguntur inter se. Cum ergo 
             bo<lb ed="#V" n="56" break="no"/>ni angeli perfecte sint coniuncti deo: per cognitionem et amorem 
             <lb ed="#V" n="57"/>quantum fieri potest vniuntur inter se per amorem. Quod verum 
@@ -374,7 +374,7 @@
             mereban<lb ed="#V" n="76" break="no"/>tur iudei captiuorum in perside liberationem. Et hoc pro 
             il<lb ed="#V" n="77" break="no"/>lis captiuis angelus eis prepositus allegabat qui loqui 
             <lb ed="#V" n="78"/>venerat Dan veli Angelus autem qui persis praeerat allegabat quod 
-            <lb ed="#V" n="79"/>adhuc in illis captiuis aliquid purgandu restabat. et quia illi 
+            <lb ed="#V" n="79"/>adhuc in illis captiuis aliquid purgandum restabat. et quia illi 
             <lb ed="#V" n="80"/>captiui erant fideles remanentia eorum inter persas ipsis persis vt 
             <lb ed="#V" n="81"/>illis erat. et super hec diuinam sententiam corditer expectabant. 
             <lb ed="#V" n="82"/>Unde Grego. 17. Mora. longe ante medium. exponens 

--- a/kzz7yh-f31379/cod-ve09v2_kzz7yh-f31379.xml
+++ b/kzz7yh-f31379/cod-ve09v2_kzz7yh-f31379.xml
@@ -378,9 +378,9 @@
             <lb ed="#V" n="80"/>captiui erant fideles remanentia eorum inter persas ipsis persis vt 
             <lb ed="#V" n="81"/>illis erat. et super hec diuinam sententiam corditer expectabant. 
             <lb ed="#V" n="82"/>Unde Grego. 17. Mora. longe ante medium. exponens 
-            <lb ed="#V" n="83"/>illud princeps regni persarum restitit mihi. sic ait. acesi a 
-            <lb ed="#V" n="84"/>parte dicat: precum quidem tuarum merita exigunt vt hisra 
-            <lb ed="#V" n="85"/>eliticus populus a iugo sue captluitatis exuatur. sed est 
+            <lb ed="#V" n="83"/>illud princeps regni persarum restitit mihi. sic ait. ac si a 
+            <lb ed="#V" n="84"/>parte dicat: precum quidem tuarum merita exigunt vt hisra
+            <lb ed="#V" n="85" break="no"/>eliticus populus a iugo sue captluitatis exuatur. sed est 
             <lb ed="#V" n="86"/>adhoc quod in eodem populo purgari debeat. Unde 
             excep<lb ed="#V" n="87" break="no"/>tioni illius persarum princeps mihi iure contradicit. 
             quam<lb ed="#V" n="88" break="no"/>uis preces tuas eorum quoque lachryme qui in udea 

--- a/kzz7yh-f31379/cod-ve09v2_kzz7yh-f31379.xml
+++ b/kzz7yh-f31379/cod-ve09v2_kzz7yh-f31379.xml
@@ -104,10 +104,10 @@
             ¶ Item qui permittit 
             er<lb ed="#V" n="40" break="no"/>rare rem commissam sue custodie dignus est reprehendi. Sed 
             <lb ed="#V" n="41"/>boni angeli non possunt fieri reprehensione digni. ergo cum 
-            <lb ed="#V" n="42"/>multi homines errent. videntur ab abgelis non custodiri¬ 
+            <lb ed="#V" n="42"/>multi homines errent. videntur ab <sic>abgelis</sic> non custodiri¬ 
           </p>
           <p xml:id="kzz7yh-f31379-d1e180">
-            <lb ed="#V" n="43"/>¶ Item Iob. 7. quid faciam tibi ocustos hominum. Deus. 
+            <lb ed="#V" n="43"/>¶ Item Iob. 7. quid faciam tibi <sic>ocustos</sic> hominum. Deus. 
             <lb ed="#V" n="44"/>ergo custodit homines per se ipsum. Ergo superfluum esset 
             <lb ed="#V" n="45"/>hominem custodiri per angelum. 
           </p>
@@ -120,7 +120,7 @@
           <p xml:id="kzz7yh-f31379-d1e200">
             ¶ Item Glo. super illud ecclesi. 17. in vnam 
             <lb ed="#V" n="50"/>quamque gentem preposuit rectores. ibi. angelos. quibus 
-            <lb ed="#V" n="51"/>commisit deus custodiam simgularium gentium.
+            <lb ed="#V" n="51"/>commisit deus custodiam <sic>simgularium</sic> gentium.
           </p>
           <p xml:id="kzz7yh-f31379-d1e207">
             ¶ Item 
@@ -130,7 +130,7 @@
           </p>
           <p xml:id="kzz7yh-f31379-d1e216">
             <lb ed="#V" n="55"/>Respondeo quod vnicuique puto homini viatori 
-            <lb ed="#V" n="56"/>fuit adhita custodia angeli. et ante 
+            <lb ed="#V" n="56"/>fuit <sic>adhita</sic> custodia angeli. et ante 
             <lb ed="#V" n="57"/>lapsum et post lapsum et adhibebitur vsque ad completionem 
             nu<lb ed="#V" n="58" break="no"/>meri electorum. Sicut enim dicit Diony. in libro de angelica hie 
             <lb ed="#V" n="59"/>rar. capi. 4. lex diuine prouidentie est inferiora reducere in 
@@ -165,7 +165,7 @@
             <lb ed="#V" n="82"/>non haberet pugnam interiorem: tamen habuit 
             impugna<lb ed="#V" n="83" break="no"/>tionem exterius: non tamen violentiam in ferendo: sed malum 
             <lb ed="#V" n="84"/>suadendo. Et preterea non tantum ahibetur angelica 
-            custo<lb ed="#V" n="85" break="no"/>dia ad prohibendum malum: sed esiam ad promouendum 
+            custo<lb ed="#V" n="85" break="no"/>dia ad prohibendum malum: sed etiam ad promouendum 
             bo<lb ed="#V" n="86" break="no"/>num.
           </p>
           <p xml:id="kzz7yh-f31379-d1e295">
@@ -237,7 +237,7 @@
             ¶ Item ita est bonus angelus sollicitus in ad 
             <lb ed="#V" n="126"/>iuuando sicut malus in impugnando. Sed malus nunquam 
             de<lb ed="#V" n="127" break="no"/>sinit insidiari. Unde Ber. immedita. suis. ca. 21. mors vbique 
-            <lb ed="#V" n="128"/>tibi minatur: diabolus infidiatur. Ergo videtur quod bons 
+            <lb ed="#V" n="128"/>tibi minatur: diabolus infidiatur. Ergo videtur quod bonus 
             <lb ed="#V" n="129"/>angelus nunquam desinit auxiliari. 
           </p>
           <p xml:id="kzz7yh-f31379-d1e417">
@@ -248,7 +248,7 @@
           </p>
           <p xml:id="kzz7yh-f31379-d1e428">
             ¶ Pro quae etiam 
-            <lb ed="#V" n="134"/>opinione videtur facere quod superius dictum est distin. 6 secuend 
+            <lb ed="#V" n="134"/>opinione videtur facere quod superius dictum est distin. 6 scilicet 
             <lb ed="#V" n="135"/>quod malus angelus cum ita perfecte vincitur ab aliquo 
             <lb ed="#V" n="136"/>quod non estimat se amplius illum vincere posse recedit ab eo. 
             <!--00102.xml-->
@@ -283,7 +283,7 @@
             ¶ Ea 
             <lb ed="#V" n="16"/>etiam que adducta suerunt pro alia opinione in corpore 
             que<lb ed="#V" n="17" break="no"/>stionis non cogunt. quia angelus circa hominem quantuncunque 
-            ma<lb ed="#V" n="18" break="no"/>lum dum est in via potest exercere effectum retractonis 
+            ma<lb ed="#V" n="18" break="no"/>lum dum est in via potest exercere effectum <sic>retractonis</sic> 
             <lb ed="#V" n="19"/>ab aliquo malo quod non potest medicus circa quencumque 
             infir<lb ed="#V" n="20" break="no"/>mum. Angelus. etiam malus nisi sit ita perfecte victus quod non 
             <lb ed="#V" n="21"/>estimat se posse illum a quo victus est retrahere ab aliquo 
@@ -315,7 +315,7 @@
             <lb ed="#V" n="34"/>medium. quia certa angelorum ministeria dispensandis 
             sin<lb ed="#V" n="35" break="no"/>gulis quibusque gentibus sunt prelata: cum subiectorum 
             <lb ed="#V" n="36"/>mores aduersum se vicissim prepositorum spirituum opecem 
-            meren<lb ed="#V" n="37" break="no"/>tur: ipsi qui presunt spiritus contra se venire refetuntur 
+            meren<lb ed="#V" n="37" break="no"/>tur: ipsi qui presunt spiritus contra se venire <sic>refetuntur</sic> 
             <lb ed="#V" n="38"/>Ergo videtur quod propter contrarietatem populorum quos custodiunt 
             <lb ed="#V" n="39"/>inter se angeli custodientes contrariantur. 
           </p>
@@ -378,7 +378,7 @@
             <lb ed="#V" n="80"/>captiui erant fideles remanentia eorum inter persas ipsis persis vt 
             <lb ed="#V" n="81"/>illis erat. et super hec diuinam sententiam corditer expectabant. 
             <lb ed="#V" n="82"/>Unde Grego. 17. Mora. longe ante medium. exponens 
-            <lb ed="#V" n="83"/>illud princeps regni persarum restitit mihi. sic ait. acsi a 
+            <lb ed="#V" n="83"/>illud princeps regni persarum restitit mihi. sic ait. acesi a 
             <lb ed="#V" n="84"/>parte dicat: precum quidem tuarum merita exigunt vt hisra 
             <lb ed="#V" n="85"/>eliticus populus a iugo sue captluitatis exuatur. sed est 
             <lb ed="#V" n="86"/>adhoc quod in eodem populo purgari debeat. Unde 
@@ -394,7 +394,7 @@
             Un<lb ed="#V" n="93" break="no"/>de Grego. 17. libro Mora. parum post auctoritatem prius 
             <lb ed="#V" n="94"/>in arguendo allegatam. Recte dicitur quod contra se 
             angeli<lb ed="#V" n="95" break="no"/>veniunt. qui subiectarum sibi gentium vicissim merita 
-            con<lb ed="#V" n="96" break="no"/>tra dicunt. natuam sublimes spiritus eisdem gentibus 
+            con<lb ed="#V" n="96" break="no"/>tra dicunt. nam sublimes spiritus eisdem gentibus 
             prin<lb ed="#V" n="97" break="no"/>cipantes nequaquam pro iniuste agentibus decertant. sed eorum 
             <lb ed="#V" n="98"/>facta iuste iudicantes examinant. cum vnius cuiusque 
             gen<lb ed="#V" n="99" break="no"/>tis vel culpa vel iusticia ad superne curie consilium ducitur: 


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve09v2_kzz7yh-f31379.xml`.

## Applied changes

- p. 44r l. 52: deignitas: not in Latin word list — review needed
- p. 44r l. 87: antixprsum: 3+ consecutive consonants — likely garbled OCR; Glosionus: not in Latin word list — review needed
- p. 44r l. 104: pertium -> partium: e/a swap (genitive plural of pars)
- p. 44r l. 113: Glosu: not in Latin word list — review needed
- p. 44r l. 133: saitate: not in Latin word list — review needed
- p. 44v l. 17: uon: not in Latin word list — review needed
- p. 44v l. 38: conrietatem: not in Latin word list — review needed
- p. 44v l. 54: propinquores → propinquiores: not in word list (OCR transform matched)
- p. 44v l. 79: purgandu: not in Latin word list — review needed

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_