### PR TITLE
Transcription corrections: cod-ve09v2_kzz7yh-f38947.xml (18 changes)

### DIFF
--- a/kzz7yh-f38947/cod-ve09v2_kzz7yh-f38947.xml
+++ b/kzz7yh-f38947/cod-ve09v2_kzz7yh-f38947.xml
@@ -188,7 +188,7 @@
             perspi<lb ed="#V" n="118" break="no"/>cue frigide et humide formaliter et effectiue: etiam illud 
             ce<lb ed="#V" n="119" break="no"/>lum est perspicuum formaliter: frigidum autem et humidum 
             <lb ed="#V" n="120"/>effectiue: quamuis non formaliter. Unde virtus eius in istis 
-            <lb ed="#V" n="121"/>inferioribus contemperat caliditatem et ficcitatem quam ad hoc 
+            <lb ed="#V" n="121"/>inferioribus contemperat caliditatem et siccitatem quam ad hoc 
             in<lb ed="#V" n="122" break="no"/>feriora influunt aliqua superiora corpora: et sphera ignis. 
             <!--TODO: paragraph split-->
             <lb ed="#V" n="123"/>Qui vult tenere hanc vltimam opinionem: 
@@ -206,11 +206,11 @@
           </p>
           <p xml:id="kzz7yh-f38947-d1e356">
             ¶ Ad tertium dicendum. quod non persona est 
-            <lb ed="#V" n="132"/>simile deordinatione partium in maiori mundo et minoti 
+            <lb ed="#V" n="132"/>simile deordinatione partium in maiori mundo et minori 
             <!--00123.xml-->
             <pb ed="#V" n="55-r"/>
             <cb ed="#P" n="a"/>
-            <lb ed="#V" n="1"/>quia sn malori ordinantur secundum maiorem et minorem 
+            <lb ed="#V" n="1"/>quia sn maiori ordinantur secundum maiorem et minorem 
             nobi<lb ed="#V" n="2" break="no"/>litatem: quia ex hac ordinatione sit quedam influentiarum 
             <lb ed="#V" n="3"/>contemperantia homini vtilior et conuenientior. Si autem 
             <lb ed="#V" n="4"/>in minori mundo membrum nobilissimum quod est 
@@ -250,7 +250,7 @@
           <head xml:id="kzz7yh-f38947-Hd1e436">Quaestio 2</head>
           <head xml:id="kzz7yh-f38947-Hd1e450" type="question-title">Utrum caelum crystallinum moveatur</head>
           <p xml:id="kzz7yh-f38947-d1e438">
-            Quaesio II. 
+            Quaestio II. 
             <lb ed="#V" n="29"/>SEcundo quaeritur vtrum caelum crystallinum 
             <lb ed="#V" n="30"/>moueatur. Et videtur quod non. quia caelum 
             <lb ed="#V" n="31"/>empyreum non est stellatum: ideo non mouetur: sed caelum 
@@ -266,7 +266,7 @@
           </p>
           <p xml:id="kzz7yh-f38947-d1e462">
             ¶ Item omnis motus est 
-            <lb ed="#V" n="38"/>xropter acquisitionem perfectionis vel exclusionem 
+            <lb ed="#V" n="38"/>propter acquisitionem perfectionis vel exclusionem 
             imperfe<lb ed="#V" n="39" break="no"/>ctionis in ipso mobili vel in aliquo alio. Sed caelum 
             cri<lb ed="#V" n="40" break="no"/>stallinum per motum non acquireret in se aliquam perfectionem 
             <lb ed="#V" n="41"/>nec a se excluderet aliquam imperfectionem. Sua enim 
@@ -286,7 +286,7 @@
           <p xml:id="kzz7yh-f38947-d1e498">
             ¶ Item est medius inter firmamentum et caelum 
             <lb ed="#V" n="52"/>empyreum: ergo debet participare aliquam vtriusque proprietatem. 
-            <lb ed="#V" n="53"/>Sed caelum empyreu non est stellatum nec mouetur: 
+            <lb ed="#V" n="53"/>Sed caelum empyreum non est stellatum nec mouetur: 
             firmamen<lb ed="#V" n="54" break="no"/>tum est stellatum et mouetur. ergo cum caelum crystallinum non sit 
             <lb ed="#V" n="55"/>stellatum conueniens est quod moueatur. 
           </p>
@@ -322,8 +322,8 @@
             mo<lb ed="#V" n="77" break="no"/>uetur. Sed huius ratio posita est supra dist. 2. q. primo tertii. arti. 
           </p>
           <p xml:id="kzz7yh-f38947-d1e569">
-            <lb ed="#V" n="78"/>¶ Ad 2m cum dicitur: quod primus motus debet esse mesura aliorum 
-            mo<lb ed="#V" n="79" break="no"/>tuum etc. Dico quod hoc debet intelligi de primo motu materifeste 
+            <lb ed="#V" n="78"/>¶ Ad 2m cum dicitur: quod primus motus debet esse mensura aliorum 
+            mo<lb ed="#V" n="79" break="no"/>tuum etc. Dico quod hoc debet intelligi de primo motu manifeste 
             no<lb ed="#V" n="80" break="no"/>bis noto existente in tali mobili: sicut in subiecto in quo sunt 
             <lb ed="#V" n="81"/>signa ad que anima respiciens potest in apprehensiones certas 
             di<lb ed="#V" n="82" break="no"/>stinctiones facere in illo motu: et per ipsum mensurare 
@@ -498,8 +498,8 @@
             ¶ Item quelibet pars sphere equaliter distat a 
             cem<lb ed="#V" n="51" break="no"/>tro. Sed quelibet pars firmamenti non equaliter distat a 
             <lb ed="#V" n="52"/>terra que dicitur eius quasi centrum: quia in estate sol est 
-            <lb ed="#V" n="53"/>a terra remotior quam in hyeme. ergo videtur quod firmamen 
-            <lb ed="#V" n="54"/>tum non habeat figuram sphericam.
+            <lb ed="#V" n="53"/>a terra remotior quam in hyeme. ergo videtur quod 
+            firmamen<lb ed="#V" n="54" break="no"/>tum non habeat figuram sphericam.
           </p>
           <p xml:id="kzz7yh-f38947-d1e886">
             ¶ Item figura 
@@ -541,7 +541,7 @@
           <p xml:id="kzz7yh-f38947-d1e948">
             ¶ Preterea cum caelum sit corpus perfectum et inter 
             fi<lb ed="#V" n="74" break="no"/>guras perfectior fuit spherica: conuenientius fuit celum 
-            sphe<lb ed="#V" n="75" break="no"/>ricam habere siguram quam aliam.
+            sphe<lb ed="#V" n="75" break="no"/>ricam habere figuram quam aliam.
           </p>
           <p xml:id="kzz7yh-f38947-d1e955">
             ¶ Preterea cum simplex sit 
@@ -556,13 +556,13 @@
             relin<lb ed="#V" n="81" break="no"/>queretur vacuum inter ipsum et celum crystallinum: et quod 
             ali<lb ed="#V" n="82" break="no"/>qua pars eius: aliquando simul esset cum aliqua parte 
             celi<lb ed="#V" n="83" break="no"/>crystallini: que secundum naturam impossibilia sunt. Et predicte 
-            <lb ed="#V" n="84"/>rationes extrahi possunt ex sententia phlosophi. 2. celi et mundi. 
+            <lb ed="#V" n="84"/>rationes extrahi possunt ex sententia philosophi. 2. celi et mundi. 
             <lb ed="#V" n="85"/>Et Auicen. lib. suo de celo et mundo. ca. 8. vbi probat quod 
             <lb ed="#V" n="86"/>figura celi est spherica. 
           </p>
           <p xml:id="kzz7yh-f38947-d1e985">
             <lb ed="#V" n="87"/>Ad primum in oppositum dicendum: quod scriptura ibi
-            <lb ed="#V" n="88"/>loquitur de figura caeli quanctum ad 
+            <lb ed="#V" n="88"/>loquitur de figura caeli quantum ad 
             sen<lb ed="#V" n="89" break="no"/>suum nostrorum apparentiam vel quantum ad nostrum 
             hemispe<lb ed="#V" n="90" break="no"/>rium tantum.
           </p>
@@ -601,7 +601,7 @@
           <head xml:id="kzz7yh-f38947-Hd1e1052">Quaestio 5</head>
           <head xml:id="kzz7yh-f38947-Hd1e1078" type="question-title">Utrum firmamentum habeat dextram et sinistram</head>
           <p xml:id="kzz7yh-f38947-d1e1054">
-            Quaesio V 
+            Quaestio V 
             <lb ed="#V" n="112"/>QUinto queritur vtrum firmamentum habeat 
             <lb ed="#V" n="113"/>dextram et sinistram. Et videtur quod sic 
             <lb ed="#V" n="114"/>philosophus. 2. celi et mundi. Si est principium motus caeli: 
@@ -818,7 +818,7 @@
             il<lb ed="#V" n="120" break="no"/>lud celum quiescit.
           </p>
           <p xml:id="kzz7yh-f38947-d1e1449">
-            ¶ Et praeterea non apporet ratio: quare perfectius sit 
+            ¶ Et praeterea non apparet ratio: quare perfectius sit 
             <lb ed="#V" n="121"/>celum per suum motum ab oriente in occidentem quam econuerso. Auic. 
             <lb ed="#V" n="122"/>etiam libro 9. meta. ca. 2. Dicit quod principium motuum celi non est natura: nec 
             <lb ed="#V" n="123"/>est per violentiam. Sed est per volutatem et si intellexisset non de 
@@ -855,7 +855,7 @@
             <lb ed="#V" n="7"/>est intellectus dirigens et voluntas motum imperans: sed est alia 
             <lb ed="#V" n="8"/>potenta motum exequens secundum imperium voluntatis 
             intelligen<lb ed="#V" n="9" break="no"/>tie prout potest: vnde hoc articulus scilicet quod angelus solta volutate 
-            <lb ed="#V" n="10"/>mouet caelum a domino Stephano episco Parisien. et 
+            <lb ed="#V" n="10"/>mouet caelum a domino Stephano episcopo Parisien. et 
             sacre<lb ed="#V" n="11" break="no"/>theologie doctore excommunicatus est.
           </p>
           <p xml:id="kzz7yh-f38947-d1e1526">
@@ -870,7 +870,7 @@
             <lb ed="#V" n="19"/>modo predicto est quasi instrumentalis motor. Forma autem 
             <lb ed="#V" n="20"/>naturalis tam accidentalis quam formalis ipsius celi est illud quod est 
             <lb ed="#V" n="21"/>in celo naturalis aptitudo: vt sic moueatur: et quamdiu hoc virtus 
-            con<lb ed="#V" n="22" break="no"/>tinuabitur in celo: per ipsius intelligentie potentiam tandiu 
+            con<lb ed="#V" n="22" break="no"/>tinuabitur in celo: per ipsius intelligentie potentiam tamdiu 
             <lb ed="#V" n="23"/>caelum mouebitur: et cum desinet predictam influentiam causare et 
             com<lb ed="#V" n="24" break="no"/>seruare in celo: caelum quiescet. 
           </p>
@@ -927,7 +927,7 @@
           </p>
           <p xml:id="kzz7yh-f38947-d1e1645">
             ¶ Uel potest 
-            di<lb ed="#V" n="57" break="no"/>ci quod si philosophus per primum motorem ibi intellexit allquam 
+            di<lb ed="#V" n="57" break="no"/>ci quod si philosophus per primum motorem ibi intellexit aliquam 
             intelligen<lb ed="#V" n="58" break="no"/>tiam creatam: quod pro tanto dixit ipsum esse infinite potentie: quia 
             <lb ed="#V" n="59"/>mouet in virtute causae prime que habet infinitam potentiam in 
             vi<lb ed="#V" n="60" break="no"/>gore: vnde Auic. 9. meta. ca. 2. motor celestis corporis mouet 
@@ -951,7 +951,7 @@
             phi<lb ed="#V" n="73" break="no"/>sicorum. de motu tractus scilicet quod attractio in qua attrahens est 
             <lb ed="#V" n="74"/>quiescens et attractum est motum: non est attractio in veritate 
             <lb ed="#V" n="75"/>rei: sed attractum mouetur ex se ad attrahens vt perficiat se: 
-            <lb ed="#V" n="76"/>vt lapis mouetur ad inferius et ignis ad superius: et similite 
+            <lb ed="#V" n="76"/>vt lapis mouetur ad inferius et ignis ad superius: et similiter 
             <lb ed="#V" n="77"/>opetet hoc intelligere de motu ferri ad magnetem: et 
             nutri<lb ed="#V" n="78" break="no"/>menti ad membra: et paucis intcrpositis subiungit quod 
             nutri<lb ed="#V" n="79" break="no"/>menta non mouentur ad nutriendum nisi cum fuerit in aliqua 

--- a/kzz7yh-f38947/cod-ve09v2_kzz7yh-f38947.xml
+++ b/kzz7yh-f38947/cod-ve09v2_kzz7yh-f38947.xml
@@ -102,7 +102,7 @@
           </p>
           <p xml:id="kzz7yh-f38947-d1e169">
             ¶ Item secundum philosophum 
-            <lb ed="#V" n="61"/>8. phy. homn est minor mundus. Sed in homine membrum 
+            <lb ed="#V" n="61"/>8. phy. homo est minor mundus. Sed in homine membrum 
             <lb ed="#V" n="62"/>frigidum et humidum hoc est cerebrum est in superiori parte. ergo 
             <lb ed="#V" n="63"/>a simili in maiori mundo elementum frigidum et humidum quod 
             <lb ed="#V" n="64"/>est aqua est in superiori parte.
@@ -173,7 +173,7 @@
             <lb ed="#V" n="106"/>videtur velle quod sint ibi quasi vaporaliter suspense: ad 
             mo<lb ed="#V" n="107" break="no"/>dum quo videmus eas super istum aerem inferiorem in loco 
             <lb ed="#V" n="108"/>nubium: nec tendunt ad inferiora: sicut nec iste quamdiu 
-            va<lb ed="#V" n="109" break="no"/>poraliter suspense sunt. Hug. etiam id est lib.o de sacra. par id est c. 20. 
+            va<lb ed="#V" n="109" break="no"/>poraliter suspense sunt. Hug. etiam id est libro de sacra. par id est c. 20. 
             <lb ed="#V" n="110"/>dicit quod partim supra firmamentum partim infra earundem 
             <lb ed="#V" n="111"/>aquarum natura consistit.
           </p>
@@ -274,7 +274,7 @@
             <lb ed="#V" n="43"/>habere per naturam: nec est per suum motum acquireretur in alio: 
             <lb ed="#V" n="44"/>aliqua perfectio vel excluderetur imperfectio: quia cum sit 
             vni<lb ed="#V" n="45" break="no"/>forme non aliter influeret motum quam non motum: quia a qualibet 
-            <lb ed="#V" n="46"/>tius parte est influentia similis: ergo non mouetur. 
+            <lb ed="#V" n="46"/>eius parte est influentia similis: ergo non mouetur. 
           </p>
           <p xml:id="kzz7yh-f38947-d1e484">
             <lb ed="#V" n="47"/>Contra Auic. 9. meta. cap. 3. supra spheram stellatam 
@@ -304,7 +304,7 @@
             sphe<lb ed="#V" n="63" break="no"/>ram motu proprio simul moueri ad oppositas partes positionis. 
             <lb ed="#V" n="64"/>Sed sphera stellarum fixarum proprio motu: mouetur ab 
             occiden<lb ed="#V" n="65" break="no"/>te in oriens in centum annis per gradum vnum: et tamen videmus 
-            <lb ed="#V" n="66"/>eam moueri ab oriente in oecidens diurno motu: ergo oportet quod 
+            <lb ed="#V" n="66"/>eam moueri ab oriente in <sic>oecidens</sic> diurno motu: ergo oportet quod 
             <lb ed="#V" n="67"/>haec motus sit in ea per motum alterius sphere circundantis eam 
             <lb ed="#V" n="68"/>et eam motu suo reuoluentis. Sed illa sphera non est caelum em¬ 
             <!--00123.xml-->
@@ -358,7 +358,7 @@
           </p>
           <p xml:id="kzz7yh-f38947-d1e629">
             ¶ Item 
-            <lb ed="#V" n="98"/>Aug. 3. de libe. arbicurio inter principium et medium. In 
+            <lb ed="#V" n="98"/>Aug. 3. de libe. ar. inter principium et medium. In 
             corruptibi<lb ed="#V" n="99" break="no"/>libus lux tenet primum locum: per lucem intelligens ignem. Sed 
             <lb ed="#V" n="100"/>inter corpora nobis sensibilia firmamentum tenet primum 
             lo<lb ed="#V" n="101" break="no"/>cum: ergo est sphera ignis vt videtur.
@@ -393,7 +393,7 @@
             <lb ed="#V" n="117"/>naturam corpoream simplicem preter elementa. Cuius 
             opinio<lb ed="#V" n="118" break="no"/>nis videtur fuisse Marcianus in haec quod dicit quod mundus 
             con<lb ed="#V" n="119" break="no"/>stat ex quatuor elementis in modum sphere globatus non 
-            <lb ed="#V" n="120"/>faciendo mnetionem de aliquo corpore quinto. Huius 
+            <lb ed="#V" n="120"/>faciendo <sic>mnetionem</sic> de aliquo corpore quinto. Huius 
             opi<lb ed="#V" n="121" break="no"/>nionis videtur fuisse Plato in thymeo. Augustinus etiam dicit 
             <lb ed="#V" n="122"/>vnum verbum. x. de trini. cap. 7. in quo videtur abiicere 
             opi<lb ed="#V" n="123" break="no"/>nionem illorum qui ponunt nescio quod corpus quintum super ista 
@@ -420,9 +420,9 @@
             <pb ed="#V" n="55-v"/>
             <cb ed="#P" n="a"/>
             <lb ed="#V" n="1"/>tia docet quod saturnus infrigidat: lumna humectat: Ignis 
-            <lb ed="#V" n="2"/>autem calefacit et deficcat: ergo saturnus et luna non sunt 
+            <lb ed="#V" n="2"/>autem calefacit et desiccat: ergo saturnus et luna non sunt 
             <lb ed="#V" n="3"/>ignee nature: ergo nec firmamentum in quo luminaria 
-            pre<lb ed="#V" n="4" break="no"/>dicta sunt posita. Sol autem calefacit et deficcat: terra autem 
+            pre<lb ed="#V" n="4" break="no"/>dicta sunt posita. Sol autem calefacit et desiccat terra autem 
             <lb ed="#V" n="5"/>infrigidat et aqua et aer humectant: ergo non est nature 
             <lb ed="#V" n="6"/>terree nec aquee nec aeree. ergo nec firmamentum: 
             quan<lb ed="#V" n="7" break="no"/>tum ad spheras planetarum est alicuius elementaris 
@@ -441,14 +441,14 @@
           </p>
           <p xml:id="kzz7yh-f38947-d1e780">
             ¶ Ex parte saluationis 
-            ele<lb ed="#V" n="17" break="no"/>mentorum arguitur sic. vnum elementum non est saluatiuu 
+            ele<lb ed="#V" n="17" break="no"/>mentorum arguitur sic. vnum elementum non est saluatiuum 
             al<lb ed="#V" n="18" break="no"/>terius per se: sed magis corruptiuum: et tamen vnum 
-            elemen<lb ed="#V" n="19" break="no"/>tum remnuit separari ab alio: vt patet in clepsydria: in qua cum 
+            elemen<lb ed="#V" n="19" break="no"/>tum rennuit separari ab alio: vt patet in clepsydria: in qua cum 
             <lb ed="#V" n="20"/>obturatur foramen superius ne aer intrare possit aqua non 
             <lb ed="#V" n="21"/>descendit per foramina inferiora: ergo haec est propter 
             rece<lb ed="#V" n="22" break="no"/>ptionem influentie alicuius corporis non elementaris: quam 
             <lb ed="#V" n="23"/>non posset recipere ab aliis elementis separata: eo quod 
-            influen<lb ed="#V" n="24" break="no"/>tie corporales per vacuu non transmittuntur. 
+            influen<lb ed="#V" n="24" break="no"/>tie corporales per vacuum non transmittuntur. 
           </p>
           <p xml:id="kzz7yh-f38947-d1e800">
             <lb ed="#V" n="25"/>Ad primum in oppositum dicendum: quod ibi Dam. 
@@ -503,7 +503,7 @@
           </p>
           <p xml:id="kzz7yh-f38947-d1e886">
             ¶ Item figura 
-            quadra<lb ed="#V" n="55" break="no"/>ta magis attestatur firmitati quam spherica: ergo magen 
+            quadra<lb ed="#V" n="55" break="no"/>ta magis attestatur firmitati quam spherica: ergo magis 
             firma<lb ed="#V" n="56" break="no"/>mentum decet esse figure quadrate quam spherice.
           </p>
           <p xml:id="kzz7yh-f38947-d1e893">
@@ -821,7 +821,7 @@
             ¶ Et praeterea non apparet ratio: quare perfectius sit 
             <lb ed="#V" n="121"/>celum per suum motum ab oriente in occidentem quam econuerso. Auic. 
             <lb ed="#V" n="122"/>etiam libro 9. meta. ca. 2. Dicit quod principium motuum celi non est natura: nec 
-            <lb ed="#V" n="123"/>est per violentiam. Sed est per volutatem et si intellexisset non de 
+            <lb ed="#V" n="123"/>est per violentiam. Sed est per voluntatem et si intellexisset non de 
             volun<lb ed="#V" n="124" break="no"/>tate anime: sed de voluntate intelligentie: bene intellexisset: sed 
             extima<lb ed="#V" n="125" break="no"/>uit quod anima celi mouebat ipsum per voluntatem: in quo errauit: quia 
             <lb ed="#V" n="126"/>caelum animatum non est.
@@ -854,7 +854,7 @@
             <lb ed="#V" n="6"/>ergo et in motu quo angelus mouet celum: non tantummodo 
             <lb ed="#V" n="7"/>est intellectus dirigens et voluntas motum imperans: sed est alia 
             <lb ed="#V" n="8"/>potenta motum exequens secundum imperium voluntatis 
-            intelligen<lb ed="#V" n="9" break="no"/>tie prout potest: vnde hoc articulus scilicet quod angelus solta volutate 
+            intelligen<lb ed="#V" n="9" break="no"/>tie prout potest: vnde hoc articulus scilicet quod angelus sola volutate 
             <lb ed="#V" n="10"/>mouet caelum a domino Stephano episcopo Parisien. et 
             sacre<lb ed="#V" n="11" break="no"/>theologie doctore excommunicatus est.
           </p>
@@ -866,7 +866,7 @@
             determi<lb ed="#V" n="15" break="no"/>natur ad motum determinatum imperatum ab intelligentie 
             vo<lb ed="#V" n="16" break="no"/>luntate: et per illam virtutem ipsum celum mouet se. Sunt ergo 
             <lb ed="#V" n="17"/>ista sic ordinata in mouendo caelum: quod angelus sub deo est 
-            <lb ed="#V" n="18"/>celi principalis motor: virtus cansnata in celo ab ipso angelo 
+            <lb ed="#V" n="18"/>celi principalis motor: virtus causata in celo ab ipso angelo 
             <lb ed="#V" n="19"/>modo predicto est quasi instrumentalis motor. Forma autem 
             <lb ed="#V" n="20"/>naturalis tam accidentalis quam formalis ipsius celi est illud quod est 
             <lb ed="#V" n="21"/>in celo naturalis aptitudo: vt sic moueatur: et quamdiu hoc virtus 
@@ -905,7 +905,7 @@
             <lb ed="#V" n="41"/>cum dicitur primum mobile mouet se ipsum etc. potest dici quod philosophus ibi 
             <lb ed="#V" n="42"/>estimauit corpora celestia animata: et ideo estimauit mobile 
             <lb ed="#V" n="43"/>mouere seipsum per animam suam: et ideo cum corpora celestia 
-            anima<lb ed="#V" n="44" break="no"/>ta non sint: non opetet in verbo praedicto philosopho consentire.
+            anima<lb ed="#V" n="44" break="no"/>ta non sint: non oportet in verbo praedicto philosopho consentire.
           </p>
           <p xml:id="kzz7yh-f38947-d1e1613">
             ¶ 
@@ -952,8 +952,8 @@
             <lb ed="#V" n="74"/>quiescens et attractum est motum: non est attractio in veritate 
             <lb ed="#V" n="75"/>rei: sed attractum mouetur ex se ad attrahens vt perficiat se: 
             <lb ed="#V" n="76"/>vt lapis mouetur ad inferius et ignis ad superius: et similiter 
-            <lb ed="#V" n="77"/>opetet hoc intelligere de motu ferri ad magnetem: et 
-            nutri<lb ed="#V" n="78" break="no"/>menti ad membra: et paucis intcrpositis subiungit quod 
+            <lb ed="#V" n="77"/>oportet hoc intelligere de motu ferri ad magnetem: et 
+            nutri<lb ed="#V" n="78" break="no"/>menti ad membra: et paucis <sic>intcrpositis</sic> subiungit quod 
             nutri<lb ed="#V" n="79" break="no"/>menta non mouentur ad nutriendum nisi cum fuerit in aliqua 
             <lb ed="#V" n="80"/>dispositione de nutrito: et semper ferrum non mouetur ad magnetem 
             <lb ed="#V" n="81"/>nisi cum fuerit in aliqua qualitate de magnete. Cum ergo 

--- a/kzz7yh-f38947/cod-ve09v2_kzz7yh-f38947.xml
+++ b/kzz7yh-f38947/cod-ve09v2_kzz7yh-f38947.xml
@@ -173,7 +173,7 @@
             <lb ed="#V" n="106"/>videtur velle quod sint ibi quasi vaporaliter suspense: ad 
             mo<lb ed="#V" n="107" break="no"/>dum quo videmus eas super istum aerem inferiorem in loco 
             <lb ed="#V" n="108"/>nubium: nec tendunt ad inferiora: sicut nec iste quamdiu 
-            va<lb ed="#V" n="109" break="no"/>poraliter suspense sunt. Hug. etiam id est libro de sacra. par id est c. 20. 
+            va<lb ed="#V" n="109" break="no"/>poraliter suspense sunt. Hug. etiam i. lib. de sacra. par i. c. 20. 
             <lb ed="#V" n="110"/>dicit quod partim supra firmamentum partim infra earundem 
             <lb ed="#V" n="111"/>aquarum natura consistit.
           </p>
@@ -194,12 +194,12 @@
             <lb ed="#V" n="123"/>Qui vult tenere hanc vltimam opinionem: 
             po<lb ed="#V" n="124" break="no"/>test dicem ad argumentum 
             pri<lb ed="#V" n="125" break="no"/>mum in oppositum quod illud caelum inter empyreum et 
-            fir<lb ed="#V" n="126" break="no"/>mamentum in scriptura nominatur nomine aquarum. 
-            <lb ed="#V" n="127"/>pter conformitatem in proprietatibus predictis
+            fir<lb ed="#V" n="126" break="no"/>mamentum in scriptura nominatur nomine aquarum. pro
+            <lb ed="#V" n="127" break="no"/>pter conformitatem in proprietatibus predictis
           </p>
           <p xml:id="kzz7yh-f38947-d1e345">
-            ¶ Ad se. 
-            <lb ed="#V" n="128"/>cundum dicendum: quod Augu. non dixit hoc asserendo quod ita sit 
+            ¶ Ad se
+            <lb ed="#V" n="128" break="no"/>cundum dicendum: quod Augu. non dixit hoc asserendo quod ita sit 
             <lb ed="#V" n="129"/>sed quod ita potuit ese: nec ibi determinat quales sint ille aqua 
             <lb ed="#V" n="130"/>sed magis sub dubio relinquere videtur: quomodo ibi sint 
             <lb ed="#V" n="131"/>et quales sint.
@@ -217,8 +217,8 @@
             cor<lb ed="#V" n="5" break="no"/>poneretur in parte superiori non esset conueniens 
             ordina<lb ed="#V" n="6" break="no"/>tio per comparationem ad actiones anime: cuius sunt 
             instru<lb ed="#V" n="7" break="no"/>menta. Quia tamen in ratione pro predicta opinione 
-            sup<lb ed="#V" n="8" break="no"/>ponitur scilicet quod hoc est ordo corporum mundi: vt corpora nobilio 
-            <lb ed="#V" n="9"/>ras situm habeant altiorem dubium est: quamuis enim corpus quintum 
+            sup<lb ed="#V" n="8" break="no"/>ponitur scilicet quod hoc est ordo corporum mundi: vt corpora nobilio
+            <lb ed="#V" n="9" break="no"/>ra situm habeant altiorem dubium est: quamuis enim corpus quintum 
             <lb ed="#V" n="10"/>nobilius sit elementis et altius: et inter elementa illud quod 
             <lb ed="#V" n="11"/>est nobilius sit altius: et inter spheras corporis quinti 
             no<lb ed="#V" n="12" break="no"/>bilissima sit altissima que est caelum empyreum: tamen 
@@ -941,10 +941,8 @@
             ¶ Ad sextum dicendum quod ille 
             <lb ed="#V" n="66"/>motus nec est pulsio nec tractio proprie loquendo: quamuis 
             <lb ed="#V" n="67"/>magis assimiletur tractioni quod pulsioni: ipsum enim caelum 
-            <lb ed="#V" n="68"/>per virtutem de ipso eductam de potentia ad actum: per poten¬ 
-            <!--00126.xml-->
-            <cb ed="#P" n="b"/>
-            <lb ed="#V" n="69"/>tiam intelligentie seipsum mouet motu imperato ab 
+            <lb ed="#V" n="68"/>per virtutem de ipso eductam de potentia ad actum: per poten<!--00126.xml-->
+            <cb ed="#P" n="b"/><lb ed="#V" n="69" break="no"/>tiam intelligentie seipsum mouet motu imperato ab 
             intel<lb ed="#V" n="70" break="no"/>ligentie voluntate: et in hoc quasi trahit se ad quandam 
             concor<lb ed="#V" n="71" break="no"/>diam cum voluntate intelligentie: quod autem proprie non sit tractus 
             <lb ed="#V" n="72"/>motus ille patet per illud quod dicit Commen. super. 7. 


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve09v2_kzz7yh-f38947.xml`.

## Applied changes

- p. 54v l. 121: caliditatem: not in Latin word list — review needed; ficcitatem → siccitatem: f/s misread at word start
- p. 54v l. 132: deordinatione: not in Latin word list — review needed; minoti → minori: t/r transposition
- p. 55r l. 1: malori: not in Latin word list — review needed
- p. 55r l. 28: Quaesio: not in Latin word list — review needed
- p. 55r l. 38: xropter: not in Latin word list — review needed
- p. 55r l. 53: empyreu: not in Latin word list — review needed
- p. 55r l. 78: mesura: not in Latin word list — review needed
- p. 55r l. 79: materifeste: not in Latin word list — review needed
- p. 55v l. 54: 'firmamen' + 'tum' split across line break without break="no" on lb n=54
- p. 55v l. 75: siguram → figuram: s/f misread at word start
- p. 55v l. 84: phlosophi: 3+ consecutive consonants — likely garbled OCR
- p. 55v l. 88: quanctum: 3+ consecutive consonants — likely garbled OCR
- p. 55v l. 111: Quaesio: not in Latin word list — review needed
- p. 56r l. 120: apporet: not in Latin word list — review needed
- p. 56v l. 10: episco: not in Latin word list — review needed
- p. 56v l. 22: tandiu: not in Latin word list — review needed
- p. 56v l. 57: allquam: 3+ consecutive consonants — likely garbled OCR
- p. 56v l. 76: similite: not in Latin word list — review needed

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_