### PR TITLE
Transcription corrections: cod-ve09v2_kzz7yh-f40575.xml (18 changes)

### DIFF
--- a/kzz7yh-f40575/cod-ve09v2_kzz7yh-f40575.xml
+++ b/kzz7yh-f40575/cod-ve09v2_kzz7yh-f40575.xml
@@ -119,20 +119,20 @@
           <p xml:id="kzz7yh-f40575-d1e201">
             ¶ Item omnis differentia 
             indi<lb ed="#V" n="119" break="no"/>cat formam ergo diuerse differentie diuersas formas. Sed quodlibet 
-            <lb ed="#V" n="120"/>elatum habet plures differentias nec predicatur vna de alia. ergo quodlibet elatum habet 
-            <lb ed="#V" n="121"/>plurles formas.
+            <lb ed="#V" n="120"/>elementum habet plures differentias nec predicatur vna de alia. ergo quodlibet elementum habet 
+            <lb ed="#V" n="121"/>plures formas.
           </p>
           <p xml:id="kzz7yh-f40575-d1e211">
             ¶ Item fora in qua vnum elatum conuenit cum alio: 
             <lb ed="#V" n="122"/>non est illa in qua vnum differt ab alio. Sed eta conueniunt in 
-            for<lb ed="#V" n="123" break="no"/>ma subalitatis et corporeitatis: differunt autem in suis formis 
-            <lb ed="#V" n="124"/>completis: ergo in eltis alia est forma corporea alia forus completiua. 
+            for<lb ed="#V" n="123" break="no"/>ma substantialitatis et corporeitatis: differunt autem in suis formis 
+            <lb ed="#V" n="124"/>completis: ergo in elementis alia est forma corporea alia forma completiua. 
           </p>
           <p xml:id="kzz7yh-f40575-d1e220">
             <lb ed="#V" n="125"/>Contra vna productio terminatur ad vnam formam. Sed 
-            <lb ed="#V" n="126"/>quodlibet elatum vna productione producitur non sic homo
-            <lb ed="#V" n="127"/>cuius vna pars producitur per generationem alia pars per creationem: ergo in quo 
-            <lb ed="#V" n="128"/>libet elatio est tantum vna sora.
+            <lb ed="#V" n="126"/>quodlibet elementum vna productione producitur non sic homo
+            <lb ed="#V" n="127"/>cuius vna pars producitur per generationem alia pars per creationem: ergo in 
+            quo<lb ed="#V" n="128" break="no"/>libet elemento est tantum vna forma.
           </p>
           <p xml:id="kzz7yh-f40575-d1e231">
             ¶ Item Aui. libro suo phy. li. 1 ca. 13. 
@@ -140,9 +140,9 @@
             constitu<lb ed="#V" n="130" break="no"/>ta ex formis multis nuon: ergo in nullo elto sunt plures forme. 
           </p>
           <p xml:id="kzz7yh-f40575-d1e238">
-            <lb ed="#V" n="131"/>Respondeo quod in quolibet elemento est tantum vna subsantialis 
+            <lb ed="#V" n="131"/>Respondeo quod in quolibet elemento est tantum vna substantialis 
             <lb ed="#V" n="132"/>forma: quam veritatem quidam sic declarare 
-            <lb ed="#V" n="133"/>nituntur: domintes quod ex duabus rebus in actu impossibile est vnum per 
+            <lb ed="#V" n="133"/>nituntur: dicentes quod ex duabus rebus in actu impossibile est vnum per 
             essen<lb ed="#V" n="134" break="no"/>tiam constitui: vnde philosophus. 7. meta. Impossibile est substantiam ex substantiis 
             <lb ed="#V" n="135"/>esse in existentibus sic in actu. duo namque sic actu numquam sunt vnum 
             <lb ed="#V" n="136"/>actu. Sed si potestate duo fuerint erut vnum. Sed quelibet forma 
@@ -434,13 +434,13 @@
             <lb ed="#V" n="59"/>forme substantiali. Sed etiam accidentali: et tamen certum est: quod 
             <lb ed="#V" n="60"/>multe forme accidentales habent gradus in sui essentia: per quod 
             <lb ed="#V" n="61"/>participari possunt a materia secundum magis et minus: per hoc enim: 
-            <lb ed="#V" n="62"/>materia magitr participat formam quam plus habet de essentia illius.
+            <lb ed="#V" n="62"/>materia magis participat formam quam plus habet de essentia illius.
           </p>
           <p xml:id="kzz7yh-f40575-d1e784">
             ¶ Ad 
             <lb ed="#V" n="63"/>quartum dicendum: quod forma substantialis elementaris: educitur de 
             <lb ed="#V" n="64"/>potentia materie naturaliter permutationem continuam nec fuit 
-            <lb ed="#V" n="65"/>intentio phlosophi. 5. phy. hoc negare. Sed intendebat differe quod motus 
+            <lb ed="#V" n="65"/>intentio philosophi. 5. phy. hoc negare. Sed intendebat differe quod motus 
             <lb ed="#V" n="66"/>dicit trasmutationem in comparatione ad subiectum. Unde subiectum 
             <lb ed="#V" n="67"/>motus mouetur vt terminus motus. generatio vero dicit trans 
             <lb ed="#V" n="68"/>mutationem in comparatione ad terminum. vnde subiectum genera¬ 
@@ -470,8 +470,8 @@
             <lb ed="#V" n="87"/>magis accedit ad complementum tanto magis a tali compositione 
             <lb ed="#V" n="88"/>recedit. Prima compotio nobilitatis est in forma que non est 
             na<lb ed="#V" n="89" break="no"/>ta habere totam perfectionem suam in vno indiuisibili. Sed 
-            <lb ed="#V" n="90"/>secunda compotmo ignobilitatis est vnde cum dicitur quod quanto forma est 
-            per<lb ed="#V" n="91" break="no"/>fectior tanto est simpl cior. Dico quod si verbum arcetur ad 
+            <lb ed="#V" n="90"/>secunda compositio ignobilitatis est vnde cum dicitur quod quanto forma est 
+            per<lb ed="#V" n="91" break="no"/>fectior tanto est simplicior. Dico quod si verbum arcetur ad 
             for<lb ed="#V" n="92" break="no"/>mas generabiles et corruptibiles per naturam: debet intelligi de 
             <lb ed="#V" n="93"/>simplicitate opposita secunde intentioni non prime.
           </p>
@@ -609,7 +609,7 @@
             ¶ Uel potest dici quod quamuis in vno 
             <lb ed="#V" n="51"/>elemento non sit vis actiua naturaliter coaptata ad formam 
             al<lb ed="#V" n="52" break="no"/>terius: tamen in ipsis elementis simul est vis actiua ad mixtorum 
-            <lb ed="#V" n="53"/>generabiles et corruptibiles formas: quia elita per suas 
+            <lb ed="#V" n="53"/>generabiles et corruptibiles formas: quia elementa per suas 
             virtu<lb ed="#V" n="54" break="no"/>tes actiuas seinuicem tramsmutando secundum proportiones 
             diuer<lb ed="#V" n="55" break="no"/>sas materiam suam disponunt ad diuersas formas mixtorum et quod 
             il<lb ed="#V" n="56" break="no"/>le fuerit intellectus <ref xml:id="kzz7yh-f40575-Rv77yyy" corresp="#kzz7yh-f40575-Qc81ccc">Aug. videtur per illud quod in eodem liro ca. sequenti</ref>
@@ -757,7 +757,7 @@
           </p>
           <p xml:id="kzz7yh-f40575-d1e1361">
             ¶ Alii dicunt quod causa motus eorum est virtus 
-            <lb ed="#V" n="4"/>loci naturalis attrahens: ita quod motus eltorum ad sua loca est 
+            <lb ed="#V" n="4"/>loci naturalis attrahens: ita quod motus elementorum ad sua loca est 
             mo<lb ed="#V" n="5" break="no"/>tus tractus.
           </p>
           <p xml:id="kzz7yh-f40575-d1e1368">
@@ -787,7 +787,7 @@
             <lb ed="#V" n="25"/>illud graue quod incepit moueri a loco superiori: velocius 
             ve<lb ed="#V" n="26" break="no"/>niet ad terram quam aliud graue a distantia equali: et tamen in 
             distan<lb ed="#V" n="27" break="no"/>tia equali equaliter respiciebantur ab influentia loci. Et quod 
-            <lb ed="#V" n="28"/>ista fuerit intentio phlosophi. 8. physi. patet per hoc quod ad probandum 
+            <lb ed="#V" n="28"/>ista fuerit intentio philosophi. 8. physi. patet per hoc quod ad probandum 
             <lb ed="#V" n="29"/>grauia et leuia non moueri a se: videtur hac propositione quod ea que 
             <lb ed="#V" n="30"/>mouentur a se non sunt determinata ad vnum motum: sed possunt 
             <lb ed="#V" n="31"/>se mouere ad partes contrarias: in quo satis ostendit: quod 
@@ -965,13 +965,13 @@
             <lb ed="#V" n="3"/>¶ Item a domino Stephano episco Parisiensis excommunicati sunt 
             <lb ed="#V" n="4"/>dogmatizantes: quod in causis efficientibus cessante prima cessat 
             <lb ed="#V" n="5"/>secunda ab operatione sua. Duntumn secunda operetur secundum materiam suam. 
-            <lb ed="#V" n="6"/>sed inter causas efficientes caelum est causa prior quam quodcumque elaenetum. 
+            <lb ed="#V" n="6"/>sed inter causas efficientes caelum est causa prior quam quodcumque elementum. 
           </p>
           <p xml:id="kzz7yh-f40575-d1e1741">
             <lb ed="#V" n="7"/>Contra si celum non moueretur non influeret: quia eius 
             in<lb ed="#V" n="8" break="no"/>stuentia est per motum: sed si celum staret ignis 
             <lb ed="#V" n="9"/>in stuppam ageret: contrarium enim dogmatizantes a domino 
-            Ste<lb ed="#V" n="10" break="no"/>phano episco Parisien. excommunicati sunt: ergo elita aliquid 
+            Ste<lb ed="#V" n="10" break="no"/>phano episco Parisien. excommunicati sunt: ergo elementa aliquid 
             pos<lb ed="#V" n="11" break="no"/>sent operari si celum in ipsa non influeret.
           </p>
           <p xml:id="kzz7yh-f40575-d1e1755">
@@ -1051,7 +1051,7 @@
             <!--00131.xml-->
             <cb ed="#P" n="b"/>
             <lb ed="#V" n="69"/>materia non desineret esse per subtractionem corporis quinti 
-            inftuen<lb ed="#V" n="70" break="no"/>tie. Sed si forme eltorum desinerent e. per subtractionem influentie 
+            inftuen<lb ed="#V" n="70" break="no"/>tie. Sed si forme elementorum desinerent esse per subtractionem influentie 
             <lb ed="#V" n="71"/>corporis quinti materia eorum desineret esse: cum non produceretur 
             <lb ed="#V" n="72"/>aliqua forma alia mediante quasi materiam haberet esse: materia autem 
             <lb ed="#V" n="73"/>naturaliter esse non potest nisi per formam: quia sicut 

--- a/kzz7yh-f40575/cod-ve09v2_kzz7yh-f40575.xml
+++ b/kzz7yh-f40575/cod-ve09v2_kzz7yh-f40575.xml
@@ -124,7 +124,7 @@
           </p>
           <p xml:id="kzz7yh-f40575-d1e211">
             ¶ Item fora in qua vnum elatum conuenit cum alio: 
-            <lb ed="#V" n="122"/>non est illa in qua vnum differt ab alio. Sed eta conueniunt in 
+            <lb ed="#V" n="122"/>non est illa in qua vnum differt ab alio. Sed elementa conueniunt in 
             for<lb ed="#V" n="123" break="no"/>ma substantialitatis et corporeitatis: differunt autem in suis formis 
             <lb ed="#V" n="124"/>completis: ergo in elementis alia est forma corporea alia forma completiua. 
           </p>
@@ -136,8 +136,8 @@
           </p>
           <p xml:id="kzz7yh-f40575-d1e231">
             ¶ Item Aui. libro suo phy. li. 1 ca. 13. 
-            <lb ed="#V" n="129"/>forma simplex est sicut forma aqua aut ingnis quie e non 
-            constitu<lb ed="#V" n="130" break="no"/>ta ex formis multis nuon: ergo in nullo elto sunt plures forme. 
+            <lb ed="#V" n="129"/>forma simplex est sicut forma aquae aut ignis quae non 
+            constitu<lb ed="#V" n="130" break="no"/>ta ex formis multis numero: ergo in nullo elemento sunt plures forme. 
           </p>
           <p xml:id="kzz7yh-f40575-d1e238">
             <lb ed="#V" n="131"/>Respondeo quod in quolibet elemento est tantum vna substantialis 

--- a/kzz7yh-f40575/cod-ve09v2_kzz7yh-f40575.xml
+++ b/kzz7yh-f40575/cod-ve09v2_kzz7yh-f40575.xml
@@ -136,7 +136,7 @@
           </p>
           <p xml:id="kzz7yh-f40575-d1e231">
             ¶ Item Aui. libro suo phy. li. 1 ca. 13. 
-            <lb ed="#V" n="129"/>forma simplex est sicut forma aquae aut ignis quae non 
+            <lb ed="#V" n="129"/>forma simplex est sicut forma aquae aut ignis quae est non 
             constitu<lb ed="#V" n="130" break="no"/>ta ex formis multis numero: ergo in nullo elemento sunt plures forme. 
           </p>
           <p xml:id="kzz7yh-f40575-d1e238">


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve09v2_kzz7yh-f40575.xml`.

## Applied changes

- p. 56v l. 120: elatum (×2) → elementum (×2): repeated misread of elementum throughout article
- p. 56v l. 121: plurles → plures: transposed letters
- p. 56v l. 123: subalitatis → substantialitatis: severely garbled
- p. 56v l. 124: eltis → elementis; forus → forma
- p. 56v l. 126: elatum → elementum
- p. 56v l. 128: quolibet split across lb 127–128 without break="no"; elatio → elemento; sora → forma
- p. 56v l. 131: subsantialis → substantialis: missing 't'
- p. 56v l. 133: domintes → dicentes: garbled word
- p. 57v l. 62: magitr → magis: spurious 'tr'
- p. 57v l. 65: phlosophi → philosophi: missing 'i'
- p. 57v l. 90: compotmo → compositio: garbled
- p. 57v l. 91: simpl cior → simplicior: spurious space + missing letters
- p. 58r l. 53: elita → elementa: garbled abbreviation
- p. 58v l. 4: eltorum → elementorum
- p. 58v l. 28: phlosophi → philosophi
- p. 59r l. 6: elaenetum → elementum: severely garbled
- p. 59r l. 10: elita → elementa
- p. 59r l. 70: eltorum → elementorum; e. → esse (abbreviated)

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_