### PR TITLE
Transcription corrections: cod-ve09v2_kzz7yh-f42515.xml (11 changes)

### DIFF
--- a/kzz7yh-f42515/cod-ve09v2_kzz7yh-f42515.xml
+++ b/kzz7yh-f42515/cod-ve09v2_kzz7yh-f42515.xml
@@ -93,7 +93,7 @@
             <lb ed="#V" n="132"/>PRimo ostendo quod omnia 
             lumi<lb ed="#V" n="133" break="no"/>naria posita sunt 
             <lb ed="#V" n="134"/>in vno corpore continuo: philosophus. 12. meta. quod vnum 
-            <lb ed="#V" n="135"/>sit caelum manitum est: sed contigua non sunt: vnde ergo omnes 
+            <lb ed="#V" n="135"/>sit caelum manifestum est: sed contigua non sunt: vnde ergo omnes 
             <lb ed="#V" n="136"/>spere celestes sunt continue.
           </p>
           <p xml:id="kzz7yh-f42515-d1e164">
@@ -306,8 +306,8 @@
             <lb ed="#V" n="2"/>planeta moueatur circa centrum proprium satis creditur de 
             <lb ed="#V" n="3"/>sole quod non de saturno: aut ioue: marte: venere: et 
             mercu<lb ed="#V" n="4" break="no"/>rio: mihi est incertum. Unde cum certum est quod nullus 
-            pla<lb ed="#V" n="5" break="no"/>neta transfertur. de vna parte epicrcli ad alia: sicut nec 
-            epi<lb ed="#V" n="6" break="no"/>cyclus de vna parte deserentis ad aliam. Utrum tamen 
+            pla<lb ed="#V" n="5" break="no"/>neta transfertur. de vna parte epicycli ad alia: sicut nec 
+            epi<lb ed="#V" n="6" break="no"/>cyclus de vna parte deferentis ad aliam. Utrum tamen 
             <lb ed="#V" n="7"/>probatur multis quod luna motu proprio circulariter 
             mouea<lb ed="#V" n="8" break="no"/>tur circa suum centrum: quod habet inter concauum et 
             con<lb ed="#V" n="9" break="no"/>uexum epicycli: quia illa macula que est in luna nunquam 
@@ -319,7 +319,7 @@
             <lb ed="#V" n="15"/>motus lune circa centrum suum ad partem contrariam 
             mo<lb ed="#V" n="16" break="no"/>tus epicycli in tali proportione quod quantum per motum 
             epicy<lb ed="#V" n="17" break="no"/>cli: illa macula transponeretur tantum per motum lune proprium 
-            <lb ed="#V" n="18"/>ad contrarium trnaspositio prohibetur. 
+            <lb ed="#V" n="18"/>ad contrarium transpositio prohibetur. 
           </p>
           <p xml:id="kzz7yh-f42515-d1e578">
             <lb ed="#V" n="19"/>Qui ergo vult tenere hanc opinionem potest 
@@ -424,7 +424,7 @@
             ce<lb ed="#V" n="79" break="no"/>lum suum (creando spacium extra ipsum 
             <lb ed="#V" n="80"/>siue non creando) motu recto: quamuis enim eandem rem per se 
             <lb ed="#V" n="81"/>et secundum se totam impossibile sit moueri motu locali recto: per 
-            quan<lb ed="#V" n="82" break="no"/>cumque potentiam nisi extra ipsam sit aliquod spoacium. Unde si 
+            quan<lb ed="#V" n="82" break="no"/>cumque potentiam nisi extra ipsam sit aliquod spatium. Unde si 
             nul<lb ed="#V" n="83" break="no"/>la creatura esset: nisi vnus angelus: deus non posset ipsum 
             an<lb ed="#V" n="84" break="no"/>gelum tali motu mouere nisi inquantum posset creare aliquod 
             <lb ed="#V" n="85"/>spatium extra ipsum: vel circa: tamen per accidens vel secundum partem 
@@ -434,7 +434,7 @@
             pellem<lb ed="#V" n="89" break="no"/>do per motum rectum: partem lancee inferiorem versus vltimam 
             <lb ed="#V" n="90"/>superficiem celi empyrei: faceret quod lancea motu recto 
             tran<lb ed="#V" n="91" break="no"/>scenderet quantum ad aliquam sui partem vltimam superficiem 
-            ce<lb ed="#V" n="92" break="no"/>liempyrei: quamuis extra ipsam nullum sit spratium: sic dico quod 
+            ce<lb ed="#V" n="92" break="no"/>liempyrei: quamuis extra ipsam nullum sit spatium: sic dico quod 
             <lb ed="#V" n="93"/>deus si moueret motu proprio recto vnam partem celi 
             empy<lb ed="#V" n="94" break="no"/>rei vsque ad terram figura celi et quantitate saluis 
             manen<lb ed="#V" n="95" break="no"/>tibus faceret non alia pars celi moueretur motu recto: 
@@ -506,7 +506,7 @@
             <!--00134.xml-->
             <pb ed="#V" n="60-v"/>
             <cb ed="#P" n="a"/>
-            <lb ed="#V" n="1"/>torpus humanum inter corpora mixta propter magnam 
+            <lb ed="#V" n="1"/>corpus humanum inter corpora mixta propter magnam 
             <lb ed="#V" n="2"/>sui equalitatem: et recessum a contrarietate est animabile anima 
             <lb ed="#V" n="3"/>intellectiua. Sed corpora celestia maxime recedunt a 
             con<lb ed="#V" n="4" break="no"/>trarietate secundum doctrinam philosophi. i. celi et mundi: ergo maxime 
@@ -518,8 +518,8 @@
             <lb ed="#V" n="7"/>quod sit: eim a quo sit par esse non potest: ergo nec maius: sed 
             <lb ed="#V" n="8"/>secundum eundem. xi. de ciuitate. capi. 7. viuentia preponuntur non 
             <lb ed="#V" n="9"/>viuentibus. Cum ergo corpora superiora sint causa vite 
-            <lb ed="#V" n="10"/>in istis inferoribus: vt patet in generratione plantarum et brutorum 
-            <lb ed="#V" n="11"/>generatorum: per viam putrefactionis: videtur quod hebeant vitam. 
+            <lb ed="#V" n="10"/>in istis inferoribus: vt patet in generatione plantarum et brutorum 
+            <lb ed="#V" n="11"/>generatorum: per viam putrefactionis: videtur quod habeant vitam. 
           </p>
           <p xml:id="kzz7yh-f42515-d1e939">
             <lb ed="#V" n="12"/>Contra si corpora celestia essent animata: probabile
@@ -534,7 +534,7 @@
           </p>
           <p xml:id="kzz7yh-f42515-d1e961">
             ¶ Item Dama. libro 2. capi. 5. nullus 
-            <lb ed="#V" n="21"/>aninmatos celos vel luminaria existinet: inanimati enim sunt et in 
+            <lb ed="#V" n="21"/>animatos caelos vel luminaria existimet: inanimati enim sunt et in 
             <lb ed="#V" n="22"/>sensibiles.
           </p>
           <p xml:id="kzz7yh-f42515-d1e968">
@@ -667,7 +667,7 @@
           </p>
           <p xml:id="kzz7yh-f42515-d1e1192">
             ¶ Item 
-            <lb ed="#V" n="103"/>philosophus in libro de proprietatibus elaltetorum: dicit quod regna vacua sunt 
+            <lb ed="#V" n="103"/>philosophus in libro de proprietatibus elementorum: dicit quod regna vacua sunt 
             <lb ed="#V" n="104"/>et terre deppopulate apud coniunctione duarum magnarum 
             stel<lb ed="#V" n="105" break="no"/>larum scilicet Iouis et Saturni. Sed talia dependent ex libero 
             arbi<lb ed="#V" n="106" break="no"/>irio: ergo astra causa sunt effectuum ex libero arbitrii dependentium: 

--- a/kzz7yh-f42515/cod-ve09v2_kzz7yh-f42515.xml
+++ b/kzz7yh-f42515/cod-ve09v2_kzz7yh-f42515.xml
@@ -293,7 +293,7 @@
             pro<lb ed="#V" n="128" break="no"/>prium illius sphere: qui est ab occidente in oriens 
             moue<lb ed="#V" n="129" break="no"/>tur etiam per motum deferentis: quilibet etiam planeta 
             <lb ed="#V" n="130"/>preter solem vltra predictos mouetur per motum in 
-            epi<lb ed="#V" n="131" break="no"/>ticli. Solus autem sol inter plauetas caret epiticlo nec est 
+            epi<lb ed="#V" n="131" break="no"/>ticli. Solus autem sol inter planetas caret epiciclo nec est 
             <lb ed="#V" n="132"/>intelligendum: quod epicyclus transferat de vna parte 
             deferen<lb ed="#V" n="133" break="no"/>tis ad aliam. Sed sicut tota sphera mouetur motu 
             circu<lb ed="#V" n="134" break="no"/>lari circa suum centrum: et deferens circa suum centrum: 
@@ -539,8 +539,8 @@
           </p>
           <p xml:id="kzz7yh-f42515-d1e968">
             ¶ Item ponere corpora celestia animata est 
-            arti<lb ed="#V" n="23" break="no"/>culus excommunicatus a domino Stepsopho quodam perisien. episco: et 
-            sa<lb ed="#V" n="24" break="no"/>cre theologie doctorre. 
+            arti<lb ed="#V" n="23" break="no"/>culus excommunicatus a domino Stephano quodam parisiensi episcopo: et 
+            sa<lb ed="#V" n="24" break="no"/>cre theologie <sic>doctorre</sic>. 
           </p>
           <p xml:id="kzz7yh-f42515-d1e975">
             <lb ed="#V" n="25"/>Respondeo quod quamuis Aum. et Auicen. 
@@ -559,7 +559,7 @@
             uegeta<lb ed="#V" n="38" break="no"/>tiua separari: omne enim quod sentit hebet aliquam potentiam vege 
             <lb ed="#V" n="39"/>tatiue. Nec habent animam intellectiuam: quia nullum corpus 
             <lb ed="#V" n="40"/>potest informari anima intellectiua: nisi habente vtum 
-            delectan<lb ed="#V" n="41" break="no"/>di vegetandi et senfificandi: quia suas operateones intelligibiles 
+            delectan<lb ed="#V" n="41" break="no"/>di vegetandi et sensificandi: quia suas <sic>operateones</sic> intelligibiles 
             <lb ed="#V" n="42"/>per corpus non exercet: nisi mediantibus aliquibus viribus 
             <lb ed="#V" n="43"/>sensitiuis. Cum ergo vt dicit philosophus 2. de anima: non sit 
             ani<lb ed="#V" n="44" break="no"/>ma preter predictas: sequitur quod corpora celestia 
@@ -650,7 +650,7 @@
             ¶ Item alterans omnia corpora non debet esse 
             altera<lb ed="#V" n="92" break="no"/>tum. Sed corpora celestia alterantur ab intelligentiis mouentibus 
             <lb ed="#V" n="93"/>in quantum de ipsis educunt virtutes per quas mouentur vt 
-            su<lb ed="#V" n="94" break="no"/>perius dictum est. Ergo saltem non possunt alteratr omnia ista corpora 
+            su<lb ed="#V" n="94" break="no"/>perius dictum est. Ergo saltem non possunt alterare omnia ista corpora 
             <lb ed="#V" n="95"/>inferiora.
           </p>
           <p xml:id="kzz7yh-f42515-d1e1172">


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve09v2_kzz7yh-f42515.xml`.

## Applied changes

- p. 59r l. 135: manitum → manifestum: severely garbled
- p. 60r l. 5: epicrcli → epicycli: garbled
- p. 60r l. 6: deserentis → deferentis: s/f misread
- p. 60r l. 18: trnaspositio → transpositio: transposed letters
- p. 60r l. 82: spoacium → spatium: garbled
- p. 60r l. 92: spratium → spatium: garbled
- p. 60v l. 1: torpus → corpus: t/c misread
- p. 60v l. 10: generratione → generatione: double 'r'
- p. 60v l. 11: hebeant → habeant: e/a misread
- p. 60v l. 21: aninmatos → animatos (transposed 'n'); existinet → existimet
- p. 60v l. 103: elaltetorum → elementorum: severely garbled

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_