### PR TITLE
Transcription corrections: cod-ve09v2_kzz7yh-f45810.xml (5 changes)

### DIFF
--- a/kzz7yh-f45810/cod-ve09v2_kzz7yh-f45810.xml
+++ b/kzz7yh-f45810/cod-ve09v2_kzz7yh-f45810.xml
@@ -78,13 +78,13 @@
             <lb ed="#V" n="32"/>fiant brutorum anime et alie corruptibiles forme: 
             <lb ed="#V" n="33"/>Quia illud non est tota essentia forme: quia sic 
             for<lb ed="#V" n="34" break="no"/>me non generarentur: sed essent materie concreate nec pars 
-            <lb ed="#V" n="35"/>essentie forme: quia ita difficile est vnam partem forme sieri de 
+            <lb ed="#V" n="35"/>essentie forme: quia ita difficile est vnam partem forme fieri de 
             <lb ed="#V" n="36"/>nihilo: sicut totam nec aliquid purum possibile: quia aliquid 
             <lb ed="#V" n="37"/>purum possibile esse videtur includere contradictionem: cum 
             <lb ed="#V" n="38"/>esse sit actus.
           </p>
           <p xml:id="kzz7yh-f45810-d1e150">
-            ¶ Item si est aliquid in materia de quo siat 
+            ¶ Item si est aliquid in materia de quo fiat 
             cor<lb ed="#V" n="39" break="no"/>ruptibilis forma: aut illud est tramsmutabile in formam: aut 
             <lb ed="#V" n="40"/>non si sic. desinit esse quod erat: et ita in productione forme 
             fie<lb ed="#V" n="41" break="no"/>ret alicuius rei adnihilatio quod inconueniens videtur. Si non 
@@ -289,7 +289,7 @@
             ad<lb ed="#V" n="52" break="no"/>nihilari: quod in aliud tramsmutatur: et non maneat quod erat antem. 
           </p>
           <p xml:id="kzz7yh-f45810-d1e535">
-            <lb ed="#V" n="53"/>¶ Ad tertium dicendum: quod illud verbum phlosophi. 7. meta scilicet quod 
+            <lb ed="#V" n="53"/>¶ Ad tertium dicendum: quod illud verbum philosophi. 7. meta scilicet quod 
             for<lb ed="#V" n="54" break="no"/>ma non sit sed compositum: restringi debet ad factionem rei 
             <lb ed="#V" n="55"/>complete per se stantis naturaliter cuiusmodi est substantia 
             <lb ed="#V" n="56"/>composita: et non corruptibilis forma.
@@ -301,8 +301,8 @@
             <lb ed="#V" n="59"/>quod fuit transmutatum in ipsam: sed in aliud secundum quod vna res 
             <lb ed="#V" n="60"/>pure possibilis potest dici aliud ab vna re possibili: quae non 
             <lb ed="#V" n="61"/>est ipsa: et est alietas potentialis: et etiam si illud principium 
-            <lb ed="#V" n="62"/>purum possibile transmutatur in formam non tramsmutabi. 
-            <lb ed="#V" n="63"/>tur in eadem numero: que resoluta suit in ipsum: sed in aliam 
+            <lb ed="#V" n="62"/>purum possibile transmutatur in formam non 
+            transmutabi<lb ed="#V" n="63" break="no"/>tur in eadem numero: que resoluta fuit in ipsum: sed in aliam 
             <lb ed="#V" n="64"/>Et ideo ex predicta positione non sequitur eandem formam 
             <lb ed="#V" n="65"/>in numero posse reduci per naturam.
           </p>
@@ -375,7 +375,7 @@
             In<lb ed="#V" n="103" break="no"/>qualibet autem parte materie ipsius bruti: que animatur 
             <lb ed="#V" n="104"/>anima sensitiua: prefuit principium purum possibile 
             tramsmu<lb ed="#V" n="105" break="no"/>tabile in ipsam: nec probabile videtur: quod in qualet parte materie fuit totum: 
-            <lb ed="#V" n="106"/>ergo de qualbet parte materie bruti animati anima sensitiua educta est aliuom 
+            <lb ed="#V" n="106"/>ergo de qualbet parte materie bruti animati anima sensitiua educta est aliquam 
             <lb ed="#V" n="107"/>pars ipsius anime sensitiue: secundum ergo vnam sui partem est 
             <lb ed="#V" n="108"/>in vna parte materie: et secundum aliam in alia parte quod non esset 
             <lb ed="#V" n="109"/>verum si non esset extensa secundum extensionem sue materie.

--- a/kzz7yh-f45810/cod-ve09v2_kzz7yh-f45810.xml
+++ b/kzz7yh-f45810/cod-ve09v2_kzz7yh-f45810.xml
@@ -93,7 +93,7 @@
           <p xml:id="kzz7yh-f45810-d1e161">
             ¶ Item philosophus. 7. meta. 
             probar<lb ed="#V" n="43" break="no"/>quod forma non generatur: nisi quia compositum generatur: ergo 
-            <lb ed="#V" n="44"/>illud de quo sit forma non est al: ud: quam illud de quo sit 
+            <lb ed="#V" n="44"/>illud de quo sit forma non est <sic>al:ud</sic>: quam illud de quo sit 
             con<lb ed="#V" n="45" break="no"/>positum. Cum materia ergo sit de quo sit compositu: non 
             opor<lb ed="#V" n="46" break="no"/>tet vltra hoc ponere aliquid de quo fiat forma.
           </p>
@@ -183,7 +183,7 @@
             ¶ Alii dicunt ad questionem 
             <lb ed="#V" n="108"/>quod in fundamento materie est aliquid de quo sit forma 
             corru<lb ed="#V" n="109" break="no"/>ptibilis: et hoc est aliquis gradus essentie illius forme. Sed 
-            <lb ed="#V" n="110"/>hec etiam rantuns non videtur sunfficiens: quia aut ille gradus 
+            <lb ed="#V" n="110"/>hec etiam responsio non videtur sufficiens: quia aut ille gradus 
             trans<lb ed="#V" n="111" break="no"/>mutatur in alium gradum: aut non. Si non: non video 
             quomo<lb ed="#V" n="112" break="no"/>do de illo fiat alius gradus. Si sic iam ille prior gradus 
             <lb ed="#V" n="113"/>non remanet: quia impossibile videtur quod vna res tramsmute 
@@ -272,7 +272,7 @@
             adnihila<lb ed="#V" n="35" break="no"/>tur: quia quamuis non maneat purum possibile: sicut ante erat: 
             <lb ed="#V" n="36"/>manet tamen actualitas forme: in quam tramsmutatur: quamuis 
             <lb ed="#V" n="37"/>enim substantia panis transubstantietur in corpus christi: non tamen 
-            <lb ed="#V" n="38"/>adnihilatur: quia quamuis non remaneat panis substantia: maeriet 
+            <lb ed="#V" n="38"/>adnihilatur: quia quamuis non remaneat panis substantia: manet 
             <lb ed="#V" n="39"/>tamen corpus christi: in quod tansmutatur: quamuis autem inter 
             <lb ed="#V" n="40"/>istas tramsmutationes multa sit dissimilitudo: quia in 
             sacra<lb ed="#V" n="41" break="no"/>mento altaris tramsmutatur substantia composita in 


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve09v2_kzz7yh-f45810.xml`.

## Applied changes

- p. 64r l. 35: sieri → fieri: s/f misread
- p. 64r l. 38: siat → fiat: s/f misread
- p. 64v l. 53: phlosophi → philosophi: missing 'i'
- p. 64v l. 63: tramsmutabi. → transmutabi (trams- → trans-, spurious period); missing break="no" on lb 63; suit → fuit (s/f misread)
- p. 64v l. 106: aliuom → aliquam: garbled

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_