### PR TITLE
Transcription corrections: cod-ve09v2_kzz7yh-f46637.xml (3 changes)

### DIFF
--- a/kzz7yh-f46637/cod-ve09v2_kzz7yh-f46637.xml
+++ b/kzz7yh-f46637/cod-ve09v2_kzz7yh-f46637.xml
@@ -259,7 +259,8 @@
             <lb ed="#V" n="61"/>Ad istam questionem dixerunt quidam 
             <lb ed="#V" n="62"/>quod anima 
             nobi<lb ed="#V" n="63" break="no"/>lior est quam sit animal: quia secundum eos forma nobilior est quam 
-            com<lb ed="#V" n="64" break="no"/>positum ex materia et forma: quorum ratio est: quia secundum istos nihil<lb ed="#V" n="65" break="no"/>est de essentia animalis vel cuiuscumque alterius rei que 
+            com<lb ed="#V" n="64" break="no"/>positum ex materia et forma: quorum ratio est: quia secundum istos nihil
+            <lb ed="#V" n="65"/>est de essentia animalis vel cuiuscumque alterius rei que 
             di<lb ed="#V" n="66" break="no"/>citur composita nisi actualitas: et secundum eos: non est aliqua 
             differen<lb ed="#V" n="67" break="no"/>tia realis inter actualitatem et formam: vnde nihil est de 
             essen<lb ed="#V" n="68" break="no"/>tia compositi nisi forma. Materia vero nihil aliud est rea 

--- a/kzz7yh-f46637/cod-ve09v2_kzz7yh-f46637.xml
+++ b/kzz7yh-f46637/cod-ve09v2_kzz7yh-f46637.xml
@@ -180,12 +180,12 @@
           </p>
           <p xml:id="kzz7yh-f46637-d1e337">
             <lb ed="#V" n="10"/>Primum argumentum ad partem secundam 
-            procaedit<lb ed="#V" n="11" break="no"/>de prioritate ordine nature que 
+            proce<lb ed="#V" n="11" break="no"/>dit de prioritate ordine nature que 
             attendi<lb ed="#V" n="12" break="no"/>tur de imperfecto ad perfectum.
           </p>
           <p xml:id="kzz7yh-f46637-d1e347">
             ¶ Ad secundum dicendum quod 
-            ma<lb ed="#V" n="13" break="no"/>ior est falsa: quia naturale et reale esse corruptibilis forme nihit 
+            ma<lb ed="#V" n="13" break="no"/>ior est falsa: quia naturale et reale esse corruptibilis forme nihil 
             <lb ed="#V" n="14"/>aliud est: quam esse in materia: sicut naturale et reale esse 
             acciden<lb ed="#V" n="15" break="no"/>tis nihil aliud quam esse ipsum in subiecto: et reale esse creatu 
             <lb ed="#V" n="16"/>re nihil aliud est: quam esse non de aliquo ab alio. Unde sicut 
@@ -259,8 +259,7 @@
             <lb ed="#V" n="61"/>Ad istam questionem dixerunt quidam 
             <lb ed="#V" n="62"/>quod anima 
             nobi<lb ed="#V" n="63" break="no"/>lior est quam sit animal: quia secundum eos forma nobilior est quam 
-            com<lb ed="#V" n="64" break="no"/>positum ex materia et forma: quorum ratio est: quia secundum istos 
-            nihit<lb ed="#V" n="65" break="no"/>est de essentia animalis vel cuiuscumque alterius rei que 
+            com<lb ed="#V" n="64" break="no"/>positum ex materia et forma: quorum ratio est: quia secundum istos nihil<lb ed="#V" n="65" break="no"/>est de essentia animalis vel cuiuscumque alterius rei que 
             di<lb ed="#V" n="66" break="no"/>citur composita nisi actualitas: et secundum eos: non est aliqua 
             differen<lb ed="#V" n="67" break="no"/>tia realis inter actualitatem et formam: vnde nihil est de 
             essen<lb ed="#V" n="68" break="no"/>tia compositi nisi forma. Materia vero nihil aliud est rea 


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve09v2_kzz7yh-f46637.xml`.

## Applied changes

- p. 65v l. 11: procaedit|de → proce|dit: word 'procedit' garbled and incorrectly split; stem should be 'proce', suffix 'dit'
- p. 65v l. 13: nihit → nihil: l misread as t
- p. 65v l. 64: nihit → nihil (l misread as t); note: lb 65 has spurious break="no" connecting nihil to est as one word — should be removed

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_