### PR TITLE
Transcription corrections: cod-ve09v2_kzz7yh-f49503.xml (10 changes)

### DIFF
--- a/kzz7yh-f49503/cod-ve09v2_kzz7yh-f49503.xml
+++ b/kzz7yh-f49503/cod-ve09v2_kzz7yh-f49503.xml
@@ -497,7 +497,7 @@
             depen<lb ed="#V" n="105" break="no"/>dens. Sed dico quod tota quantum ad suum completum 
             natu<lb ed="#V" n="106" break="no"/>ralis existentie modum est a corpore dependens: et secundum se 
             to<lb ed="#V" n="107" break="no"/>tam est a corpore independens quantum ad esse simpliciter 
-            <lb ed="#V" n="108"/>quia remanet in actuali esse post corrporis corruptionem 
+            <lb ed="#V" n="108"/>quia remanet in actuali esse post <sic>corrporis</sic> corruptionem 
             <lb ed="#V" n="109"/>quia vt inferius ostendetur ipsa est incorruptibilis per 
             na<lb ed="#V" n="110" break="no"/>turam.
           </p>
@@ -578,7 +578,7 @@
             <lb ed="#V" n="20"/>Si animus eius vsque ad eam porrigeretur: presentiaque 
             sen<lb ed="#V" n="21" break="no"/>tiret: videtur ergo sentire Aug. quod anima suum corpus non 
             <lb ed="#V" n="22"/>transcendat substantialiter: quia aliter homo posset scire 
-            na<lb ed="#V" n="23" break="no"/>turaliter: que siunt in locis: vbi corpus suum presens non 
+            na<lb ed="#V" n="23" break="no"/>turaliter: que fiunt in locis: vbi corpus suum presens non 
             <lb ed="#V" n="24"/>est.
           </p>
           <p xml:id="kzz7yh-f49503-d1e1047">

--- a/kzz7yh-f49503/cod-ve09v2_kzz7yh-f49503.xml
+++ b/kzz7yh-f49503/cod-ve09v2_kzz7yh-f49503.xml
@@ -83,7 +83,7 @@
           <head xml:id="kzz7yh-f49503-Hd1e142">Quaestio 1</head>
           <head xml:id="kzz7yh-f49503-Hd1e146" type="question-title">De anima Ade.</head>
           <p xml:id="kzz7yh-f49503-d1e144">
-            Quaeoid I. 
+            Quaestio I. 
             <lb ed="#V" n="88"/>PRimo ostendo quo anima Ade. non 
             <lb ed="#V" n="89"/>fuerit producta 
             <lb ed="#V" n="90"/>ex aliqua materia. Quia aut illa materia prius 
@@ -145,8 +145,8 @@
             <lb ed="#V" n="3"/>vt sonus tantum. Et sic ad hoc dicunt aliqui: quod anima ade: nec aliqua 
             <lb ed="#V" n="4"/>alia anima rationalis producta fuit ex aliqua materia. Non enim 
             <lb ed="#V" n="5"/>secundum istos necessarium est ponere materiam in anima: nisi 
-            accipien<lb ed="#V" n="6" break="no"/>do materiam pro principio pure possibili: quod est tramsmuta 
-            <lb ed="#V" n="7"/>bile in illas accidentales formas: que de potentia ipsius 
+            accipien<lb ed="#V" n="6" break="no"/>do materiam pro principio pure possibili: quod est 
+            transmuta<lb ed="#V" n="7" break="no"/>bile in illas accidentales formas: que de potentia ipsius 
             <lb ed="#V" n="8"/>anime educi possunt per virtutem agentis creati. Cum 
             <lb ed="#V" n="9"/>ergo illud principium purum possibile non sit de essentia 
             <lb ed="#V" n="10"/>eius: in quo est: videtur eis in anima non esse materiam 
@@ -159,7 +159,7 @@
           </p>
           <p xml:id="kzz7yh-f49503-d1e283">
             ¶ Alii autem dicunt: quod anima habet materiam 
-            <lb ed="#V" n="17"/>que est pars essentie sue: non tame vnigeneam cum materia 
+            <lb ed="#V" n="17"/>que est pars essentie sue: non tamen vnigeneam cum materia 
             <lb ed="#V" n="18"/>corporalium: et ad hoc declarandum recurrendum est superius 
             <lb ed="#V" n="19"/>ad dist. 3. vbi declaratum est quaestione. 2 essentiam angeli esse 
             compo<lb ed="#V" n="20" break="no"/>sitam ex materia et forma: extendendo nomen materie ad omnem naturam 
@@ -299,7 +299,7 @@
           </p>
           <p xml:id="kzz7yh-f49503-d1e529">
             ¶ Sed 
-            vi<lb ed="#V" n="105" break="no"/>detur rationabilius dicendum: quod suit creata in corpore 
+            vi<lb ed="#V" n="105" break="no"/>detur rationabilius dicendum: quod fuit creata in corpore 
             quam<lb ed="#V" n="106" break="no"/>uis eam deus creasse potuisset ante corpus: si voluisset 
             <lb ed="#V" n="107"/>Et quod in corpore creata fuerit videtur innuere textus 
             sa<lb ed="#V" n="108" break="no"/>cre scripture. Genm. 2. vbi dicitur formauit dominus deus 
@@ -321,7 +321,7 @@
           <p xml:id="kzz7yh-f49503-d1e567">
             <lb ed="#V" n="120"/>Ad primum in oppositum cum dicitur quod forma prior
             <lb ed="#V" n="121"/>est materia. Dico quod hoc
-            intelligen<lb ed="#V" n="122" break="no"/>dum est: autem de prioritate dignitatis autm de prioritate 
+            intelligen<lb ed="#V" n="122" break="no"/>dum est: autem de prioritate dignitatis aut de prioritate 
             ali<lb ed="#V" n="123" break="no"/>qualis causalitatis in forma respectu materie prime: eo quod 
             ac<lb ed="#V" n="124" break="no"/>tualitas essendi conuenire non potest per naturam materie 
             <lb ed="#V" n="125"/>nisi per aliquam formam: corpus autem ade. cui deus infudit 
@@ -494,7 +494,7 @@
             ¶ Ad tertium 
             <lb ed="#V" n="103"/>dicendum: quod essentia anime non est totaliter dependens a 
             <lb ed="#V" n="104"/>corpore: nec secundum partem vnam dependens: et secundum aliam non 
-            depemn<lb ed="#V" n="105" break="no"/>dens. Sed dico quod tota quantum ad suum completum 
+            depen<lb ed="#V" n="105" break="no"/>dens. Sed dico quod tota quantum ad suum completum 
             natu<lb ed="#V" n="106" break="no"/>ralis existentie modum est a corpore dependens: et secundum se 
             to<lb ed="#V" n="107" break="no"/>tam est a corpore independens quantum ad esse simpliciter 
             <lb ed="#V" n="108"/>quia remanet in actuali esse post corrporis corruptionem 
@@ -509,7 +509,7 @@
             ho<lb ed="#V" n="114" break="no"/>mini genus.
           </p>
           <p xml:id="kzz7yh-f49503-d1e916">
-            ¶ Ad quintum dicendum: quod xredictum verbum 
+            ¶ Ad quintum dicendum: quod praedictum verbum 
             <lb ed="#V" n="115"/>Auicen. falsum est: et contra symbolum in quo dicitur quod anima 
             <lb ed="#V" n="116"/>rationalis et caro vnus est homo.
           </p>
@@ -548,7 +548,7 @@
             <!--00154.xml-->
             <pb ed="#V" n="70-v"/>
             <cb ed="#P" n="a"/>
-            <lb ed="#V" n="1"/>Dicit de santstico hominis: quod cum corpus non sit: tamen 
+            <lb ed="#V" n="1"/>Dicit de fantastico hominis: quod cum corpus non sit: tamen 
             <lb ed="#V" n="2"/>mira celeritate corporum formas capit: et ipsum sopitis: aut 
             <lb ed="#V" n="3"/>oppressis corporeis hominis sensibus: ad aliorum sensuum 
             <lb ed="#V" n="4"/>nescio quo ineffabili modo figura corporea posse 
@@ -564,7 +564,7 @@
             ¶ Item loquitur de beato Ambro. 
             <lb ed="#V" n="12"/>quod interfuit exequiis beati Martini: corpore suo viuente 
             <lb ed="#V" n="13"/>remanente Mediolani quod esse non potuisset: nisi anima 
-            tramn<lb ed="#V" n="14" break="no"/>scendisset corpus: et simul remansisset actu elus forma. 
+            tramn<lb ed="#V" n="14" break="no"/>scendisset corpus: et simul remansisset actu eius forma. 
           </p>
           <p xml:id="kzz7yh-f49503-d1e1020">
             <lb ed="#V" n="15"/>Contra <ref xml:id="kzz7yh-f49503-Rd1e1056">Aug. libro de quantitate anime</ref>: non multum 
@@ -901,7 +901,7 @@
           </p>
           <p xml:id="kzz7yh-f49503-d1e1632">
             ¶ 
-            Con<lb ed="#V" n="112" break="no"/>tra haoec etiam quod dicunt: quod recedente intellectiua noua accidentia 
+            Con<lb ed="#V" n="112" break="no"/>tra haec etiam quod dicunt: quod recedente intellectiua noua accidentia 
             <lb ed="#V" n="113"/>introducuntur in ma prioribus similia. Arguitur sic. illa enim 
             <lb ed="#V" n="114"/>introductio non esset a casu: quia secundum philosophum. 2. phy. que sunt a 
             <lb ed="#V" n="115"/>casu eueniunt: vt in paucioribus: nec posset huius 


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve09v2_kzz7yh-f49503.xml`.

## Applied changes

- p. 69r l. 87: Quaeoid → Quaestio: garbled OCR
- p. 69v l. 7: tramsmutabile → transmutabile: trams/trans transposition; lb 7 missing break="no"
- p. 69v l. 17: tame → tamen: missing final n
- p. 69v l. 105: suit → fuit: s/f misread
- p. 69v l. 122: autm → aut: spurious m
- p. 70v l. 1: santstico → fantastico: garbled OCR
- p. 70v l. 14: elus → eius: l/i misread
- p. 70r l. 105: depemn/dens → depen/dens: extra m before break="no" lb 105
- p. 70r l. 114: xredictum → praedictum: garbled OCR
- p. 71r l. 112: haoec → haec: garbled OCR (spurious 'o')

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_