### PR TITLE
Transcription corrections: cod-ve09v2_kzz7yh-f53797.xml (3 changes)

### DIFF
--- a/kzz7yh-f53797/cod-ve09v2_kzz7yh-f53797.xml
+++ b/kzz7yh-f53797/cod-ve09v2_kzz7yh-f53797.xml
@@ -252,7 +252,7 @@
           </p>
           <p xml:id="kzz7yh-f53797-d1e462">
             ¶ Sed hec secunda 
-            solu<lb ed="#V" n="114" break="no"/>lutio aliquibus non placet: quia non videtur ratio: 
+            solu<lb ed="#V" n="114" break="no"/>tio aliquibus non placet: quia non videtur ratio: 
             qua<lb ed="#V" n="115" break="no"/>re portio facta de materia ad eo creata minus esset 
             radi<lb ed="#V" n="116" break="no"/>calis in corpore mulieris quam portio facta de costa: 13m. 
           </p>

--- a/kzz7yh-f53797/cod-ve09v2_kzz7yh-f53797.xml
+++ b/kzz7yh-f53797/cod-ve09v2_kzz7yh-f53797.xml
@@ -252,7 +252,7 @@
           </p>
           <p xml:id="kzz7yh-f53797-d1e462">
             ¶ Sed hec secunda 
-            solu<lb ed="#V" n="114" break="no"/>tio aliquibus non placet: quia non videtur ratio: 
+            solu<lb ed="#V" n="114" break="no"/><sic>lu</sic>tio aliquibus non placet: quia non videtur ratio: 
             qua<lb ed="#V" n="115" break="no"/>re portio facta de materia ad eo creata minus esset 
             radi<lb ed="#V" n="116" break="no"/>calis in corpore mulieris quam portio facta de costa: 13m. 
           </p>

--- a/kzz7yh-f53797/cod-ve09v2_kzz7yh-f53797.xml
+++ b/kzz7yh-f53797/cod-ve09v2_kzz7yh-f53797.xml
@@ -252,7 +252,7 @@
           </p>
           <p xml:id="kzz7yh-f53797-d1e462">
             ¶ Sed hec secunda 
-            solu<lb ed="#V" n="114" break="no"/><sic>lu</sic>tio aliquibus non placet: quia non videtur ratio: 
+            <sic>solu<lb ed="#V" n="114" break="no"/>lutio</sic> aliquibus non placet: quia non videtur ratio: 
             qua<lb ed="#V" n="115" break="no"/>re portio facta de materia ad eo creata minus esset 
             radi<lb ed="#V" n="116" break="no"/>calis in corpore mulieris quam portio facta de costa: 13m. 
           </p>

--- a/kzz7yh-f53797/cod-ve09v2_kzz7yh-f53797.xml
+++ b/kzz7yh-f53797/cod-ve09v2_kzz7yh-f53797.xml
@@ -67,7 +67,7 @@
           <lb ed="#V" n="102"/>productum fuerit de illa costa secundum rationem seminalem. 
         </p>
         <p xml:id="kzz7yh-f53797-d1e118">
-          <lb ed="#V" n="103"/>¶ Tertio vtrum ratio seminalis sit aliquid tramsmutabile 
+          <lb ed="#V" n="103"/>¶ Tertio vtrum ratio seminalis sit aliquid transmutabile 
           <lb ed="#V" n="104"/>in quamlibet formam educibilem per naturam de potentia 
           <lb ed="#V" n="105"/>materie. im3ta a 
         </p>
@@ -77,8 +77,7 @@
           <p xml:id="kzz7yh-f53797-d1e132">
             Questio. I. 
             <lb ed="#V" n="106"/>PRimo ostendo quod corpus mulieris non 
-            <lb ed="#V" n="107"/>fuit semen de costa viri dormien 
-            dormien<lb ed="#V" n="108" break="no"/>tis: Quia <ref xml:id="kzz7yh-f53797-Rd1e145">Genesis primo</ref> dicitur quod masculum et 
+            <lb ed="#V" n="107"/>fuit semen de costa viri dormien<lb ed="#V" n="108" break="no"/>tis: Quia <ref xml:id="kzz7yh-f53797-Rd1e145">Genesis primo</ref> dicitur quod masculum et 
             fe<lb ed="#V" n="109" break="no"/>minam creauit. Sed quod creatur non sit de 
             ali<lb ed="#V" n="110" break="no"/>quo. ergo corpus mulieris non fuit factum de costa viri. 
           </p>
@@ -179,7 +178,7 @@
             effi<lb ed="#V" n="65" break="no"/>caciam habere per meritum passionis iesu christi: per 
             quo<lb ed="#V" n="66" break="no"/>rum sacramentorum virtutem ecclesia iungitur christo. 
             <lb ed="#V" n="67"/>Ideo decuit vt mulier: que viro fiebat in coniugium 
-            de<lb ed="#V" n="68" break="no"/>parte virilis lateris sumeretur. o: 
+            de<lb ed="#V" n="68" break="no"/>parte virilis lateris sumeretur. 
             <!--00164.xml-->
             <cb ed="#P" n="b"/>
           </p>


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve09v2_kzz7yh-f53797.xml`.

## Applied changes

- p. 75r l. 103: tramsmutabile → transmutabile: trams/trans transposition
- p. 75r l. 108: dormien duplicated by dittography before lb 108 break="no"; first occurrence should be removed
- p. 75v l. 68: spurious 'o:' at end of line

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_