### PR TITLE
Transcription corrections: cod-ve09v2_kzz7yh-f54682.xml (6 changes)

### DIFF
--- a/kzz7yh-f54682/cod-ve09v2_kzz7yh-f54682.xml
+++ b/kzz7yh-f54682/cod-ve09v2_kzz7yh-f54682.xml
@@ -366,7 +366,7 @@
             <lb ed="#V" n="95"/>debent esse perfectiones. 
           </p>
           <p xml:id="kzz7yh-f54682-d1e650">
-            <lb ed="#V" n="96"/>Respondeo quoima ade et anima eue: et omnes alie anie 
+            <lb ed="#V" n="96"/>Respondeo quod anima ade et anima eue: et omnes alie anime 
             <lb ed="#V" n="97"/>non simul fuerunt facte: cuius rationem aliqui 
             <lb ed="#V" n="98"/>assignant: quia non potuissent fieri multe anime in numero ante 
             <lb ed="#V" n="99"/>corporis multitudinem: eo quod anime indiuiduantur per corpora: et hoc 

--- a/kzz7yh-f54682/cod-ve09v2_kzz7yh-f54682.xml
+++ b/kzz7yh-f54682/cod-ve09v2_kzz7yh-f54682.xml
@@ -165,7 +165,7 @@
           <p xml:id="kzz7yh-f54682-d1e290">
             Quaesio II. 
             <lb ed="#V" n="103"/>SEcundo quaeritur vtrum anima eue fuerit 
-            fcin<lb ed="#V" n="104" break="no"/>de anima ade: et vtrum anime filiorum si 
+            facta<lb ed="#V" n="104" break="no"/>de anima ade: et vtrum anime filiorum si 
             <lb ed="#V" n="105"/>ant per generationem de animabus patrum. Et videtur quod 
             <lb ed="#V" n="106"/>sic. Gensem 46. dicitur quod omnes anime que egresse sunt de 
             <lb ed="#V" n="107"/>semore Iacob absque vxoribus filiorum et ingresse sunt cum 
@@ -225,7 +225,7 @@
             gene<lb ed="#V" n="3" break="no"/>rante sequitur quod anima prolis non generatur a parente. 
           </p>
           <p xml:id="kzz7yh-f54682-d1e398">
-            <lb ed="#V" n="4"/>Respondeo quod anima eue suit facta de anima ade nec 
+            <lb ed="#V" n="4"/>Respondeo quod anima eue fuit facta de anima ade nec 
             <lb ed="#V" n="5"/>anime filiorum fiunt per generationem 
             <lb ed="#V" n="6"/>de animabus patrum. Sed quelibet anima intellectiua producitur 
             <lb ed="#V" n="7"/>a deo immediate tantum per creationem. Per nullam enim formam 
@@ -276,7 +276,7 @@
             auctori<lb ed="#V" n="43" break="no"/>tas a deo creata: et infra ca. 7. veraciter fixeque credendum 
             <lb ed="#V" n="44"/>est deum animas creare. Et auctor de ecclesiasticis dogmatibus 
             <lb ed="#V" n="45"/>cap. 13. dicit quod ale cum corporibus per coitum non seminantur: sed 
-            <lb ed="#V" n="46"/>creantur: et Glo. super illud pslamum. Qui sinxit sigillatim: dicit quod 
+            <lb ed="#V" n="46"/>creantur: et Glo. super illud psalmum. Qui finxit sigillatim: dicit quod 
             <lb ed="#V" n="47"/>anime fiunt ex nihilo. 
           </p>
           <p xml:id="kzz7yh-f54682-d1e505">
@@ -294,7 +294,7 @@
           <p xml:id="kzz7yh-f54682-d1e525">
             ¶ Ad 3m dicendum: quod homo dicitur generare 
             <lb ed="#V" n="55"/>hominem non quia generet intellectiuam que est hominis substantia 
-            <lb ed="#V" n="56"/>le complementum: sed quia de potentia materie vis gnantiua ipsius patris 
+            <lb ed="#V" n="56"/>le complementum: sed quia de potentia materie vis generatiua ipsius patris 
             <lb ed="#V" n="57"/>educit quandam formam substantialem incompletam et quasdam 
             dispositio<lb ed="#V" n="58" break="no"/>nes accidentales disponentes materiam ad susceptionem intellectiue. 
           </p>
@@ -348,13 +348,13 @@
             <lb ed="#V" n="85"/>si sic: non esset ratio quare vna fuisset creata post aliam. 
           </p>
           <p xml:id="kzz7yh-f54682-d1e621">
-            <lb ed="#V" n="86"/>Contra psamum Quod sinxit figillatim corda eorum. Cum ergo 
+            <lb ed="#V" n="86"/>Contra psalmum Quod finxit sigillatim corda eorum. Cum ergo 
             <lb ed="#V" n="87"/>per corda intelligat animas: videtur quod deus creet 
             <lb ed="#V" n="88"/>animas non simul: sed vna post aliam.
           </p>
           <p xml:id="kzz7yh-f54682-d1e630">
             ¶ Item de ecclesiasticis 
-            <lb ed="#V" n="89"/>dogmatibus. cap. 13. dicitur animas hominium non esse ab initio siml 
+            <lb ed="#V" n="89"/>dogmatibus. cap. 13. dicitur animas hominum non esse ab initio siml 
             <lb ed="#V" n="90"/>creatas: sicut origenes fingit: sed formato iam corpore animam 
             <lb ed="#V" n="91"/>creari et infundi.
           </p>


### PR DESCRIPTION
Automated transcription corrections applied to `cod-ve09v2_kzz7yh-f54682.xml`.

## Applied changes

- p. 76v l. 103: fcin → facta: garbled OCR; break="no" on lb 104 should also be removed // remove break no from lb 104
- p. 77r l. 4: suit → fuit: s/f misread
- p. 77r l. 46: pslamum → psalmum: missing l; sinxit → finxit: s/f misread
- p. 77r l. 56: gnantiua → generatiua: garbled OCR
- p. 77r l. 86: psamum → psalmum: missing l; sinxit → finxit: s/f misread; figillatim → sigillatim: f/s misread
- p. 77r l. 89: hominium → hominum: spurious i

---
_Generated by `apply.py` (SCTA Transcription Review Tool)_